### PR TITLE
makefile: print target names

### DIFF
--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -47,21 +47,28 @@ LDFLAGS        ?= -w -linkmode 'auto' -extldflags '-static' \
 .PHONY: build build-darwin build-linux
 ## build: builds a local binary
 build: $(APPLICATION)
+	@echo "====> $@"
 ## build-darwin: builds a local binary for darwin/amd64
 build-darwin: $(APPLICATION)-darwin
+	@echo "====> $@"
 ## build-linux: builds a local binary for linux/amd64
 build-linux: $(APPLICATION)-linux
+	@echo "====> $@"
 
 $(APPLICATION): $(APPLICATION)-v$(VERSION)-$(OS)-amd64
+	@echo "====> $@"
 	cp -a $< $@
 
 $(APPLICATION)-darwin: $(APPLICATION)-v$(VERSION)-darwin-amd64
+	@echo "====> $@"
 	cp -a $< $@
 
 $(APPLICATION)-linux: $(APPLICATION)-v$(VERSION)-linux-amd64
+	@echo "====> $@"
 	cp -a $< $@
 
 $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
+	@echo "====> $@"
 	GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
 
 {{- if eq .CurrentFlavour .FlavourCLI}}
@@ -69,11 +76,14 @@ $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 .PHONY: package-darwin package-linux
 ## package-darwin: prepares a packaged darwin/amd64 version
 package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz
+	@echo "====> $@"
 ## package-linux: prepares a packaged linux/amd64 version
 package-linux: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
+	@echo "====> $@"
 
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64
+	@echo "====> $@"
 	mkdir -p $(DIR)
 	cp $< $(DIR)/$(APPLICATION)
 	cp README.md LICENSE $(DIR)
@@ -86,37 +96,44 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERS
 .PHONY: install
 ## install: install the application
 install:
+	@echo "====> $@"
 	go install -ldflags "$(LDFLAGS)" .
 
 .PHONY: run
 ## run: runs go run main.go
 run:
+	@echo "====> $@"
 	go run -ldflags "$(LDFLAGS)" -race .
 
 .PHONY: clean
 ## clean: cleans the binary
 clean:
+	@echo "====> $@"
 	rm -f $(APPLICATION)*
 	go clean
 
 .PHONY: imports
 ## imports: runs goimports
 imports:
+	@echo "====> $@"
 	goimports -local $(shell go list .) -w .
 
 .PHONY: lint
 ## lint: runs golangci-lint
 lint:
+	@echo "====> $@"
 	golangci-lint run -E gosec -E goconst --timeout=15m ./...
 
 .PHONY: test
 ## test: runs go test with default values
 test:
+	@echo "====> $@"
 	go test -ldflags "$(LDFLAGS)" -race ./...
 
 .PHONY: build-docker
 ## build-docker: builds docker image to registry
 build-docker: build-linux
+	@echo "====> $@"
 	docker build -t ${APPLICATION}:${VERSION} .
 
 .PHONY: help


### PR DESCRIPTION
Before:

```
$ make package-linux
GOOS=linux GOARCH=amd64 go build -ldflags "-w -linkmode 'auto' -extldflags '-static' -X 'github.com/giantswarm/devctl/pkg/project.buildTimestamp=2020-07-06T10:12:10Z' -X 'github.com/giantswarm/devctl/pkg/project.gitSHA=4235a773379af1e4c3730482fae80881f0ca1055' -X 'github.com/giantswarm/devctl/pkg/project.version=0.0.0-4235a773379af1e4c3730482fae80881f0ca1055'" -o devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64 .
mkdir -p ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
cp devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64 ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/devctl
cp README.md LICENSE ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
tar -C ./bin-dist -cvzf ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64.tar.gz devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/LICENSE
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/devctl
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/README.md
rm -rf ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
rm -rf devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
```

After:

```
$ make package-linux
====> devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
GOOS=linux GOARCH=amd64 go build -ldflags "-w -linkmode 'auto' -extldflags '-static' -X 'github.com/giantswarm/devctl/pkg/project.buildTimestamp=2020-07-06T10:12:10Z' -X 'github.com/giantswarm/devctl/pkg/project.gitSHA=4235a773379af1e4c3730482fae80881f0ca1055' -X 'github.com/giantswarm/devctl/pkg/project.version=0.0.0-4235a773379af1e4c3730482fae80881f0ca1055'" -o devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64 .
====> bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64.tar.gz
mkdir -p ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
cp devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64 ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/devctl
cp README.md LICENSE ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
tar -C ./bin-dist -cvzf ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64.tar.gz devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/LICENSE
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/devctl
a devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64/README.md
rm -rf ./bin-dist/devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
rm -rf devctl-v0.0.0-4235a773379af1e4c3730482fae80881f0ca1055-linux-amd64
====> package-linux
```