### PR TITLE
Add executed command as comment for release creation

### DIFF
--- a/cmd/release/create/runner.go
+++ b/cmd/release/create/runner.go
@@ -2,7 +2,10 @@ package create
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -34,8 +37,9 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (r *runner) run(_ context.Context, _ *cobra.Command, _ []string) error {
-	err := release.CreateRelease(r.flag.Name, r.flag.Base, r.flag.Releases, r.flag.Provider, r.flag.Components, r.flag.Apps, r.flag.Overwrite)
+func (r *runner) run(_ context.Context, cmd *cobra.Command, _ []string) error {
+	creationCommand := fmt.Sprintf("%v", strings.Join(os.Args, " "))
+	err := release.CreateRelease(r.flag.Name, r.flag.Base, r.flag.Releases, r.flag.Provider, r.flag.Components, r.flag.Apps, r.flag.Overwrite, creationCommand)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -16,7 +16,7 @@ import (
 
 // Creates a release on the filesystem from the given parameters. This is the entry point
 // for the `devctl create release` command logic.
-func CreateRelease(name, base, releases, provider string, components, apps []string, overwrite bool) error {
+func CreateRelease(name, base, releases, provider string, components, apps []string, overwrite bool, creationCommand string) error {
 	// Paths
 	baseVersion := *semver.MustParse(base) // already validated to be a valid semver string
 	providerDirectory := filepath.Join(releases, provider)
@@ -84,6 +84,11 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 	releaseYAML, err := yaml.Marshal(newRelease)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+	// Prepend command used for creation
+	{
+		yamlComment := []byte(fmt.Sprintf("# Generated with:\n# %s\n", creationCommand))
+		releaseYAML = append(yamlComment, releaseYAML...)
 	}
 	err = ioutil.WriteFile(releaseYAMLPath, releaseYAML, 0644)
 	if err != nil {


### PR DESCRIPTION
This has annoyed me one time too many now. We always lose this execution. This adds it as a comment to the release YAML.

AFAIK @tfussell wanted to do this?