### PR TITLE
Fix embed directive

### DIFF
--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/devctl/pkg/gen/input/workflows/internal/params"
 )
 
-// go:embed create_release.yaml.template
+//go:embed create_release.yaml.template
 var createReleaseTemplate string
 
 func NewCreateReleaseInput(p params.Params) input.Input {


### PR DESCRIPTION
There can't be any spaces between `//` and contents in directives.
This caused the `create_release` workflow to be removed.