### PR TITLE
Upgrade github release action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade Github release action.
+
 ## [4.11.0] - 2021-11-26
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -282,13 +282,10 @@ jobs:
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Add ${{ matrix.platform }} package to release
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.tar.gz
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}
-          asset_name: ${{ env.FILE_NAME }}
-          asset_content_type: application/octet-stream
+          files: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}
 
 {{{{- end }}}}

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -164,12 +164,12 @@ jobs:
           git push "${REMOTE_REPO}" --tags
       - name: Create release
         id: create_gh_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
-          release_name: "v${{ needs.gather_facts.outputs.version }}"
+          name: "v${{ needs.gather_facts.outputs.version }}"
 
 {{{{- if .EnableFloatingMajorVersionTags }}}}
 


### PR DESCRIPTION
The official release action is no longer maintained, https://github.com/actions/create-release

This PR upgrade the action to what I found to be the "best" fork, https://github.com/softprops/action-gh-release