### PR TITLE
Use the full path for setting the gitSHA in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Command line tool for the development daily business.
 
 This project uses Go modules. Be sure to have it outside your `$GOPATH` or
 set `GO111MODULE=on` environment variable. Then regular `go install` should do
-the trick. Alternatively the following one-liner may help. 
+the trick. Alternatively the following one-liner may help.
 
 ```sh
-GO111MODULE=on go install -ldflags "-X main.gitCommit=$(git rev-parse HEAD)" .
+GO111MODULE=on go install -ldflags "-X 'github.com/giantswarm/devctl/pkg/project.gitSHA=$(git rev-parse HEAD)'" .
 ```
 
 ## Configuration


### PR DESCRIPTION
This PR corrects the `go install -ldflags..` command in readme to correctly include the gitSHA in the installed binary.