### PR TITLE
makefile: Disable CGO when building static assets

### DIFF
--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -64,7 +64,7 @@ $(APPLICATION)-linux: $(APPLICATION)-v$(VERSION)-linux-amd64
 
 $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	@echo "====> $@"
-	GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
 
 {{- if .IsFlavourCLI }}
 


### PR DESCRIPTION
This PR aims to add support for light distros such as `alpine` linux, which don't use `glibc`.
(This is something a customer complained about with `kubectl-gs`)