### PR TITLE
Pretty print errors on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `--language` flag to `gen makefile`.
 - Generate main Makefile including `*.mk` files to allow custom Makefiles.
+- Pretty print errors.
 
 ## Changed
 

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -117,11 +117,12 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	c := &cobra.Command{
-		Use:          project.Name(),
-		Short:        project.Description(),
-		Long:         project.Description(),
-		RunE:         r.Run,
-		SilenceUsage: true,
+		Use:           project.Name(),
+		Short:         project.Description(),
+		Long:          project.Description(),
+		RunE:          r.Run,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	f.Init(c)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	err := mainE(context.Background())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", microerror.Pretty(err, true))
-		os.Exit(1)
+		os.Exit(2)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,7 +15,8 @@ import (
 func main() {
 	err := mainE(context.Background())
 	if err != nil {
-		panic(fmt.Sprintf("%#v\n", err))
+		fmt.Fprintf(os.Stderr, "Error: %s\n", microerror.Pretty(err, true))
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Before:

```
$ go run . gen makefile
Error: invalid flag error: --flavour must be one of <app|cli|generic>
panic: {"kind":"invalidFlagError","annotation":"--flavour must be one of \u003capp|cli|generic\u003e","stack":[{"file":"/Users/kopiczko/go/src/github.com/giantswarm/devctl/cmd/gen/makefile/flag.go","line":30},{"file":"/Users/kopiczko/go/src/github.com/giantswarm/devctl/cmd/gen/makefile/runner.go","line":28},{"file":"/Users/kopiczko/go/src/github.com/giantswarm/devctl/main.go","line":48}]}


goroutine 1 [running]:
main.main()
        /Users/kopiczko/go/src/github.com/giantswarm/devctl/main.go:17 +0xd7
exit status 2
```

After:

```
$ go run . gen makefile
Error: Invalid flag: --flavour must be one of <app|cli|generic>
        /Users/kopiczko/go/src/github.com/giantswarm/devctl/cmd/gen/makefile/flag.go:30
        /Users/kopiczko/go/src/github.com/giantswarm/devctl/cmd/gen/makefile/runner.go:28
        /Users/kopiczko/go/src/github.com/giantswarm/devctl/main.go:50
exit status 2
```