### PR TITLE
Exclude CAPI deps and suggest apiextensions v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renovate excludes cluster-api dependencies.
+- Renovate only suggest giantswarm/apiextensions >= 4.0.0.
+
 ### Added
 
 - Add `k8sapi` flavour to `gen` commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Renovate excludes cluster-api dependencies.
+- Renovate exclude cluster-api dependencies.
 - Renovate only suggest giantswarm/apiextensions >= 4.0.0.
 
 ### Added

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -29,7 +29,15 @@
     {
       "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
       "allowedVersions": "< 0.7.0"
-    }
+    },
+     {
+       "matchPackagePatterns": ["github.com/giantswarm/apiextensions*"],
+       "allowedVersions": ">= 4.0.0"
+     },
+     {
+       "excludePackagePatterns": ["sigs.k8s.io/cluster-api*"],
+       "groupName": "capi modules"
+     }
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   {{- end }}


### PR DESCRIPTION
We can't just upgrade the CAPI dependencies, we want to control when this happens. So let's exclude those dependencies from renovate.

Also we want to exclude one faulty apiextensions release 3.40.0, so let's suggest v4.0.0 onwards.

### Checklist

- [X] Update changelog in CHANGELOG.md.
