### PR TITLE
Push docker image to quay when building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,15 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
+      - architect/push-to-docker:
+          name: push-devctl-to-quay
+          image: "quay.io/giantswarm/devctl"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          requires:
+            - go-build-devctl
+          filters:
+            # Needed to trigger job also on git tag.
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
The repository is added to [github](https://github.com/giantswarm/github/blob/2188505466ef354ab96bbf2db06af099a8d4168d/repositories/meta.yaml#L11-L13) but circleci configuration is not the common one, so I'm adding a step to publish the Docker image to Quay.