### PR TITLE
Update wiring for root command to use pkg/project

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -14,11 +14,7 @@ import (
 	"github.com/giantswarm/devctl/cmd/replace"
 	"github.com/giantswarm/devctl/cmd/repo"
 	"github.com/giantswarm/devctl/cmd/version"
-)
-
-const (
-	name        = "devctl"
-	description = "Command line development utility."
+	"github.com/giantswarm/devctl/pkg/project"
 )
 
 type Config struct {
@@ -148,9 +144,9 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	c := &cobra.Command{
-		Use:          name,
-		Short:        description,
-		Long:         description,
+		Use:          project.Name(),
+		Short:        project.Description(),
+		Long:         project.Description(),
 		RunE:         r.Run,
 		SilenceUsage: true,
 	}


### PR DESCRIPTION
A small improvement but I noticed this when setting up apptestctl in https://github.com/giantswarm/apptestctl/pull/1