### PR TITLE
Update architect to v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `setup-go` action to v2.1.5.
+- Update `architect` to v6.1.0.
 
 ## [4.15.0] - 2022-02-02
 

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -90,7 +90,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "5.3.0"
+          version: "6.1.0"
       - name: Install semver
         uses: giantswarm/install-binary-action@v1.0.0
         with:
@@ -283,7 +283,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "5.3.0"
+          version: "6.1.0"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2.1.5
         with:

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -118,7 +118,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "5.3.0"
+          version: "6.1.0"
       - name: Checkout code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Brings in the `--update-changelog` flag for future release notes automation.

### Checklist

- [x] Update changelog in CHANGELOG.md.
