### PR TITLE
Test/fix check values schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make values schema checking resilient against slashes in branch names.
+
 ## [5.1.0] - 2022-04-08
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -16,12 +16,9 @@ jobs:
           VALUES_FILE_CHANGED="false"
           SCHEMA_FILE_CHANGED="false"
 
-          base_ref=${GITHUB_BASE_REF##*/}
-          head_ref=${GITHUB_HEAD_REF##*/}
+          echo "Comparing ${GITHUB_BASE_REF}...${GITHUB_HEAD_REF}"
 
-          echo "Comparing ${base_ref}...${head_ref}"
-
-          changed_files=$(gh api repos/{owner}/{repo}/compare/${base_ref}...${head_ref} --jq ".files[] | .filename")
+          changed_files=$(gh api 'repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF}' --jq ".files[] | .filename")
 
           if grep -q "values.schema.json" <<< $(git ls-tree -r --name-only ${GITHUB_SHA}); then
 


### PR DESCRIPTION
This PR attempts to fix the helm values checking workflow to allow slashes in the branch names.

This does not completely fix the action. Trivial changes in values.yaml (comments, value changes with the same type, ordering, ...) will be still reported as a missing change to its schema.

### Checklist

- [x] Update changelog in CHANGELOG.md.
