### PR TITLE
Update gitleaks action to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Update `gitleaks action` to version `1.2.0` using `gitleaks` version `7.2.0`.
+
 ## [4.0.0] - 2020-12-08
 
 ## Removed
 
-- Remove `go mod tidy` workflow. 
+- Remove `go mod tidy` workflow.
 
 ## Added
 

--- a/pkg/gen/input/dependabot/internal/file/dependabot.go
+++ b/pkg/gen/input/dependabot/internal/file/dependabot.go
@@ -12,11 +12,12 @@ func NewCreateDependabotInput(p params.Params) input.Input {
 		Path:         filepath.Join(p.Dir, "dependabot.yml"),
 		TemplateBody: createDependabotTemplate,
 		TemplateData: map[string]interface{}{
-			"EcosystemGomod": params.EcosystemGomod(p),
-			"Ecosystems":     params.Ecosystems(p),
-			"Header":         params.Header("#"),
-			"Interval":       params.Interval(p),
-			"Reviewers":      params.Reviewers(p),
+			"EcosystemGithubActions": params.EcosystemGithubActions(p),
+			"EcosystemGomod":         params.EcosystemGomod(p),
+			"Ecosystems":             params.Ecosystems(p),
+			"Header":                 params.Header("#"),
+			"Interval":               params.Interval(p),
+			"Reviewers":              params.Reviewers(p),
 		},
 	}
 
@@ -26,6 +27,7 @@ func NewCreateDependabotInput(p params.Params) input.Input {
 var createDependabotTemplate = `{{ .Header }}
 {{- $interval := .Interval }}
 {{- $ecosystemGomod := .EcosystemGomod }}
+{{- $ecosystemGithubActions := .EcosystemGithubActions }}
 {{- $reviewers := .Reviewers }}
 version: 2
 updates:
@@ -47,6 +49,10 @@ updates:
       - dependency-name: k8s.io/*
         versions:
           - ">=0.19.0"
-{{- end }}
+  {{- end }}
+  {{- if eq $ecosystem $ecosystemGithubActions }}
+    ignore:
+      - dependency-name: zricethezav/gitleaks-action
+  {{- end }}
 {{- end }}
 `

--- a/pkg/gen/input/dependabot/internal/params/key.go
+++ b/pkg/gen/input/dependabot/internal/params/key.go
@@ -11,6 +11,10 @@ func Ecosystems(p Params) []string {
 	return p.Ecosystems
 }
 
+func EcosystemGithubActions(p Params) string {
+	return gen.EcosystemGithubActions.String()
+}
+
 func EcosystemGomod(p Params) string {
 	return gen.EcosystemGomod.String()
 }

--- a/pkg/gen/input/workflows/internal/file/gitleaks.go
+++ b/pkg/gen/input/workflows/internal/file/gitleaks.go
@@ -34,5 +34,5 @@ jobs:
       with:
         fetch-depth: '0'
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@v1.1.4
+      uses: zricethezav/gitleaks-action@v1.2.0
 `


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14868

This updates the gitleaks action to version 1.2.0 to fix an issue between the action flags and the official docker image flags which caused it to silently fail.