### PR TITLE
replace: fix writing in place

### DIFF
--- a/cmd/replace/runner.go
+++ b/cmd/replace/runner.go
@@ -96,8 +96,9 @@ func (r *runner) processFile(fileName string, regex *regexp.Regexp, replacement 
 
 	replaced := regex.ReplaceAll(content, []byte(replacement))
 
+	// When --inplace flag isn't specified print replacement to stdout and
+	// return.
 	if !r.flag.InPlace {
-		// Print result to stdout.
 		fmt.Fprintf(r.stdout, "%s", replaced)
 
 		return nil


### PR DESCRIPTION
There was bug in the condition which caused replace command to override
the file only when nothing was replaced.