### PR TITLE
fix Get version bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `Get version` job failing with some commit messages.
+
 ## [4.11.0] - 2021-11-26
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -30,7 +30,10 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          title="$(echo "${{ github.event.head_commit.message }}" | head -n 1 -)"
+          title="$(cat << 'COMMIT_MESSAGE_END' | head -n 1 -
+          ${{ github.event.head_commit.message }}
+          COMMIT_MESSAGE_END
+          )"
           # Matches strings like:
           #
           #   - "Release v1.2.3"

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -64,18 +64,21 @@ jobs:
       - name: Check if reference version
         id: ref_version
         run: |
-          title="$(echo "${{ github.event.head_commit.message }}" | head -n 1 -)"
-          if echo $title | grep -qE '^release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
-            version=$(echo $title | cut -d ' ' -f 2)
+          title="$(cat <<- 'COMMIT_MESSAGE_END' | head -n 1 -
+          ${{ github.event.head_commit.message }}
+          COMMIT_MESSAGE_END
+          )"
+          if echo "${title}" | grep -qE '^release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+            version=$(echo "${title}" | cut -d ' ' -f 2)
           fi
-          version=$(echo $title | cut -d ' ' -f 2)
+          version=$(echo "${title}" | cut -d ' ' -f 2)
           version="${version#v}" # Strip "v" prefix.
           refversion=false
           if [[ "${version}" =~ ^[0-9]+.[0-9]+.[0-9]+-[0-9]+$ ]]; then
             refversion=true
           fi
-          echo "refversion =\"$refversion\""
-          echo "::set-output name=refversion::$refversion"
+          echo "refversion =\"${refversion}\""
+          echo "::set-output name=refversion::${refversion}"
   update_project_go:
     name: Update project.go
     runs-on: ubuntu-20.04

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -42,11 +42,11 @@ jobs:
           #   - "Release v1.2.3-r4 (#56)"
           #
           # And outputs version part (1.2.3).
-          if echo $title | grep -iqE '^Release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
-            version=$(echo $title | cut -d ' ' -f 2)
+          if echo "${title}" | grep -iqE '^Release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+          version=$(echo "${title}" | cut -d ' ' -f 2)
           fi
           version="${version#v}" # Strip "v" prefix.
-          echo "version=\"$version\""
+          echo "version=\"${version}\""
           echo "::set-output name=version::${version}"
       - name: Checkout code
         if: ${{ steps.get_version.outputs.version != '' }}

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -30,7 +30,7 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          title="$(cat << 'COMMIT_MESSAGE_END' | head -n 1 -
+          title="$(cat <<- 'COMMIT_MESSAGE_END' | head -n 1 -
           ${{ github.event.head_commit.message }}
           COMMIT_MESSAGE_END
           )"


### PR DESCRIPTION
With some commit messages the `Get version` job fails with

```
Run title="$(echo "disable capi controller on kvm (#782)
/home/runner/work/_temp/8532b5f1-4835-41e4-9331-7127a6116541.sh: line 1: unexpected EOF while looking for matching `)'
Error: Process completed with exit code 2.
```

see: https://github.com/giantswarm/prometheus-meta-operator/runs/4583563350?check_suite_focus=true

I also went ahead and protected aligned variables protection with quotes and curly braces.