### PR TITLE
Don't crash if the container linux version is not present in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check for latest version before running commands.
 - Make generated Makefile help target on par with kubebuilder.
 
+### Fixed
+
+- Don't crash if the container linux version is not present in the upstream changelog.
+
 ## [4.4.0] - 2021-03-19
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 replace (
 	github.com/coreos/etcd v3.3.10+incompatible => github.com/coreos/etcd v3.3.25+incompatible
 	github.com/coreos/etcd v3.3.13+incompatible => github.com/coreos/etcd v3.3.25+incompatible
+	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 )

--- a/go.sum
+++ b/go.sum
@@ -106,7 +106,7 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -94,7 +94,7 @@ var knownComponentParseParams = map[string]parseParams{
 	},
 	"containerlinux": {
 		tag:       "https://www.flatcar-linux.org/releases/#release-{{.Version}}",
-		changelog: "https://www.flatcar-linux.org/releases-json/releases-stable.json",
+		changelog: "https://kinvolk.io/flatcar-container-linux/releases-json/releases-stable.json",
 	},
 	"cert-exporter": {
 		tag:       "https://github.com/giantswarm/cert-exporter/releases/tag/v{{.Version}}",

--- a/pkg/release/changelog/containerlinux.go
+++ b/pkg/release/changelog/containerlinux.go
@@ -2,6 +2,7 @@ package changelog
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 )
@@ -16,8 +17,14 @@ func parseContainerLinuxChangelog(body []byte, componentVersion string) (string,
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
+
+	b, ok := releases[componentVersion]
+	if !ok {
+		return fmt.Sprintf("Containerlinux release %q was not found in the changelog", componentVersion), nil
+	}
+
 	var release containerlinuxRelease
-	err = json.Unmarshal(releases[componentVersion], &release)
+	err = json.Unmarshal(b, &release)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}


### PR DESCRIPTION
If the container linux version being set for a release is not present in the changelog upstream devctl crashes:

```
Error: Unexpected end of JSON input
        /home/whites/workspace/devctl/pkg/release/changelog/containerlinux.go:27
        /home/whites/workspace/devctl/pkg/release/changelog/changelog.go:246
        /home/whites/workspace/devctl/pkg/release/release_notes.go:57
        /home/whites/workspace/devctl/pkg/release/create.go:102
        /home/whites/workspace/devctl/cmd/release/create/runner.go:44
        /home/whites/workspace/devctl/cmd/release/create/runner.go:34
        /home/whites/workspace/devctl/main.go:50
```

This PR aims at avoiding the crash and setting an empty changelog in the release readme instead