### PR TITLE
Fix fetching release notes from flatcar releases and add more apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add more apps for release notes.
+
+### Fixed
+
+- Fix fetching flatcar release notes.
+
 ## [4.21.0] - 2022-03-04
 
 ### Changed

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -94,7 +94,7 @@ var knownComponentParseParams = map[string]parseParams{
 	},
 	"containerlinux": {
 		tag:       "https://www.flatcar-linux.org/releases/#release-{{.Version}}",
-		changelog: "https://kinvolk.io/flatcar-container-linux/releases-json/releases-stable.json",
+		changelog: "https://www.flatcar.org/releases-json/releases-stable.json",
 	},
 	"cert-exporter": {
 		tag:       "https://github.com/giantswarm/cert-exporter/releases/tag/v{{.Version}}",
@@ -138,6 +138,12 @@ var knownComponentParseParams = map[string]parseParams{
 		start:     commonStartPattern,
 		end:       commonEndPattern,
 	},
+	"kiam-watchdog": {
+		tag:       "https://github.com/giantswarm/kiam-watchdog/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/kiam-watchdog/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
 	"kube-state-metrics": {
 		tag:       "https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v{{.Version}}",
 		changelog: "https://raw.githubusercontent.com/giantswarm/kube-state-metrics-app/v{{.Version}}/CHANGELOG.md",
@@ -177,6 +183,18 @@ var knownComponentParseParams = map[string]parseParams{
 	"aws-ebs-csi-driver": {
 		tag:       "https://github.com/giantswarm/aws-ebs-csi-driver-app/releases/tag/v{{.Version}}",
 		changelog: "https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
+	"vertical-pod-autoscaler": {
+		tag:       "https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/vertical-pod-autoscaler-app/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
+	"vertical-pod-autoscaler-crd": {
+		tag:       "https://github.com/giantswarm/vertical-pod-autoscaler-crd/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/vertical-pod-autoscaler-crd/v{{.Version}}/CHANGELOG.md",
 		start:     commonStartPattern,
 		end:       commonEndPattern,
 	},

--- a/pkg/release/changelog/containerlinux.go
+++ b/pkg/release/changelog/containerlinux.go
@@ -11,15 +11,11 @@ type containerlinuxRelease struct {
 }
 
 func parseContainerLinuxChangelog(body []byte, componentVersion string) (string, error) {
-	var releases map[string]json.RawMessage
+	var releases map[string]containerlinuxRelease
 	err := json.Unmarshal(body, &releases)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
-	var release containerlinuxRelease
-	err = json.Unmarshal(releases[componentVersion], &release)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-	return release.ReleaseNotes, nil
+
+	return releases[componentVersion].ReleaseNotes, nil
 }


### PR DESCRIPTION
- When fetching flatcar release notes it doesn't work anymore `Error: Unexpected end of JSON input`.
- Adding more apps for release notes.

### Checklist

- [x] Update changelog in CHANGELOG.md.