### PR TITLE
Add arm64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.3.0
 
 workflows:
   go-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.0.0
+  architect: giantswarm/architect@2.1.0
 
 workflows:
   go-build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add darwin-arm64 and linux-arm64 build targets to generated Makefile and GitHub workflows.
+
 ## [4.3.0] - 2021-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add azure-scheduled-events to known apps for `gen release`.
 - Add darwin-arm64 and linux-arm64 build targets to generated Makefile and GitHub workflows.
 - Add `--architecture` flag to `gen workflows` which allows to enable arm64 builds in release workflows.
+- Upgrade used `architect` version in generated `create_release` and `create_release_pr` workflows to `3.4.0`.
+- Upgrade used go version in generated `create_release` and `create_release_pr` workflows to `1.16.2`.
 
 ## [4.3.0] - 2021-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add azure-scheduled-events to known apps for `gen release`.
 - Add darwin-arm64 and linux-arm64 build targets to generated Makefile and GitHub workflows.
+- Add `--architecture` flag to `gen workflows` which allows to enable arm64 builds in release workflows.
 
 ## [4.3.0] - 2021-02-15
 

--- a/cmd/gen/workflows/command.go
+++ b/cmd/gen/workflows/command.go
@@ -17,7 +17,10 @@ There are different generation flavours:
 
   - app - project containing a helm chart
   - cli - project released with a downloadable binary
