### PR TITLE
add changelog entries to release body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add changelog entries to release body.
+
 ## [4.11.0] - 2021-11-26
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -152,6 +152,12 @@ jobs:
           file="${{ needs.gather_facts.outputs.project_go_path }}"
           version="${{ needs.gather_facts.outputs.version }}"
           grep -qE "version[[:space:]]*=[[:space:]]*\"$version\"" $file
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ needs.gather_facts.outputs.version }}
+          path: ./CHANGELOG.md
       - name: Create tag
         run: |
           version="${{ needs.gather_facts.outputs.version }}"
@@ -168,6 +174,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          body: ${{ steps.changelog_reader.outputs.changes }}
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
           release_name: "v${{ needs.gather_facts.outputs.version }}"
 


### PR DESCRIPTION
Add changelog entries to the Github release content, so we can see what a specific release contains just by looking at Github release.

* view release
![image](https://user-images.githubusercontent.com/6536819/146799192-412dda98-3f3e-4d06-b9ba-b8b4d6250ade.png)
* edit release
![image](https://user-images.githubusercontent.com/6536819/146799243-e18c37d6-05cb-4709-8ae7-14d3e28d9776.png)

ci job: https://github.com/giantswarm/prometheus-meta-operator/runs/4584835308?check_suite_focus=true