### PR TITLE
Update actions to newer versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Include k8s dependency for 1.18 in dependabot.
+
+### Security
+
 - Update upload-artifact action to v2.2.0.
 - Update cache action to v2.1.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Include k8s dependency for 1.18 in dependabot.
+- Update upload-artifact action to v2.2.0.
+- Update cache action to v2.1.1.
 
 ### Fixed
 

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -134,7 +134,7 @@ jobs:
         run: |
           ${{ steps.key.outputs.cache_dir }}/${{ steps.key.outputs.binary }} --version
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v2.2.0
         with:
           name: "${{ steps.key.outputs.binary }}"
           path: "${{ steps.key.outputs.cache_dir }}/${{ steps.key.outputs.binary }}"
@@ -324,7 +324,7 @@ jobs:
         run: |
           ${{ env.DIR }}/${{ env.BINARY }} version
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v2.2.0
         with:
           name: "${{ env.BINARY }}"
           path: "${{ env.DIR }}/${{ env.BINARY }}"

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -96,7 +96,7 @@ jobs:
           echo "::set-output name=cache_key::${cache_key}"
       - name: Cache
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2.1.1
         with:
           key: "${{ steps.get_cache_key.outputs.cache_key }}"
           path: "${{ env.DIR }}"
@@ -111,7 +111,7 @@ jobs:
         run: |
           ${{ env.DIR }}/${{ env.BINARY }} version
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v2.2.0
         with:
           name: "${{ env.BINARY }}"
           path: "${{ env.DIR }}/${{ env.BINARY }}"
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Cache
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2.1.1
         with:
           key: "${{ needs.install_architect.outputs.cache_key }}"
           path: /opt/bin


### PR DESCRIPTION
These actions got updated on the repositories by dependabot, and regenerating the files would put old versions again.