-  - generic - everything else, i.e a project which simply needs to be released`
+  - generic - everything else, i.e a project which simply needs to be released
+
+For flavour "cli", it is possible to choose the architectures to build release binaries for. darwin,linux,darwin-arm64,linux-arm64.
+Default: darwin,linux`
 )
 
 type Config struct {

--- a/cmd/gen/workflows/command.go
+++ b/cmd/gen/workflows/command.go
@@ -20,7 +20,7 @@ There are different generation flavours:
   - generic - everything else, i.e a project which simply needs to be released
 
 For flavour "cli", it is possible to choose the architectures to build release binaries for. darwin-amd64,linux-amd6,darwin-arm64,linux-arm64.
-Default: darwin-amd64,linux-amd64`
+Default: darwin-amd64,linux-amd6,darwin-arm64,linux-arm64`
 )
 
 type Config struct {

--- a/cmd/gen/workflows/command.go
+++ b/cmd/gen/workflows/command.go
@@ -19,8 +19,8 @@ There are different generation flavours:
   - cli - project released with a downloadable binary
   - generic - everything else, i.e a project which simply needs to be released
 
-For flavour "cli", it is possible to choose the architectures to build release binaries for. darwin,linux,darwin-arm64,linux-arm64.
-Default: darwin,linux`
+For flavour "cli", it is possible to choose the architectures to build release binaries for. darwin-amd64,linux-amd6,darwin-arm64,linux-arm64.
+Default: darwin-amd64,linux-amd64`
 )
 
 type Config struct {

--- a/cmd/gen/workflows/flag.go
+++ b/cmd/gen/workflows/flag.go
@@ -13,21 +13,28 @@ import (
 const (
 	flagCheckSecrets = "check-secrets"
 	flagFlavour      = "flavour"
+	flagArchitecture = "architecture"
 )
 
 type flag struct {
-	CheckSecrets bool
-	Flavours     gen.FlavourSlice
+	CheckSecrets  bool
+	Flavours      gen.FlavourSlice
+	Architectures gen.ArchitectureSlice
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`The type of project that you want to generate the workflows for. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().BoolVar(&f.CheckSecrets, flagCheckSecrets, true, "If true, also generate a secret-scanning workflow. Possible values: true (default), false.")
+	cmd.Flags().VarP(gen.NewArchitectureSliceFlagValue(&f.Architectures, gen.ArchitectureSlice{gen.ArchitectureDarwin, gen.ArchitectureLinux}), flagArchitecture, "a", fmt.Sprintf(`The architectures to build release artifacts for through workflows. Possible values: <%s>`, strings.Join(gen.AllArchitectures(), "|")))
 }
 
 func (f *flag) Validate() error {
 	if len(f.Flavours) == 0 {
 		return microerror.Maskf(invalidFlagError, "--%s must be one of: %s", flagFlavour, strings.Join(gen.AllFlavours(), ", "))
+	}
+
+	if len(f.Architectures) == 0 {
+		return microerror.Maskf(invalidFlagError, "--%s must contain only values of: %s", flagArchitecture, strings.Join(gen.AllArchitectures(), ", "))
 	}
 
 	return nil

--- a/cmd/gen/workflows/flag.go
+++ b/cmd/gen/workflows/flag.go
@@ -25,7 +25,7 @@ type flag struct {
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`The type of project that you want to generate the workflows for. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().BoolVar(&f.CheckSecrets, flagCheckSecrets, true, "If true, also generate a secret-scanning workflow. Possible values: true (default), false.")
-	cmd.Flags().VarP(gen.NewArchitectureSliceFlagValue(&f.Architectures, gen.ArchitectureSlice{gen.ArchitectureDarwin, gen.ArchitectureLinux}), flagArchitecture, "a", fmt.Sprintf(`The architectures to build release artifacts for through workflows. Possible values: <%s>`, strings.Join(gen.AllArchitectures(), "|")))
+	cmd.Flags().VarP(gen.NewArchitectureSliceFlagValue(&f.Architectures, gen.ArchitectureSlice{gen.ArchitectureDarwin, gen.ArchitectureLinux, gen.ArchitectureDarwinARM64, gen.ArchitectureLinuxARM64}), flagArchitecture, "a", fmt.Sprintf(`The architectures to build release artifacts for through workflows. Possible values: <%s>`, strings.Join(gen.AllArchitectures(), "|")))
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -42,7 +42,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var workflowsInput *workflows.Workflows
 	{
 		c := workflows.Config{
-			Flavours: r.flag.Flavours,
+			Flavours:      r.flag.Flavours,
+			Architectures: r.flag.Architectures,
 		}
 
 		workflowsInput, err = workflows.New(c)

--- a/pkg/gen/architecture.go
+++ b/pkg/gen/architecture.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	ArchitectureDarwin      Architecture = "darwin"
-	ArchitectureLinux       Architecture = "linux"
+	ArchitectureDarwin      Architecture = "darwin-amd64"
+	ArchitectureLinux       Architecture = "linux-amd64"
 	ArchitectureDarwinARM64 Architecture = "darwin-arm64"
 	ArchitectureLinuxARM64  Architecture = "linux-arm64"
 )

--- a/pkg/gen/architecture.go
+++ b/pkg/gen/architecture.go
@@ -1,0 +1,137 @@
+package gen
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/pflag"
+)
+
+const (
+	ArchitectureDarwin      Architecture = "darwin"
+	ArchitectureLinux       Architecture = "linux"
+	ArchitectureDarwinARM64 Architecture = "darwin-arm64"
+	ArchitectureLinuxARM64  Architecture = "linux-arm64"
+)
+
+func AllArchitectures() []string {
+	return []string{
+		ArchitectureDarwin.String(),
+		ArchitectureLinux.String(),
+		ArchitectureDarwinARM64.String(),
+		ArchitectureLinuxARM64.String(),
+	}
+}
+
+type Architecture string
+
+func NewArchitecture(s string) (Architecture, error) {
+	switch s {
+	case ArchitectureDarwin.String():
+		return ArchitectureDarwin, nil
+	case ArchitectureLinux.String():
+		return ArchitectureLinux, nil
+	case ArchitectureDarwinARM64.String():
+		return ArchitectureDarwinARM64, nil
+	case ArchitectureLinuxARM64.String():
+		return ArchitectureLinuxARM64, nil
+	}
+
+	return Architecture("unknown"), microerror.Maskf(invalidConfigError, "Architecture must be one of %s", strings.Join(AllArchitectures(), "|"))
+}
+
+func (f Architecture) String() string {
+	return string(f)
+}
+
+type ArchitectureSlice []Architecture
+
+func (s ArchitectureSlice) Contains(f Architecture) bool {
+	for _, x := range s {
+		if x == f {
+			return true
+		}
+	}
+	return false
+}
+
+type ArchitectureSliceFlagValue struct {
+	value   *ArchitectureSlice
+	changed bool
+}
+
+var _ pflag.Value = new(ArchitectureSliceFlagValue)
+var _ pflag.SliceValue = new(ArchitectureSliceFlagValue)
+
+func NewArchitectureSliceFlagValue(p *ArchitectureSlice, value ArchitectureSlice) *ArchitectureSliceFlagValue {
+	*p = value
+	return &ArchitectureSliceFlagValue{
+		value: p,
+	}
+}
+
+func (s *ArchitectureSliceFlagValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]Architecture, len(ss))
+	for i, v := range ss {
+		var err error
+		out[i], err = NewArchitecture(v)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+
+	s.changed = true
+	return nil
+}
+
+func (s *ArchitectureSliceFlagValue) Type() string {
+	return "ArchitectureSlice"
+}
+
+func (s *ArchitectureSliceFlagValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, x := range *s.value {
+		out[i] = x.String()
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func (s *ArchitectureSliceFlagValue) Append(val string) error {
+	x, err := NewArchitecture(val)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	*s.value = append(*s.value, x)
+	return nil
+}
+
+func (s *ArchitectureSliceFlagValue) Replace(val []string) error {
+	out := make([]Architecture, len(val))
+	for i, x := range val {
+		var err error
+		out[i], err = NewArchitecture(x)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+	*s.value = out
+	return nil
+}
+
+func (s *ArchitectureSliceFlagValue) GetSlice() []string {
+	out := make([]string, len(*s.value))
+	for i, x := range *s.value {
+		out[i] = x.String()
+	}
+	return out
+}
+
+func (s *ArchitectureSliceFlagValue) Default() []string { return nil }

--- a/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
+++ b/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
@@ -42,15 +42,21 @@ LDFLAGS        ?= -w -linkmode 'auto' -extldflags '$(EXTLDFLAGS)' \
 
 .DEFAULT_GOAL := build
 
-.PHONY: build build-darwin build-linux
+.PHONY: build build-darwin build-darwin-64 build-linux build-linux-arm64
 ## build: builds a local binary
 build: $(APPLICATION)
 	@echo "====> $@"
 ## build-darwin: builds a local binary for darwin/amd64
 build-darwin: $(APPLICATION)-darwin
 	@echo "====> $@"
+## build-darwin-arm64: builds a local binary for darwin/arm64
+build-darwin-arm64: $(APPLICATION)-darwin-arm64
+	@echo "====> $@"
 ## build-linux: builds a local binary for linux/amd64
 build-linux: $(APPLICATION)-linux
+	@echo "====> $@"
+## build-linux-arm64: builds a local binary for linux/arm64
+build-linux-arm64: $(APPLICATION)-linux-arm64
 	@echo "====> $@"
 
 $(APPLICATION): $(APPLICATION)-v$(VERSION)-$(OS)-amd64
@@ -61,7 +67,15 @@ $(APPLICATION)-darwin: $(APPLICATION)-v$(VERSION)-darwin-amd64
 	@echo "====> $@"
 	cp -a $< $@
 
+$(APPLICATION)-darwin-arm64: $(APPLICATION)-v$(VERSION)-darwin-arm64
+	@echo "====> $@"
+	cp -a $< $@
+
 $(APPLICATION)-linux: $(APPLICATION)-v$(VERSION)-linux-amd64
+	@echo "====> $@"
+	cp -a $< $@
+
+$(APPLICATION)-linux-arm64: $(APPLICATION)-v$(VERSION)-linux-arm64
 	@echo "====> $@"
 	cp -a $< $@
 
@@ -69,18 +83,38 @@ $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	@echo "====> $@"
 	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
 
+$(APPLICATION)-v$(VERSION)-%-arm64: $(SOURCES)
+	@echo "====> $@"
+	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $@ .
+
 {{- if .IsFlavourCLI }}
 
-.PHONY: package-darwin package-linux
+.PHONY: package-darwin package-darwin-arm64 package-linux package-linux-arm64
 ## package-darwin: prepares a packaged darwin/amd64 version
 package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz
+	@echo "====> $@"
+## package-darwin-arm64: prepares a packaged darwin/arm64 version
+package-darwin-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-arm64.tar.gz
 	@echo "====> $@"
 ## package-linux: prepares a packaged linux/amd64 version
 package-linux: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
 	@echo "====> $@"
+## package-linux-arm64: prepares a packaged linux/arm64 version
+package-linux-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-arm64.tar.gz
+	@echo "====> $@"
 
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64
+	@echo "====> $@"
+	mkdir -p $(DIR)
+	cp $< $(DIR)/$(APPLICATION)
+	cp README.md LICENSE $(DIR)
+	tar -C $(PACKAGE_DIR) -cvzf $(PACKAGE_DIR)/$<.tar.gz $<
+	rm -rf $(DIR)
+	rm -rf $<
+
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-arm64.tar.gz: DIR=$(PACKAGE_DIR)/$<
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-arm64.tar.gz: $(APPLICATION)-v$(VERSION)-%-arm64
 	@echo "====> $@"
 	mkdir -p $(DIR)
 	cp $< $(DIR)/$(APPLICATION)

--- a/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
+++ b/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
@@ -89,15 +89,15 @@ $(APPLICATION)-v$(VERSION)-%-arm64: $(SOURCES)
 
 {{- if .IsFlavourCLI }}
 
-.PHONY: package-darwin package-darwin-arm64 package-linux package-linux-arm64
-## package-darwin: prepares a packaged darwin/amd64 version
-package-darwin: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz
+.PHONY: package-darwin-amd64 package-darwin-arm64 package-linux-amd64 package-linux-arm64
+## package-darwin-amd64: prepares a packaged darwin/amd64 version
+package-darwin-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz
 	@echo "====> $@"
 ## package-darwin-arm64: prepares a packaged darwin/arm64 version
 package-darwin-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-arm64.tar.gz
 	@echo "====> $@"
-## package-linux: prepares a packaged linux/amd64 version
-package-linux: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
+## package-linux-amd64: prepares a packaged linux/amd64 version
+package-linux-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz
 	@echo "====> $@"
 ## package-linux-arm64: prepares a packaged linux/arm64 version
 package-linux-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-arm64.tar.gz

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -108,7 +108,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.0.5"
+          version: "3.3.0"
       - name: Install semver
         uses: giantswarm/install-binary-action@v1.0.0
         with:
@@ -263,10 +263,12 @@ jobs:
       matrix:
         platform:
           - darwin
+          - darwin-arm64
           - linux
+          - linux-arm64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GO_VERSION: 1.14.2
+      GO_VERSION: 1.16.0
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
     needs:
@@ -277,7 +279,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.0.5"
+          version: "3.3.0"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2.1.3
         with:

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -14,8 +14,9 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 			Right: "}}}}",
 		},
 		TemplateData: map[string]interface{}{
-			"Header":       params.Header("#"),
-			"IsFlavourCLI": params.IsFlavourCLI(p),
+			"Header":        params.Header("#"),
+			"IsFlavourCLI":  params.IsFlavourCLI(p),
+			"Architectures": params.Architectures(p),
 		},
 	}
 
@@ -262,10 +263,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - darwin
-          - darwin-arm64
-          - linux
-          - linux-arm64
+        {{{{- range .Architectures }}}}
+          - {{{{ . }}}}
+        {{{{- end }}}}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GO_VERSION: 1.16.2

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -293,7 +293,7 @@ jobs:
       - name: Add ${{ matrix.platform }} package to release
         uses: actions/upload-release-asset@v1
         env:
-          FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}-amd64.tar.gz
+          FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.tar.gz
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -108,7 +108,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.3.0"
+          version: "3.4.0"
       - name: Install semver
         uses: giantswarm/install-binary-action@v1.0.0
         with:
@@ -268,7 +268,7 @@ jobs:
           - linux-arm64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GO_VERSION: 1.16.0
+      GO_VERSION: 1.16.2
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
     needs:
@@ -279,7 +279,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.3.0"
+          version: "3.4.0"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2.1.3
         with:

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -87,7 +87,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.3.0"
+          version: "3.4.0"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Prepare release changes

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -87,7 +87,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.0.5"
+          version: "3.3.0"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Prepare release changes

--- a/pkg/gen/input/workflows/internal/params/key_common.go
+++ b/pkg/gen/input/workflows/internal/params/key_common.go
@@ -22,8 +22,8 @@ func RegenerableFileName(p Params, suffix string) string {
 }
 
 func Architectures(p Params) []string {
-	out := make([]string, len(*&p.Architectures))
-	for i, x := range *&p.Architectures {
+	out := make([]string, len(p.Architectures))
+	for i, x := range p.Architectures {
 		out[i] = x.String()
 	}
 	return out

--- a/pkg/gen/input/workflows/internal/params/key_common.go
+++ b/pkg/gen/input/workflows/internal/params/key_common.go
@@ -20,3 +20,11 @@ func Package(p Params) string {
 func RegenerableFileName(p Params, suffix string) string {
 	return internal.RegenerableFileName(p.Dir, suffix)
 }
+
+func Architectures(p Params) []string {
+	out := make([]string, len(*&p.Architectures))
+	for i, x := range *&p.Architectures {
+		out[i] = x.String()
+	}
+	return out
+}

--- a/pkg/gen/input/workflows/internal/params/types.go
+++ b/pkg/gen/input/workflows/internal/params/types.go
@@ -7,5 +7,6 @@ type Params struct {
 	// should be generated.
 	Dir string
 
-	Flavours gen.FlavourSlice
+	Flavours      gen.FlavourSlice
+	Architectures gen.ArchitectureSlice
 }

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -8,7 +8,8 @@ import (
 )
 
 type Config struct {
-	Flavours gen.FlavourSlice
+	Flavours      gen.FlavourSlice
+	Architectures gen.ArchitectureSlice
 }
 
 type Workflows struct {
@@ -20,7 +21,8 @@ func New(config Config) (*Workflows, error) {
 		params: params.Params{
 			Dir: ".github/workflows",
 
-			Flavours: config.Flavours,
+			Flavours:      config.Flavours,
+			Architectures: config.Architectures,
 		},
 	}
 


### PR DESCRIPTION
This PR adds targets for `darwin-arm64` and `linux-arm64` to the generated Makefile for `--language go`.

Other changes

- Bump the used `architect` version in generated workflows
- Add `darwin-arm64` and `linux-arm64` targets to build matrix in workflows

Disclaimer: I have no idea how Makefiles work, I just copied around stuff until it worked on my machine:tm:

I would say, treat this PR with low priority..