### PR TITLE
Forgot one actions checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Forgot to update one `actions/checkout` in create_release_pr workflow template.
+
 ## [4.20.0] - 2022-03-02
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -120,7 +120,7 @@ jobs:
           binary: "architect"
           version: "6.1.0"
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.gather_facts.outputs.branch }}
       - name: Prepare release changes


### PR DESCRIPTION
Seems in 4.20.0 I forgot to replace one `actions/checkout` ocurrence.

### Checklist

- [x] Update changelog in CHANGELOG.md.
