### PR TITLE
circleci: add support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2
+
 jobs:
   build:
     docker:
@@ -21,3 +22,7 @@ jobs:
             - "/go/pkg/mod"
       - run: |
           ./devctl version
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./devctl


### PR DESCRIPTION
This is early stage, but I want to have something working. `architect` won't work here as go modules are used. I also wonder if we can make that an CircleCI orb and not use `architect` at all (that also allows us to run the build in container which gives extra 30s). The difficulty is to e.g. not run docker related tasks when the Dockerfile is not present. Maybe orbs will come in handy.

What it does:

- It uses cache for modules for a given `go.sum` content:
    - Build without cache (check `go test ./...` step): https://circleci.com/gh/giantswarm/devctl/3.
    - Build with cache (check `go test ./...` step): https://circleci.com/gh/giantswarm/devctl/4.
- It builds the binary sets the `gitCommit` variable.
- Calls `devctl version` as a sanity check.

What it doesn't do yet:

- Build & push docker image. PR: https://github.com/giantswarm/devctl/pull/7.
