### PR TITLE
workflows: support minor long-lived release branches

### DIFF
--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -28,7 +28,9 @@ on:
     branches:
       - 'legacy'
       - 'master'
-      - 'release-v*.x.x'
+      - 'release-v*.*.x'
+      # "!" negates previous positive patterns so it has to be at the end.
+      - '!release-v*.x.x'
 jobs:
   debug_info:
     name: Debug info

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -28,7 +28,7 @@ on:
     branches:
       - 'master#release#v*.*.*'
       - 'legacy#release#v*.*.*'
-      - 'release-v*.x.x#release#v*.*.*'
+      - 'release-v*.*.x#release#v*.*.*'
 jobs:
   debug_info:
     name: Debug info

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -29,6 +29,8 @@ on:
       - 'master#release#v*.*.*'
       - 'legacy#release#v*.*.*'
       - 'release-v*.*.x#release#v*.*.*'
+      # "!" negates previous positive patterns so it has to be at the end.
+      - '!release-v*.x.x#release#v*.*.*'
 jobs:
   debug_info:
     name: Debug info


### PR DESCRIPTION
"Create Release PR" workflow will now be triggered for branches like:

```
release-v1.2.x#release#v1.2.3
```

But wont be triggered for branches like:

```
release-v1.x.x#release#v1.2.3
```