### PR TITLE
makefile: generate packaging scripts for CLIs

### DIFF
--- a/cmd/gen/makefile/command.go
+++ b/cmd/gen/makefile/command.go
@@ -31,7 +31,10 @@ func New(config Config) (*cobra.Command, error) {
 		config.Stdout = os.Stdout
 	}
 
+	f := new(flag)
+
 	r := &runner{
+		flag:   f,
 		logger: config.Logger,
 		stderr: config.Stderr,
 		stdout: config.Stdout,
@@ -43,6 +46,8 @@ func New(config Config) (*cobra.Command, error) {
 		Long:  description,
 		RunE:  r.Run,
 	}
+
+	f.Init(c)
 
 	return c, nil
 }

--- a/cmd/gen/makefile/flag.go
+++ b/cmd/gen/makefile/flag.go
@@ -1,0 +1,25 @@
+package makefile
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	flavour = "flavour"
+
+	flavourApp      = "app"
+	flavourCLI      = "cli"
+	flavourOperator = "operator"
+)
+
+type flag struct {
+	Flavour string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.Flavour, flavour, "f", flavourOperator, `The type of project that you want to generate the Makefile for. Possible values: <app|cli|operator>`)
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/gen/makefile/flag.go
+++ b/cmd/gen/makefile/flag.go
@@ -10,6 +10,7 @@ const (
 
 	flavourApp      = "app"
 	flavourCLI      = "cli"
+	flavourLibrary  = "library"
 	flavourOperator = "operator"
 )
 
