### PR TITLE
Go 1.17.8 and architect 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update used go version in generated workflows to 1.17.8.
+- Update `architect` to v6.3.0 (with go version 1.17.8).
+
 ## [4.20.1] - 2022-03-02
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -272,7 +272,7 @@ jobs:
           - linux-arm64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GO_VERSION: 1.17.7
+      GO_VERSION: 1.17.8
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
     needs:
@@ -283,7 +283,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.0.0
         with:
           binary: "architect"
-          version: "6.2.0"
+          version: "6.3.0"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v2.2.0
         with:


### PR DESCRIPTION
This PR updates go to 1.17.8 and architect to 6.3.0

### Checklist

- [ ] Update changelog in CHANGELOG.md.
