### PR TITLE
Support ecosystem for dependabot

### DIFF
--- a/cmd/gen/dependabot/command.go
+++ b/cmd/gen/dependabot/command.go
@@ -12,9 +12,9 @@ import (
 const (
 	name        = "dependabot"
 	description = "Generates GitHub Dependabot config for go and docker dependencies (.github/dependabot.yml)."
-	example     = `  devctl gen dependabot 
-  devctl gen dependabot --interval daily --reviewers giantswarm/team-firecracker
-  devctl gen dependabot --interval weekly --reviewers giantswarm/team-firecracker,njuettner`
+	example     = `  devctl gen dependabot --ecosystems go
+  devctl gen dependabot --ecosystems docker,go --interval daily --reviewers giantswarm/team-firecracker
+  devctl gen dependabot --ecosystems docker --interval weekly --reviewers giantswarm/team-firecracker,njuettner`
 )
 
 type Config struct {

--- a/cmd/gen/dependabot/command.go
+++ b/cmd/gen/dependabot/command.go
@@ -12,9 +12,9 @@ import (
 const (
 	name        = "dependabot"
 	description = "Generates GitHub Dependabot config for go and docker dependencies (.github/dependabot.yml)."
-	example     = `  devctl gen dependabot --ecosystems go
-  devctl gen dependabot --ecosystems docker,go --interval daily --reviewers giantswarm/team-firecracker
-  devctl gen dependabot --ecosystems docker --interval weekly --reviewers giantswarm/team-firecracker,njuettner`
+	example     = `  devctl gen dependabot
+  devctl gen dependabot --interval daily --reviewers giantswarm/team-firecracker
+  devctl gen dependabot --interval weekly --reviewers giantswarm/team-firecracker,njuettner`
 )
 
 type Config struct {

--- a/cmd/gen/dependabot/flag.go
+++ b/cmd/gen/dependabot/flag.go
@@ -13,6 +13,7 @@ import (
 const (
 	flagEcosystems = "ecosystems"
 	flagInterval   = "interval"
+	flagReviewers  = "reviewers"
 )
 
 type flag struct {
@@ -23,8 +24,8 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Interval, flagInterval, "i", "weekly", "Check for daily, weekly or monthly updates (default: weekly).")
-	cmd.Flags().StringSliceVarP(&f.Reviewers, "reviewers", "r", []string{}, "Reviewers you want to assign automatically when Dependabot creates a PR, e.g. giantswarm/team-firecracker.")
-	cmd.Flags().StringSliceVarP(&f.Ecosystems, "ecosystems", "e", []string{}, "Ecosystem for each one package manager that you want GitHub Dependabot to monitor for new versions , e.g. go, docker")
+	cmd.Flags().StringSliceVarP(&f.Reviewers, flagReviewers, "r", []string{}, "Reviewers you want to assign automatically when Dependabot creates a PR, e.g. giantswarm/team-firecracker.")
+	cmd.Flags().StringSliceVarP(&f.Ecosystems, flagEcosystems, "e", []string{}, "Ecosystem for each one package manager that you want GitHub Dependabot to monitor for new versions , e.g. go, docker. Setting this flag disables autodetection of files.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gen/dependabot/flag.go
+++ b/cmd/gen/dependabot/flag.go
@@ -10,22 +10,32 @@ import (
 )
 
 const (
-	flagInterval = "interval"
+	flagEcosystems = "ecosystems"
+	flagInterval   = "interval"
 )
 
 type flag struct {
-	Interval  string
-	Reviewers []string
+	Interval   string
+	Reviewers  []string
+	Ecosystems []string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Interval, flagInterval, "i", "weekly", "Check for daily, weekly or monthly updates (default: weekly).")
 	cmd.Flags().StringSliceVarP(&f.Reviewers, "reviewers", "r", []string{}, "Reviewers you want to assign automatically when Dependabot creates a PR, e.g. giantswarm/team-firecracker.")
+	cmd.Flags().StringSliceVarP(&f.Ecosystems, "ecosystems", "e", []string{}, "Ecosystem for each one package manager that you want GitHub Dependabot to monitor for new versions , e.g. go, docker")
 }
 
 func (f *flag) Validate() error {
 	if !gen.IsValidSchedule(f.Interval) {
 		return microerror.Maskf(invalidFlagError, "--%s must be one of <%s>", flagInterval, strings.Join(gen.AllowedSchedule(), "|"))
+	}
+	if len(f.Ecosystems) == 0 {
+		return microerror.Maskf(invalidFlagError, "--%s is not set, please provide at least one ecosystem, allowed <%s>", flagEcosystems, strings.Join(gen.AllowedEcosystems(), "|"))
+	}
+
+	if !gen.IsValidEcoSystem(f.Ecosystems) {
+		return microerror.Maskf(invalidFlagError, "--%s must be one of <%s>", flagEcosystems, strings.Join(gen.AllowedEcosystems(), "|"))
 	}
 
 	return nil

--- a/cmd/gen/dependabot/runner.go
+++ b/cmd/gen/dependabot/runner.go
@@ -41,8 +41,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var dependabotInput *dependabot.Dependabot
 	{
 		c := dependabot.Config{
-			Interval:  r.flag.Interval,
-			Reviewers: r.flag.Reviewers,
+			Interval:   r.flag.Interval,
+			Reviewers:  r.flag.Reviewers,
+			Ecosystems: r.flag.Ecosystems,
 		}
 
 		dependabotInput, err = dependabot.New(c)

--- a/pkg/gen/dependabot_ecosystem.go
+++ b/pkg/gen/dependabot_ecosystem.go
@@ -1,0 +1,46 @@
+package gen
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	EcosystemDocker Ecosystem = "docker"
+	EcosystemGo     Ecosystem = "go"
+)
+
+func AllowedEcosystems() []string {
+	return []string{
+		EcosystemDocker.String(),
+		EcosystemGo.String(),
+	}
+}
+
+type Ecosystem string
+
+func NewEcosystem(s string) (Ecosystem, error) {
+	switch s {
+	case EcosystemDocker.String():
+		return EcosystemDocker, nil
+	case EcosystemGo.String():
+		return EcosystemGo, nil
+	}
+
+	return Ecosystem("unknown"), microerror.Maskf(invalidConfigError, "ecosystem must be one of %s", strings.Join(AllowedEcosystems(), "|"))
+}
+
+func (e Ecosystem) String() string {
+	return string(e)
+}
+
+func IsValidEcoSystem(ecosystems []string) bool {
+	for _, s := range ecosystems {
+		_, err := NewEcosystem(s)
+		if err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/gen/input/dependabot/dependabot.go
+++ b/pkg/gen/input/dependabot/dependabot.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Config struct {
-	Interval  string
-	Reviewers []string
+	Interval   string
+	Reviewers  []string
+	Ecosystems []string
 }
 
 type Dependabot struct {
@@ -20,8 +21,9 @@ func New(config Config) (*Dependabot, error) {
 		params: params.Params{
 			Dir: ".github/",
 
-			Interval:  config.Interval,
-			Reviewers: config.Reviewers,
+			Ecosystems: config.Ecosystems,
+			Interval:   config.Interval,
+			Reviewers:  config.Reviewers,
 		},
 	}
 

--- a/pkg/gen/input/dependabot/internal/file/dependabot.go
+++ b/pkg/gen/input/dependabot/internal/file/dependabot.go
@@ -12,8 +12,9 @@ func NewCreateDependabotInput(p params.Params) input.Input {
 		Path:         filepath.Join(p.Dir, "dependabot.yml"),
 		TemplateBody: createDependabotTemplate,
 		TemplateData: map[string]interface{}{
-			"Interval":  p.Interval,
-			"Reviewers": p.Reviewers,
+			"Ecosystems": p.Ecosystems,
+			"Interval":   p.Interval,
+			"Reviewers":  p.Reviewers,
 		},
 	}
 
@@ -24,17 +25,21 @@ var createDependabotTemplate = `# DO NOT EDIT. Generated with:
 #
 #    devctl gen dependabot
 #
+{{- $interval := .Interval }}
+{{- $reviewers := .Reviewers }}
+{{- range $ecosystem := .Ecosystems }}
+{{- if eq $ecosystem "go" }}
 version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: {{ .Interval }}
+    interval: {{ $interval }}
     time: "04:00"
   open-pull-requests-limit: 10
-{{- if .Reviewers }}
+{{- if $reviewers }}
   reviewers:
-  {{- range $reviewer:= .Reviewers }}
+  {{- range $reviewer := $reviewers }}
   - {{ $reviewer }}
   {{- end}}
 {{- end }}
@@ -42,16 +47,20 @@ updates:
   - dependency-name: k8s.io/*
     versions:
     - ">=0.17.0"
+{{- end }}
+{{- if eq $ecosystem "docker" }}
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: {{ .Interval }}
+    interval: {{ $interval }}
     time: "04:00"
   target-branch: master
-{{- if .Reviewers }}
+{{- if $reviewers }}
   reviewers:
-  {{- range $reviewer:= .Reviewers }}
+  {{- range $reviewer := $reviewers }}
   - {{ $reviewer }}
   {{- end}}
+{{- end }}
+{{- end }}
 {{- end }}
 `

--- a/pkg/gen/input/dependabot/internal/params/types.go
+++ b/pkg/gen/input/dependabot/internal/params/types.go
@@ -4,6 +4,8 @@ type Params struct {
 	// Dir is the name of the directory where the files of the resource
 	// should be generated.
 	Dir string
+	// Ecosystems contains the ecosystem for each one package manager that you want GitHub Dependabot to monitor for new versions
+	Ecosystems []string
 	// Interval to check for daily, weekly, or monthly updates (default: weekly).
 	Interval string
 	// Reviewers is a set of people or teams who are assigned as reviewers.


### PR DESCRIPTION
Ecosystems flag will be mandatory, where you can specify what what package ecosystem you want to add.
This allows someone to include only dependabot ecosystems which are inside the repo.
E.g. update docker and go updates, or only update docker updates.

This also allows us to include more ecosystems like terraform, GitHub Actions, npm, ....

Current support:

- Docker
- Go