### PR TITLE
Fixing renovate template issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Update k8s version limit in renovate.
+- `--reviewer` option from `devctl gen renovate` is not required anymore.
+
 ## [4.8.0] - 2021-08-11
 
 ## Added

--- a/cmd/gen/renovate/flag.go
+++ b/cmd/gen/renovate/flag.go
@@ -30,8 +30,5 @@ func (f *flag) Validate() error {
 	if f.Language == "" {
 		return microerror.Maskf(invalidFlagError, "--%s cannot be empty", flagLanguage)
 	}
-	if f.Reviewer == "" {
-		return microerror.Maskf(invalidFlagError, "--%s cannot be empty", flagReviewer)
-	}
 	return nil
 }

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -4,6 +4,9 @@
 {
   "extends": [
     "config:base"
+    {{- if $reviewer }},
+    ":reviewer({{ $reviewer | printf "team:%s" }})"
+    {{- end }}
   ],
   {{- if eq $language "go" }}
   "packageRules": [
@@ -21,7 +24,7 @@
     },
     {
       "matchPackagePatterns": ["^k8s.io"],
-      "allowedVersions": "< 1.21.0"
+      "allowedVersions": "< 0.21.0"
     },
     {
       "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
@@ -30,7 +33,6 @@
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   {{- end }}
-  "reviewers": [ {{ $reviewer | printf "team:%s" | printf "%q" }} ],
   "ignoreDeps": ["zricethezav/gitleaks-action"],
   "schedule": [ {{ $interval | printf "%q" }} ]
 }


### PR DESCRIPTION
1. Down the version limit of k8s to 0.21.0 
2. `--reviewer` is not required for `devctl gen renovate` anymore.  

### Checklist

- [x] Update changelog in CHANGELOG.md.
