### PR TITLE
Render the 'lint-chart' script if the flavour is either 'operator' or 'app'

### DIFF
--- a/pkg/gen/input/makefile/internal/file/makefile.go
+++ b/pkg/gen/input/makefile/internal/file/makefile.go
@@ -10,7 +10,9 @@ func NewMakefileInput(p params.Params) input.Input {
 		Path:         "Makefile",
 		TemplateBody: makefileTemplate,
 		TemplateData: map[string]interface{}{
-			"IsFlavourCLI": params.IsFlavourCLI(p),
+			"IsFlavourApp":      params.IsFlavourApp(p),
+			"IsFlavourCLI":      params.IsFlavourCLI(p),
+			"IsFlavourOperator": params.IsFlavourOperator(p),
 		},
 	}
 
@@ -131,6 +133,8 @@ build-docker: build-linux
 	@echo "====> $@"
 	docker build -t ${APPLICATION}:${VERSION} .
 
+{{- if or .IsFlavourApp .IsFlavourOperator }}
+
 .PHONY: lint-chart
 ## lint-chart: runs ct against the default chart
 lint-chart: IMAGE := giantswarm/helm-chart-testing:v3.0.0-rc.1
@@ -142,6 +146,8 @@ lint-chart:
 	architect helm template --dir /tmp/$(APPLICATION)-test/helm/$(APPLICATION)
 	docker run -it --rm -v /tmp/$(APPLICATION)-test:/wd --workdir=/wd --name ct $(IMAGE) ct lint --validate-maintainers=false --charts="helm/$(APPLICATION)"
 	rm -rf /tmp/$(APPLICATION)-test
+
+{{- end }}
 
 .PHONY: help
 ## help: prints this help message

--- a/pkg/gen/input/makefile/internal/params/key_common.go
+++ b/pkg/gen/input/makefile/internal/params/key_common.go
@@ -5,8 +5,16 @@ import (
 	"github.com/giantswarm/devctl/pkg/gen/internal"
 )
 
+func IsFlavourApp(p Params) bool {
+	return p.Flavour == gen.FlavourApp
+}
+
 func IsFlavourCLI(p Params) bool {
 	return p.Flavour == gen.FlavourCLI
+}
+
+func IsFlavourOperator(p Params) bool {
+	return p.Flavour == gen.FlavourOperator
 }
 
 func FileName(p Params, suffix string) string {


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12345

This PR makes the `lint-chart` script be rendered only if the flavour is either `operator` or `app`