### PR TITLE
Upgrade fsaintjacques/semver-tool to v3.2.0 for create release action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include release notes for app `aws-ebs-csi-driver`.
 
+### Changed
+
+- Upgrade `fsaintjacques/semver-tool` to `3.2.0`.
+
 ## [4.10.0] - 2021-09-10
 
 - fix description for name flag at archive release command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade `fsaintjacques/semver-tool` to `3.2.0`.
+- Upgrade `fsaintjacques/semver-tool` to `3.2.0` to fix problem with releases
+with high minor version.
 
 ## [4.10.0] - 2021-09-10
 

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -89,7 +89,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "semver"
-          version: "3.0.0"
+          version: "3.2.0"
           download_url: "https://github.com/fsaintjacques/${binary}-tool/archive/${version}.tar.gz"
           tarball_binary_path: "*/src/${binary}"
           smoke_test: "${binary} --version"


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C02GDJJ68Q1/p1637851676206100

In the config repo the release PR often fails even though the release gets created.

Following a hot tip from @ubergesundheit this updates the semver lib.


### Checklist

- [x] Update changelog in CHANGELOG.md.


