### PR TITLE
Replace install-tools-action with install-binary-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace install-tools-action with install-binary-action to break circular
+  dependency between devctl and install-tools-action.
+
 ## [2.0.1] - 2020-10-16
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -105,8 +105,19 @@ jobs:
     needs:
       - gather_facts
     steps:
-      - name: Install tools
-        uses: giantswarm/install-tools-action@v0.1.0
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "architect"
+          version: "3.0.5"
+      - name: Install semver
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "semver"
+          version: "3.0.0"
+          download_url: "https://github.com/fsaintjacques/${binary}-tool/archive/${version}.tar.gz"
+          tarball_binary_path: "*/src/${binary}"
+          smoke_test: "${binary} --version"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Update project.go
@@ -191,6 +202,11 @@ jobs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.version }}
     steps:
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "architect"
+          version: "3.0.5"
       - name: Install tools
         uses: giantswarm/install-tools-action@v0.1.0
       - name: Check out the repository

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -82,8 +82,11 @@ jobs:
     env:
       architect_flags: "--organisation ${{ github.repository_owner }} --project ${{ github.event.repository.name }}"
     steps:
-      - name: Install tools
-        uses: giantswarm/install-tools-action@v0.1.0
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "architect"
+          version: "3.0.5"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Prepare release changes


### PR DESCRIPTION
The new action is designed to install single binary.

This is to avoid circular dependency between the action and devctl.
Otherwise generated files are updated with dependabot. If that is merged
they will be regenerated by giantswarm/github and updated by dependabot
again.