### PR TITLE
Disable gitleaks job on `push` trigger

### DIFF
--- a/pkg/gen/input/workflows/internal/file/gitleaks.go
+++ b/pkg/gen/input/workflows/internal/file/gitleaks.go
@@ -24,7 +24,7 @@ func NewGitleaksInput(p params.Params) input.Input {
 var gitleaksTemplate = `{{{{ .Header }}}}
 name: gitleaks
 
-on: [push,pull_request]
+on: [pull_request]
 
 jobs:
   gitleaks:


### PR DESCRIPTION
Pending https://github.com/zricethezav/gitleaks-action/issues/29

We need to figure out a long-term solution here as many repositories have false positives in the history (often from the days of the `vendor` folder). We will either need to have the scanning range fixed upstream or add exclusions to a bunch of repos.