### PR TITLE
Go 1.17.7, architect 6.2.0 and ignore setup-go action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `setup-go` action to v2.2.0 in generated workflows.
+- Update used go version in generated workflows to 1.17.7.
+- Update `architect` to v6.2.0 (with go version 1.17.7).
+
 ## [4.16.1] - 2022-02-09
 
 ### Fixed

--- a/pkg/gen/input/dependabot/internal/file/dependabot.yml.template
+++ b/pkg/gen/input/dependabot/internal/file/dependabot.yml.template
@@ -27,5 +27,6 @@ updates:
   {{- if eq $ecosystem $ecosystemGithubActions }}
     ignore:
       - dependency-name: zricethezav/gitleaks-action
+      - dependency-name: actions/setup-go
   {{- end }}
 {{- end }}

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -59,7 +59,8 @@
   ],
   "ignoreDeps": [
     "architect",
-    "zricethezav/gitleaks-action"
+    "zricethezav/gitleaks-action",
+    "actions/setup-go"
   ],
   "schedule": [ {{ $interval | printf "%q" }} ]
 }

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -272,7 +272,7 @@ jobs:
           - linux-arm64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GO_VERSION: 1.17.6
+      GO_VERSION: 1.17.7
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
     needs:
@@ -283,9 +283,9 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "6.1.0"
+          version: "6.2.0"
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v2.1.5
+        uses: actions/setup-go@v2.2.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code


### PR DESCRIPTION
This PR updates go to 1.17.7, architect to 6.2.0 and ignores setup-go action

### Checklist

- [x] Update changelog in CHANGELOG.md.
