### PR TITLE
Add 'dependencies' label to renovate PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Let renovate add the `dependencies` label to every PR it creates.
+
 ## [4.17.0] - 2022-02-11
 
 ### Changed

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -8,6 +8,7 @@
     ":reviewer({{ $reviewer | printf "team:%s" }})"
     {{- end }}
   ],
+  "labels": ["dependencies"],
   {{- if eq $language "go" }}
   "packageRules": [
     {


### PR DESCRIPTION
Make renovate add a `dependencies` label to every PR it creates. See https://docs.renovatebot.com/configuration-options/#labels

### Checklist

- [x] Update changelog in CHANGELOG.md.
