### PR TITLE
Add 'v' prefix to binary name

### DIFF
--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -52,28 +52,28 @@ build-darwin: $(APPLICATION)-darwin
 ## build-linux: builds a local binary for linux/amd64
 build-linux: $(APPLICATION)-linux
 
-$(APPLICATION): $(APPLICATION)-$(VERSION)-$(OS)-amd64
+$(APPLICATION): $(APPLICATION)-v$(VERSION)-$(OS)-amd64
 	cp -a $< $@
 
-$(APPLICATION)-darwin: $(APPLICATION)-$(VERSION)-darwin-amd64
+$(APPLICATION)-darwin: $(APPLICATION)-v$(VERSION)-darwin-amd64
 	cp -a $< $@
 
-$(APPLICATION)-linux: $(APPLICATION)-$(VERSION)-linux-amd64
+$(APPLICATION)-linux: $(APPLICATION)-v$(VERSION)-linux-amd64
 	cp -a $< $@
 
-$(APPLICATION)-$(VERSION)-%-amd64: $(SOURCES)
+$(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
 
 {{- if eq .CurrentFlavour .FlavourCLI}}
 
 .PHONY: package-darwin package-linux
 ## package-darwin: prepares a packaged darwin/amd64 version
-package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-darwin-amd64.tar.gz
+package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz
 ## package-linux: prepares a packaged linux/amd64 version
-package-linux: $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-linux-amd64.tar.gz
+package-linux: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
 
-$(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
-$(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-$(VERSION)-%-amd64
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64
 	mkdir -p $(DIR)
 	cp $< $(DIR)
 	cp README.md LICENSE $(DIR)

--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -52,38 +52,36 @@ build-darwin: $(APPLICATION)-darwin
 ## build-linux: builds a local binary for linux/amd64
 build-linux: $(APPLICATION)-linux
 
+$(APPLICATION): $(APPLICATION)-$(VERSION)-$(OS)-amd64
+	cp -a $< $@
+
+$(APPLICATION)-darwin: $(APPLICATION)-$(VERSION)-darwin-amd64
+	cp -a $< $@
+
+$(APPLICATION)-linux: $(APPLICATION)-$(VERSION)-linux-amd64
+	cp -a $< $@
+
+$(APPLICATION)-$(VERSION)-%-amd64: $(SOURCES)
+	GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+
 {{- if eq .CurrentFlavour .FlavourCLI}}
 
 .PHONY: package-darwin package-linux
 ## package-darwin: prepares a packaged darwin/amd64 version
-package-darwin: $(APPLICATION)-package-darwin
+package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-darwin-amd64.tar.gz
 ## package-linux: prepares a packaged linux/amd64 version
-package-linux: $(APPLICATION)-package-linux
+package-linux: $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-linux-amd64.tar.gz
 
-$(APPLICATION)-package-%: $(SOURCES)
-	@$(MAKE) $(APPLICATION)-$*
-	@$(MAKE) $(APPLICATION)-rename-binary-$*
-	@$(MAKE) $(APPLICATION)-archive-$*
-
-$(APPLICATION)-rename-binary-%:
-	cp $(APPLICATION)-$* $(APPLICATION)-$(VERSION)-$*-amd64
-
-$(APPLICATION)-archive-%:
-	mkdir -p $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
-	mv $(APPLICATION)-$(VERSION)-$*-amd64 $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
-	cp ./{README.md,LICENSE} $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
-	cd $(PACKAGE_DIR)/ && \
-	tar -cvzf $(APPLICATION)-$(VERSION)-$*-amd64.tar.gz \
-		$(APPLICATION)-$(VERSION)-$*-amd64
-	rm -rf $(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-$*-amd64
+$(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
+$(PACKAGE_DIR)/$(APPLICATION)-$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-$(VERSION)-%-amd64
+	mkdir -p $(DIR)
+	cp $< $(DIR)
+	cp README.md LICENSE $(DIR)
+	tar -C $(PACKAGE_DIR) -cvzf $(PACKAGE_DIR)/$<.tar.gz $<
+	rm -rf $(DIR)
+	rm -rf $<
 
 {{- end}}
-
-$(APPLICATION): $(APPLICATION)-$(OS)
-	cp -a $< $@
-
-$(APPLICATION)-%: $(SOURCES)
-	GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
 
 .PHONY: install
 ## install: install the application

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -258,7 +258,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GO_VERSION: 1.14.2
       ARTIFACT_DIR: bin-dist
-      PKG_VERSION: v${{ needs.gather_facts.outputs.version }}
+      TAG: v${{ needs.gather_facts.outputs.version }}
     needs:
       - create_release
       - gather_facts

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -296,7 +296,7 @@ jobs:
       - name: Add ${{ matrix.platform }} package to release
         uses: actions/upload-release-asset@v1
         env:
-          FILE_NAME: ${{ github.event.repository.name }}-${{ env.PKG_VERSION }}-${{ matrix.platform }}-amd64.tar.gz
+          FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}-amd64.tar.gz
         with:
           path: ${{ env.ARTIFACT_DIR }}
           upload_url: ${{ needs.create_release.outputs.upload_url }}

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -290,7 +290,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: ${{ env.PKG_VERSION }}
+          ref: ${{ env.TAG }}
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Add ${{ matrix.platform }} package to release

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -258,7 +258,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GO_VERSION: 1.14.2
       ARTIFACT_DIR: bin-dist
-      PKG_VERSION: ${{ needs.gather_facts.outputs.version }}
+      PKG_VERSION: v${{ needs.gather_facts.outputs.version }}
     needs:
       - create_release
       - gather_facts
@@ -290,7 +290,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          ref: v${{ needs.gather_facts.outputs.version }}
+          ref: ${{ env.PKG_VERSION }}
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Add ${{ matrix.platform }} package to release


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11783

This PR:
* Adds a 'v' prefix to all version numbers in the generated Makefile/GitHub workflows. (e. g. `some-operator-1.0.0-darwin.tar.gz` now becomes `some-operator-v1.0.0-darwin.tar.gz`
* Refactors the generated Makefile, so it is more extendable, as suggested [here](https://github.com/giantswarm/devctl/pull/63#discussion_r445524976).