### PR TITLE
makefile: remove all the version metadata from the binary name

### DIFF
--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -75,7 +75,7 @@ package-linux: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64
 	mkdir -p $(DIR)
-	cp $< $(DIR)
+	cp $< $(DIR)/$(APPLICATION)
 	cp README.md LICENSE $(DIR)
 	tar -C $(PACKAGE_DIR) -cvzf $(PACKAGE_DIR)/$<.tar.gz $<
 	rm -rf $(DIR)


### PR DESCRIPTION
This is the last one, I promise 🤞 

With this, built binaries in the archived packages will have a simpler name:
```diff
- kubectl-gs-v0.5.0-darwin-amd64
+ kubectl-gs
```