### PR TITLE
gen/resource: make golden file tests generic

### DIFF
--- a/pkg/gen/resource/golden_test.go
+++ b/pkg/gen/resource/golden_test.go
@@ -64,7 +64,7 @@ func Test_Resource(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			ctx := context.Background()
 
-			f, err := NewResource(tc.inputConfig)
+			f, err := tc.newFileFunc(tc.inputConfig)
 			if err != nil {
 				t.Fatal(microerror.Mask(err))
 			}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5461.

This allows to just change `NewResource` to e.g. `NewCreate` and test
`create.go` generation.

For usage example see: https://github.com/giantswarm/devctl/pull/23.