### PR TITLE
workflows: generate build artifacts for CLIs

### DIFF
--- a/cmd/gen/workflows/flag.go
+++ b/cmd/gen/workflows/flag.go
@@ -1,15 +1,31 @@
 package workflows
 
 import (
+	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 )
 
+const (
+	flavour = "flavour"
+
+	flavourApp      = "app"
+	flavourCLI      = "cli"
+	flavourLibrary  = "library"
+	flavourOperator = "operator"
+)
+
 type flag struct {
+	Flavour string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.Flavour, flavour, "f", flavourOperator, `The type of project that you want to generate the Makefile for. Possible values: <app|cli|library|operator>`)
 }
 
 func (f *flag) Validate() error {
+	if f.Flavour != flavourApp && f.Flavour != flavourCLI && f.Flavour != flavourLibrary && f.Flavour != flavourOperator {
+		return microerror.Maskf(invalidFlagError, "--%s must be one of <app|cli|library|operator>", flavour)
+	}
+
 	return nil
 }

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -36,7 +36,15 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	c := workflows.Config(*r.flag)
+	var err error
+
+	var c workflows.Config
+	{
+		c.Flavour, err = mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
 
 	workflowsInput, err := workflows.New(c)
 	if err != nil {
@@ -53,4 +61,23 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	return nil
+}
+
+func mapFlavourTypeToMakeFileFlavour(f string) (int, error) {
+	switch f {
+	case flavourApp:
+		return workflows.FlavourApp, nil
+
+	case flavourCLI:
+		return workflows.FlavourCLI, nil
+
+	case flavourOperator:
+		return workflows.FlavourOperator, nil
+
+	case flavourLibrary:
+		return workflows.FlavourLibrary, nil
+
+	default:
+		return 0, microerror.Maskf(invalidFlagError, "the picked flavour is invalid")
+	}
 }

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -40,7 +40,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var c workflows.Config
 	{
-		c.Flavour, err = mapFlavourTypeToMakeFileFlavour(r.flag.Flavour)
+		c.Flavour, err = mapFlavourTypeToWorkflowFlavour(r.flag.Flavour)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -63,7 +63,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	return nil
 }
 
-func mapFlavourTypeToMakeFileFlavour(f string) (int, error) {
+func mapFlavourTypeToWorkflowFlavour(f string) (int, error) {
 	switch f {
 	case flavourApp:
 		return workflows.FlavourApp, nil

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -10,8 +10,8 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 		Path:         params.RegenerableFileName(p, "create_release.yaml"),
 		TemplateBody: createReleaseTemplate,
 		TemplateDelims: input.InputTemplateDelims{
-			Left:  "##-ignore-left-##",
-			Right: "##-ignore-right-##",
+			Left:  "{{{{",
+			Right: "}}}}",
 		},
 		TemplateData: map[string]interface{}{
 			"CurrentFlavour":  p.CurrentFlavour,
@@ -206,7 +206,7 @@ jobs:
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
           release_name: "v${{ needs.gather_facts.outputs.version }}"
 
-##-ignore-left-##- if eq .CurrentFlavour .FlavourCLI##-ignore-right-##
+{{{{- if eq .CurrentFlavour .FlavourCLI}}}}
 
   install_architect:
     name: Install architect
@@ -304,5 +304,5 @@ jobs:
           asset_name: ${{ env.FILE_NAME }}
           asset_content_type: application/octet-stream
 
-##-ignore-left-##- end##-ignore-right-##
+{{{{- end}}}}
 `

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -206,7 +206,7 @@ jobs:
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
           release_name: "v${{ needs.gather_facts.outputs.version }}"
 
-{{- if eq .CurrentFlavour .FlavourCLI}}
+##-ignore-left-##- if eq .CurrentFlavour .FlavourCLI##-ignore-right-##
 
   install_architect:
     name: Install architect
@@ -304,5 +304,5 @@ jobs:
           asset_name: ${{ env.FILE_NAME }}
           asset_content_type: application/octet-stream
 
-{{- end}}
+##-ignore-left-##- end##-ignore-right-##
 `

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -13,6 +13,13 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 			Left:  "##-ignore-left-##",
 			Right: "##-ignore-right-##",
 		},
+		TemplateData: map[string]interface{}{
+			"CurrentFlavour":  p.CurrentFlavour,
+			"FlavourApp":      p.FlavourApp,
+			"FlavourCLI":      p.FlavourCLI,
+			"FlavourLibrary":  p.FlavourLibrary,
+			"FlavourOperator": p.FlavourOperator,
+		},
 	}
 
 	return i
@@ -195,4 +202,10 @@ jobs:
         with:
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
           release_name: "v${{ needs.gather_facts.outputs.version }}"
+
+{{- if eq .CurrentFlavour .FlavourCLI}}
+
+
+
+{{- end}}
 `

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -174,6 +174,8 @@ jobs:
     needs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.version }}
+    outputs:
+      upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -196,6 +198,7 @@ jobs:
         run: |
           git push "${REMOTE_REPO}" --tags
       - name: Create release
+        id: create_gh_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -205,7 +208,101 @@ jobs:
 
 {{- if eq .CurrentFlavour .FlavourCLI}}
 
-
+  install_architect:
+    name: Install architect
+    runs-on: ubuntu-18.04
+    env:
+      BINARY: "architect"
+      DIR: "/opt/cache"
+      IMAGE: "quay.io/giantswarm/architect"
+      IMAGE_PATH: "/usr/bin/architect"
+      VERSION: "1.2.0"
+    outputs:
+      cache_key: "${{ steps.get_cache_key.outputs.cache_key }}"
+    steps:
+      - name: Get cache key
+        id: get_cache_key
+        run: |
+          cache_key="install-${{ env.BINARY }}-${{ env.VERSION }}"
+          echo "::set-output name=cache_key::${cache_key}"
+      - name: Cache
+        id: cache
+        uses: actions/cache@v1
+        with:
+          key: "${{ steps.get_cache_key.outputs.cache_key }}"
+          path: "${{ env.DIR }}"
+      - name: Download
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p ${{ env.DIR }}
+          docker container create --name tmp ${{ env.IMAGE }}:${{ env.VERSION }}
+          docker cp tmp:${{ env.IMAGE_PATH }} ${{ env.DIR }}/${{ env.BINARY }}
+          docker container rm tmp
+      - name: Smoke test
+        run: |
+          ${{ env.DIR }}/${{ env.BINARY }} version
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: "${{ env.BINARY }}"
+          path: "${{ env.DIR }}/${{ env.BINARY }}"
+  create_and_upload_build_artifacts:
+    name: Create and upload build artifacts
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        platform:
+          - darwin
+          - linux
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GO_VERSION: 1.14.2
+      ARTIFACT_DIR: bin-dist
+      PKG_VERSION: ${{ needs.gather_facts.outputs.version }}
+    needs:
+      - create_release
+      - gather_facts
+      - install_architect
+    steps:
+      - name: Cache
+        id: cache
+        uses: actions/cache@v1
+        with:
+          key: "${{ needs.install_architect.outputs.cache_key }}"
+          path: /opt/bin
+      - name: Download architect artifact to /opt/bin
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: architect
+          path: /opt/bin
+      - name: Prepare /opt/bin
+        run: |
+          chmod +x /opt/bin/*
+          echo "::add-path::/opt/bin"
+      - name: Print architect version
+        run: |
+          architect version
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: v${{ needs.gather_facts.outputs.version }}
+      - name: Create ${{ matrix.platform }} package
+        run: make package-${{ matrix.platform }}
+      - name: Add ${{ matrix.platform }} package to release
+        uses: actions/upload-release-asset@v1
+        env:
+          FILE_NAME: ${{ github.event.repository.name }}-${{ env.PKG_VERSION }}-${{ matrix.platform }}-amd64.tar.gz
+        with:
+          path: ${{ env.ARTIFACT_DIR }}
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}
+          asset_name: ${{ env.FILE_NAME }}
+          asset_content_type: application/octet-stream
 
 {{- end}}
 `

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -206,7 +206,7 @@ jobs:
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
           release_name: "v${{ needs.gather_facts.outputs.version }}"
 
-{{{{- if eq .CurrentFlavour .FlavourCLI}}}}
+{{{{- if eq .CurrentFlavour .FlavourCLI }}}}
 
   install_architect:
     name: Install architect

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -304,5 +304,5 @@ jobs:
           asset_name: ${{ env.FILE_NAME }}
           asset_content_type: application/octet-stream
 
-{{{{- end}}}}
+{{{{- end }}}}
 `

--- a/pkg/gen/input/workflows/internal/params/types.go
+++ b/pkg/gen/input/workflows/internal/params/types.go
@@ -4,4 +4,12 @@ type Params struct {
 	// Dir is the name of the directory where the files of the resource
 	// should be generated.
 	Dir string
+
+	// CurrentFlavour is the desired type of workflow that should be generated.
+	CurrentFlavour int
+
+	FlavourApp      int
+	FlavourCLI      int
+	FlavourLibrary  int
+	FlavourOperator int
 }

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -6,7 +6,15 @@ import (
 	"github.com/giantswarm/devctl/pkg/gen/input/workflows/internal/params"
 )
 
+const (
+	FlavourApp = iota
+	FlavourCLI
+	FlavourLibrary
+	FlavourOperator
+)
+
 type Config struct {
+	Flavour int
 }
 
 type Workflows struct {
@@ -17,6 +25,12 @@ func New(config Config) (*Workflows, error) {
 	w := &Workflows{
 		params: params.Params{
 			Dir: ".github/workflows",
+
+			CurrentFlavour:  config.Flavour,
+			FlavourApp:      FlavourApp,
+			FlavourCLI:      FlavourCLI,
+			FlavourLibrary:  FlavourLibrary,
+			FlavourOperator: FlavourOperator,
 		},
 	}
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/11729

Depends on the Makefile generated with https://github.com/giantswarm/devctl/pull/63 (CLI flavour)

This PR adds a new flag to the `devctl gen workflows` command. The `-f|--flavour` flag (possible values: app|cli|library|operator)

With the `cli` flavour, in the generated github release creation workflow, there will also be a step for generating build artifacts, and adding them to the newly created release.

> 

☢️ If you want to test it, make sure you have `name` and `source` set to the correct values inside of `pkg/project.go`, in your project.

