### PR TITLE
Upgrade go to 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - fix description for name flag at archive release command
+- Upgrade used `architect` version in generated `create_release` and `create_release_pr` workflows to `5.2.0`.
+- Upgrade used go version in generated `create_release` and `create_release_pr` workflows to `1.17.1`.
 
 ## [4.9.2] - 2021-08-18
 

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -84,7 +84,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.4.0"
+          version: "5.2.0"
       - name: Install semver
         uses: giantswarm/install-binary-action@v1.0.0
         with:
@@ -259,7 +259,7 @@ jobs:
           - linux-arm64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GO_VERSION: 1.16.2
+      GO_VERSION: 1.17.1
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
     needs:
@@ -270,9 +270,9 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "3.4.0"
+          version: "5.2.0"
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@v2.1.4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code


### PR DESCRIPTION
This PR updates the workflow templates to use go 1.17.1 and architect 5.2.0

### Checklist

- [x] Update changelog in CHANGELOG.md.
