### PR TITLE
gen/resource: generate current.go

### DIFF
--- a/cmd/gen/resource/runner.go
+++ b/cmd/gen/resource/runner.go
@@ -45,6 +45,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		ObjectVersion: r.flag.ObjectVersion,
 	}
 
+	currentFile, err := resource.NewCurrent(c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	resourceFile, err := resource.NewResource(c)
 	if err != nil {
 		return microerror.Mask(err)
@@ -52,6 +57,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	err = gen.Execute(
 		ctx,
+		currentFile,
 		resourceFile,
 	)
 	if gen.IsFilePath(err) {

--- a/pkg/gen/resource/current.go
+++ b/pkg/gen/resource/current.go
@@ -1,0 +1,57 @@
+package resource
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/devctl/pkg/gen/input"
+)
+
+type Current struct {
+	dir string
+}
+
+func NewCurrent(config Config) (*Current, error) {
+	err := config.Validate()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	f := &Current{
+		dir: config.Dir,
+	}
+
+	return f, nil
+}
+
+func (f *Current) GetInput(ctx context.Context) (input.Input, error) {
+	i := input.Input{
+		Path:         filepath.Join(f.dir, "current.go"),
+		TemplateBody: currentTemplate,
+		TemplateData: map[string]interface{}{
+			"Package": f.dir,
+		},
+	}
+
+	return i, nil
+}
+
+var currentTemplate = `package {{ .Package }}
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	state, err := r.stateGetter.GetCurrentState(ctx, obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return state, nil
+}
+`


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5461


```
$ go run main.go gen resource --dir=pawel --object.group=core --object.kind=ConfigMap --object.version=v1 
```

Then output of:

```
$ git --no-pager diff --no-index ../operatorkit/resource/configmap/current.go ./pawel/current.go
```

is:

```diff
diff --git a/../operatorkit/resource/configmap/current.go b/./pawel/current.go
index 977bde5..1788312 100644
--- a/../operatorkit/resource/configmap/current.go
+++ b/./pawel/current.go
@@ -1,4 +1,4 @@
-package configmap
+package pawel

 import (
        "context"
```