@@ -18,12 +19,12 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.Flavour, flavour, "f", flavourOperator, `The type of project that you want to generate the Makefile for. Possible values: <app|cli|operator>`)
+	cmd.Flags().StringVarP(&f.Flavour, flavour, "f", flavourOperator, `The type of project that you want to generate the Makefile for. Possible values: <app|cli|library|operator>`)
 }
 
 func (f *flag) Validate() error {
-	if f.Flavour != flavourApp && f.Flavour != flavourCLI && f.Flavour != flavourOperator {
-		return microerror.Maskf(invalidFlagError, "--%s must be one of <app|cli|operator>", flavour)
+	if f.Flavour != flavourApp && f.Flavour != flavourCLI && f.Flavour != flavourLibrary && f.Flavour != flavourOperator {
+		return microerror.Maskf(invalidFlagError, "--%s must be one of <app|cli|library|operator>", flavour)
 	}
 
 	return nil

--- a/cmd/gen/makefile/flag.go
+++ b/cmd/gen/makefile/flag.go
@@ -1,6 +1,7 @@
 package makefile
 
 import (
+	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 )
 
@@ -21,5 +22,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 }
 
 func (f *flag) Validate() error {
+	if f.Flavour != flavourApp && f.Flavour != flavourCLI && f.Flavour != flavourOperator {
+		return microerror.Maskf(invalidFlagError, "--%s must be one of <app|cli|operator>", flavour)
+	}
+
 	return nil
 }

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -36,7 +36,7 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	flavour := mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
+	flavour, err := mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
 	makefileInput, err := makefile.New(flavour)
 	if err != nil {
 		return microerror.Mask(err)
@@ -53,21 +53,21 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	return nil
 }
 
-func mapFlavourTypeToMakeFileFlavour(f string) int {
+func mapFlavourTypeToMakeFileFlavour(f string) (int, error) {
 	switch f {
 	case flavourApp:
-		return makefile.FlavourApp
+		return makefile.FlavourApp, nil
 
 	case flavourCLI:
-		return makefile.FlavourCLI
+		return makefile.FlavourCLI, nil
 
 	case flavourOperator:
-		return makefile.FlavourOperator
+		return makefile.FlavourOperator, nil
 
 	case flavourLibrary:
-		return makefile.FlavourLibrary
+		return makefile.FlavourLibrary, nil
 
 	default:
-		return makefile.FlavourOperator
+		return 0, microerror.Maskf(invalidFlagError, "the picked flavour is invalid", flavour)
 	}
 }

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -13,6 +13,7 @@ import (
 )
 
 type runner struct {
+	flag   *flag
 	logger micrologger.Logger
 	stdout io.Writer
 	stderr io.Writer
@@ -21,7 +22,12 @@ type runner struct {
 func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	err := r.run(ctx, cmd, args)
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -36,12 +36,17 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	flavour, err := mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
-	if err != nil {
-		return microerror.Mask(err)
+	var err error
+
+	var c makefile.Config
+	{
+		c.Flavour, err = mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
-	makefileInput, err := makefile.New(flavour)
+	makefileInput, err := makefile.New(c)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -37,6 +37,10 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
 	flavour, err := mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	makefileInput, err := makefile.New(flavour)
 	if err != nil {
 		return microerror.Mask(err)
@@ -68,6 +72,6 @@ func mapFlavourTypeToMakeFileFlavour(f string) (int, error) {
 		return makefile.FlavourLibrary, nil
 
 	default:
-		return 0, microerror.Maskf(invalidFlagError, "the picked flavour is invalid", flavour)
+		return 0, microerror.Maskf(invalidFlagError, "the picked flavour is invalid")
 	}
 }

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -64,6 +64,9 @@ func mapFlavourTypeToMakeFileFlavour(f string) int {
 	case flavourOperator:
 		return makefile.FlavourOperator
 
+	case flavourLibrary:
+		return makefile.FlavourLibrary
+
 	default:
 		return makefile.FlavourOperator
 	}

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -36,7 +36,8 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	makefileInput, err := makefile.New()
+	flavour := mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
+	makefileInput, err := makefile.New(flavour)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -50,4 +51,20 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	return nil
+}
+
+func mapFlavourTypeToMakeFileFlavour(f string) int {
+	switch f {
+	case flavourApp:
+		return makefile.FlavourApp
+
+	case flavourCLI:
+		return makefile.FlavourCLI
+
+	case flavourOperator:
+		return makefile.FlavourOperator
+
+	default:
+		return makefile.FlavourOperator
+	}
 }

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -67,7 +67,7 @@ package-darwin: $(APPLICATION)-package-darwin
 package-linux: $(APPLICATION)-package-linux
 
 $(APPLICATION)-package-%: $(SOURCES)
-	docker run --rm -it \
+	docker run --rm \
     		-v $(shell pwd):/$(APPLICATION) \
     		-w /$(APPLICATION) \
     		-e GOOS=$* -e GOARCH=amd64 \

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -8,6 +8,7 @@ type Config struct {
 	CurrentFlavour  int
 	FlavourApp      int
 	FlavourCLI      int
+	FlavourLibrary  int
 	FlavourOperator int
 }
 
@@ -19,6 +20,7 @@ func NewMakefileInput(c Config) input.Input {
 			"CurrentFlavour":  c.CurrentFlavour,
 			"FlavourApp":      c.FlavourApp,
 			"FlavourCLI":      c.FlavourCLI,
+			"FlavourLibrary":  c.FlavourLibrary,
 			"FlavourOperator": c.FlavourOperator,
 		},
 	}

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -73,16 +73,16 @@ $(APPLICATION)-package-%: $(SOURCES)
 	@$(MAKE) $(APPLICATION)-archive-$*
 
 $(APPLICATION)-rename-binary-%:
-	cp $(APPLICATION)-$* $(APPLICATION)-v$(VERSION)-$*-amd64
+	cp $(APPLICATION)-$* $(APPLICATION)-$(VERSION)-$*-amd64
 
 $(APPLICATION)-archive-%:
 	mkdir -p $(PACKAGE_DIR)
-	tar -cvzf $(APPLICATION)-v$(VERSION)-$*-amd64.tar.gz \
-		$(APPLICATION)-v$(VERSION)-$*-amd64 \
+	tar -cvzf $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz \
+		$(APPLICATION)-$(VERSION)-$*-amd64 \
 		README.md \
 		LICENSE
-	mv $(APPLICATION)-v$(VERSION)-$*-amd64.tar.gz $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-$*-amd64.tar.gz
-	rm -rf $(APPLICATION)-v$(VERSION)-$*-amd64
+	mv $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64.tar.gz
+	rm -rf $(APPLICATION)-$(VERSION)-$*-amd64
 
 {{- end}}
 

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -35,7 +35,6 @@ var makefileTemplate = `# DO NOT EDIT. Generated with:
 
 {{- if eq .CurrentFlavour .FlavourCLI}}
 
-GOVERSION      := 1.14.2
 PACKAGE_DIR    := ./bin-dist
 
 {{- end}}

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -74,16 +74,16 @@ $(APPLICATION)-package-%: $(SOURCES)
 	@$(MAKE) $(APPLICATION)-archive-$*
 
 $(APPLICATION)-rename-binary-%:
-	cp $(APPLICATION)-$* $(APPLICATION)-$(VERSION)-$*-amd64
+	cp $(APPLICATION)-$* $(APPLICATION)-v$(VERSION)-$*-amd64
 
 $(APPLICATION)-archive-%:
 	mkdir -p $(PACKAGE_DIR)
-	tar -cvzf $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz \
-		$(APPLICATION)-$(VERSION)-$*-amd64 \
+	tar -cvzf $(APPLICATION)-v$(VERSION)-$*-amd64.tar.gz \
+		$(APPLICATION)-v$(VERSION)-$*-amd64 \
 		README.md \
 		LICENSE
-	mv $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64.tar.gz
-	rm -rf $(APPLICATION)-$(VERSION)-$*-amd64
+	mv $(APPLICATION)-v$(VERSION)-$*-amd64.tar.gz $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-$*-amd64.tar.gz
+	rm -rf $(APPLICATION)-v$(VERSION)-$*-amd64
 
 {{- end}}
 

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -2,26 +2,19 @@ package file
 
 import (
 	"github.com/giantswarm/devctl/pkg/gen/input"
+	"github.com/giantswarm/devctl/pkg/gen/input/makefile/internal/params"
 )
 
-type Config struct {
-	CurrentFlavour  int
-	FlavourApp      int
-	FlavourCLI      int
-	FlavourLibrary  int
-	FlavourOperator int
-}
-
-func NewMakefileInput(c Config) input.Input {
+func NewMakefileInput(p params.Params) input.Input {
 	i := input.Input{
 		Path:         "Makefile",
 		TemplateBody: makefileTemplate,
 		TemplateData: map[string]interface{}{
-			"CurrentFlavour":  c.CurrentFlavour,
-			"FlavourApp":      c.FlavourApp,
-			"FlavourCLI":      c.FlavourCLI,
-			"FlavourLibrary":  c.FlavourLibrary,
-			"FlavourOperator": c.FlavourOperator,
+			"CurrentFlavour":  p.CurrentFlavour,
+			"FlavourApp":      p.FlavourApp,
+			"FlavourCLI":      p.FlavourCLI,
+			"FlavourLibrary":  p.FlavourLibrary,
+			"FlavourOperator": p.FlavourOperator,
 		},
 	}
 

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -69,14 +69,12 @@ package-darwin: $(APPLICATION)-package-darwin
 package-linux: $(APPLICATION)-package-linux
 
 $(APPLICATION)-package-%: $(SOURCES)
-	docker run --rm \
-    		-v $(shell pwd):/$(APPLICATION) \
-    		-w /$(APPLICATION) \
-    		-e GOOS=$* -e GOARCH=amd64 \
-    		golang:$(GOVERSION)-alpine go build \
-    		-ldflags "$(LDFLAGS)" \
-    		-o $(APPLICATION)-$(VERSION)-$*-amd64
+	@$(MAKE) $(APPLICATION)-$*
+	@$(MAKE) $(APPLICATION)-rename-binary-$*
 	@$(MAKE) $(APPLICATION)-archive-$*
+
+$(APPLICATION)-rename-binary-%:
+	cp $(APPLICATION)-$* $(APPLICATION)-$(VERSION)-$*-amd64
 
 $(APPLICATION)-archive-%:
 	mkdir -p $(PACKAGE_DIR)

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -69,13 +69,13 @@ $(APPLICATION)-rename-binary-%:
 	cp $(APPLICATION)-$* $(APPLICATION)-$(VERSION)-$*-amd64
 
 $(APPLICATION)-archive-%:
-	mkdir -p $(PACKAGE_DIR)
+	mkdir -p $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
+	mv $(APPLICATION)-$(VERSION)-$*-amd64 $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
+	cp ./{README.md,LICENSE} $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
+	cd $(PACKAGE_DIR)/ && \
 	tar -cvzf $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz \
-		$(APPLICATION)-$(VERSION)-$*-amd64 \
-		README.md \
-		LICENSE
-	mv $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64.tar.gz
-	rm -rf $(APPLICATION)-$(VERSION)-$*-amd64
+		$(APPLICATION)-$(VERSION)-$*-amd64
+	rm -rf $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
 
 {{- end}}
 

--- a/pkg/gen/input/makefile/internal/params/types.go
+++ b/pkg/gen/input/makefile/internal/params/types.go
@@ -1,0 +1,11 @@
+package params
+
+type Params struct {
+	// CurrentFlavour is the desired type of Makefile that should be generated.
+	CurrentFlavour int
+
+	FlavourApp      int
+	FlavourCLI      int
+	FlavourLibrary  int
+	FlavourOperator int
+}

--- a/pkg/gen/input/makefile/makefile.go
+++ b/pkg/gen/input/makefile/makefile.go
@@ -3,6 +3,7 @@ package makefile
 import (
 	"github.com/giantswarm/devctl/pkg/gen/input"
 	"github.com/giantswarm/devctl/pkg/gen/input/makefile/internal/file"
+	"github.com/giantswarm/devctl/pkg/gen/input/makefile/internal/params"
 )
 
 const (
@@ -12,26 +13,28 @@ const (
 	FlavourOperator
 )
 
-type Makefile struct {
-	flavour int
+type Config struct {
+	Flavour int
 }
 
-func New(flavour int) (*Makefile, error) {
+type Makefile struct {
+	params params.Params
+}
+
+func New(config Config) (*Makefile, error) {
 	m := &Makefile{
-		flavour: flavour,
+		params: params.Params{
+			CurrentFlavour:  config.Flavour,
+			FlavourApp:      FlavourApp,
+			FlavourCLI:      FlavourCLI,
+			FlavourLibrary:  FlavourLibrary,
+			FlavourOperator: FlavourOperator,
+		},
 	}
 
 	return m, nil
 }
 
 func (m *Makefile) Makefile() input.Input {
-	c := file.Config{
-		CurrentFlavour:  m.flavour,
-		FlavourApp:      FlavourApp,
-		FlavourCLI:      FlavourCLI,
-		FlavourLibrary:  FlavourLibrary,
-		FlavourOperator: FlavourOperator,
-	}
-
-	return file.NewMakefileInput(c)
+	return file.NewMakefileInput(m.params)
 }

--- a/pkg/gen/input/makefile/makefile.go
+++ b/pkg/gen/input/makefile/makefile.go
@@ -5,13 +5,31 @@ import (
 	"github.com/giantswarm/devctl/pkg/gen/input/makefile/internal/file"
 )
 
+const (
+	FlavourApp = iota
+	FlavourCLI
+	FlavourOperator
+)
+
 type Makefile struct {
+	flavour int
 }
 
-func New() (*Makefile, error) {
-	return &Makefile{}, nil
+func New(flavour int) (*Makefile, error) {
+	m := &Makefile{
+		flavour: flavour,
+	}
+
+	return m, nil
 }
 
 func (m *Makefile) Makefile() input.Input {
-	return file.NewMakefileInput()
+	c := file.Config{
+		CurrentFlavour:  m.flavour,
+		FlavourApp:      FlavourApp,
+		FlavourCLI:      FlavourCLI,
+		FlavourOperator: FlavourOperator,
+	}
+
+	return file.NewMakefileInput(c)
 }

--- a/pkg/gen/input/makefile/makefile.go
+++ b/pkg/gen/input/makefile/makefile.go
@@ -8,6 +8,7 @@ import (
 const (
 	FlavourApp = iota
 	FlavourCLI
+	FlavourLibrary
 	FlavourOperator
 )
 
@@ -28,6 +29,7 @@ func (m *Makefile) Makefile() input.Input {
 		CurrentFlavour:  m.flavour,
 		FlavourApp:      FlavourApp,
 		FlavourCLI:      FlavourCLI,
+		FlavourLibrary:  FlavourLibrary,
 		FlavourOperator: FlavourOperator,
 	}
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/11715

This adds a new `-f|--flavour` flag to the `devctl gen makefile` command, with the supported values being `app|cli|operator`.

Using the new flag, we are able to generate different Makefile scripts for different project types. For example, this PR adds scripts for packaging, for the CLI flavour of the Makefile.

The generated files are `.tar.gz` archives, for each supported platform (MacOS and generic Linux), which contain the executable binary, README and LICENSE. They are built in a Docker container.