### PR TITLE
Update setup-go action to 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `setup-go` action to v2.1.5.
+
 ## [4.15.0] - 2022-02-02
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -285,7 +285,7 @@ jobs:
           binary: "architect"
           version: "5.3.0"
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2.1.4
+        uses: actions/setup-go@v2.1.5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code


### PR DESCRIPTION
Avoids Dependabot PRs on all of our repos for this update--handled instead by the `align-files` PR.

### Checklist

- [x] Update changelog in CHANGELOG.md.
