### PR TITLE
Add windows-amd64 to platforms for CLI builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Build Windows binaries for CLIs
+- Build signed Windows binaries for CLIs
 
 ## [5.1.2] - 2022-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Build Windows binaries for CLIs
+
 ## [5.1.2] - 2022-04-14
 
 ### Fixed

--- a/cmd/gen/makefile/runner.go
+++ b/cmd/gen/makefile/runner.go
@@ -65,7 +65,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 
 		if r.flag.Language == gen.LanguageGo {
-			inputs = append(inputs, in.MakefileGenGo())
+			inputs = append(inputs, in.MakefileGenGo()...)
 		}
 	}
 

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -91,7 +91,7 @@ package-windows-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.z
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: DIR=$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 	@echo "====> $@"
-	/bin/sh .github/windows-code-signing.sh $(APPLICATION) $(VERSION)
+	/bin/sh .github/zz_generated.windows-code-signing.sh $(APPLICATION) $(VERSION)
 	@echo "Creating directory $(DIR)"
 	mkdir -p $(DIR)
 	cp $< $(DIR)/$(APPLICATION).exe

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -91,27 +91,7 @@ package-windows-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.z
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: DIR=$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 	@echo "====> $@"
-
-	@ if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" != "" ]; then \
-	  echo 'Signing the Windows binary'; \
-	  mkdir -p certs; \
-	  echo ${CODE_SIGNING_CERT_BUNDLE_BASE64} | base64 -d > certs/code-signing.p12; \
-	  mv ${APPLICATION}-v${VERSION}-windows-amd64.exe ${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe; \
-	  docker run --rm -ti \
-		  -v ${PWD}/certs:/mnt/certs \
-		  -v ${PWD}:/mnt/binaries \
-		  --user ${USERID}:${GROUPID} \
-		  quay.io/giantswarm/signcode-util:1.0.0 \
-		  sign \
-		  -pkcs12 /mnt/certs/code-signing.p12 \
-		  -n "Giant Swarm CLI tool $(APPLICATION)" \
-		  -i https://github.com/giantswarm/$(APPLICATION) \
-		  -t http://timestamp.digicert.com -verbose \
-		  -in /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe \
-		  -out /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe \
-		  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \
-	fi
-
+	/bin/sh .github/windows-code-signing.sh $(APPLICATION) $(VERSION)
 	@echo "Creating directory $(DIR)"
 	mkdir -p $(DIR)
 	cp $< $(DIR)/$(APPLICATION).exe

--- a/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
+++ b/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
@@ -10,15 +10,30 @@ import (
 //go:embed Makefile.gen.go.mk.template
 var makefileGenGoMkTemplate string
 
-func NewMakefileGenGoMkInput(p params.Params) input.Input {
-	i := input.Input{
-		Path:         "Makefile.gen.go.mk",
-		TemplateBody: makefileGenGoMkTemplate,
-		TemplateData: map[string]interface{}{
-			"IsFlavourCLI": params.IsFlavourCLI(p),
-			"Header":       params.Header("#"),
+//go:embed windows-code-signing.sh.template
+var windowsCodeSigningShellScriptTemplate string
+
+func NewMakefileGenGoMkInput(p params.Params) []input.Input {
+	inputs := []input.Input{
+		{
+			Path:         "Makefile.gen.go.mk",
+			TemplateBody: makefileGenGoMkTemplate,
+			TemplateData: map[string]interface{}{
+				"IsFlavourCLI": params.IsFlavourCLI(p),
+				"Header":       params.Header("#"),
+			},
 		},
 	}
 
-	return i
+	if params.IsFlavourCLI(p) {
+		inputs = append(inputs, input.Input{
+			Path:         ".github/windows-code-signing.sh",
+			TemplateBody: windowsCodeSigningShellScriptTemplate,
+			TemplateData: map[string]interface{}{
+				"Header": params.Header("#"),
+			},
+		})
+	}
+
+	return inputs
 }

--- a/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
+++ b/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
@@ -27,7 +27,7 @@ func NewMakefileGenGoMkInput(p params.Params) []input.Input {
 
 	if params.IsFlavourCLI(p) {
 		inputs = append(inputs, input.Input{
-			Path:         ".github/windows-code-signing.sh",
+			Path:         ".github/zz_generated.windows-code-signing.sh",
 			TemplateBody: windowsCodeSigningShellScriptTemplate,
 			TemplateData: map[string]interface{}{
 				"Header": params.Header("#"),

--- a/pkg/gen/input/makefile/internal/file/windows-code-signing.sh.template
+++ b/pkg/gen/input/makefile/internal/file/windows-code-signing.sh.template
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+{{ .Header }}
+
+APPLICATION=$1
+VERSION=$2
+
+SIGNCODE_UTIL=quay.io/giantswarm/signcode-util:1.1.1
+
+echo "APPLICATION=${APPLICATION}"
+echo "VERSION=${VERSION}"
+echo "PWD=${PWD}"
+
+if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" = "" ]; then
+	echo "Variable CODE_SIGNING_CERT_BUNDLE_PASSWORD not set."
+	exit 1
+fi;
+
+if [ "${CODE_SIGNING_CERT_BUNDLE_BASE64}" = "" ]; then
+	echo "Variable CODE_SIGNING_CERT_BUNDLE_BASE64 not set."
+	exit 1
+fi;
+
+echo "Signing the Windows binary"
+
+mkdir -p certs
+
+echo "${CODE_SIGNING_CERT_BUNDLE_BASE64}" | base64 -d > certs/code-signing.p12
+
+mv ${APPLICATION}-v${VERSION}-windows-amd64.exe ${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe
+
+docker pull --quiet ${SIGNCODE_UTIL}
+
+docker run --rm \
+	-v ${PWD}/certs:/mnt/certs \
+	-v ${PWD}:/mnt/binaries \
+	${SIGNCODE_UTIL} \
+	sign \
+	-pkcs12 /mnt/certs/code-signing.p12 \
+	-n "Giant Swarm CLI tool ${APPLICATION}" \
+	-i https://github.com/giantswarm/${APPLICATION} \
+	-t http://timestamp.digicert.com -verbose \
+	-in /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe \
+	-out /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe \
+	-pass "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}"
+
+echo "Verifying the signed binary"
+
+docker run --rm \
+	-v ${PWD}:/mnt/binaries \
+	${SIGNCODE_UTIL} \
+	verify \
+	/mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe

--- a/pkg/gen/input/makefile/makefile.go
+++ b/pkg/gen/input/makefile/makefile.go
@@ -33,7 +33,7 @@ func (m *Makefile) MakefileGenApp() input.Input {
 	return file.NewMakefileGenAppMkInput(m.params)
 }
 
-func (m *Makefile) MakefileGenGo() input.Input {
+func (m *Makefile) MakefileGenGo() []input.Input {
 	return file.NewMakefileGenGoMkInput(m.params)
 }
 

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -276,6 +276,8 @@ jobs:
       GO_VERSION: 1.17.8
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
+      CODE_SIGNING_CERT_BUNDLE_BASE64: ${{ secrets.CODE_SIGNING_CERT_BUNDLE_BASE64 }}
+      CODE_SIGNING_CERT_BUNDLE_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_BUNDLE_PASSWORD }}
     needs:
       - create_release
       - gather_facts

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -270,6 +270,7 @@ jobs:
           - linux-amd64
           - darwin-arm64
           - linux-arm64
+          - windows-amd64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GO_VERSION: 1.17.8

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -295,10 +295,15 @@ jobs:
           ref: ${{ env.TAG }}
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
+      - name: Specify package file name based on platform
+        run: |
+          if [[ "${{ matrix.platform }}" == "windows-amd64" ]]; then
+            echo "FILE_NAME=${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.zip" >> $GITHUB_ENV
+          else
+            echo "FILE_NAME=${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.tar.gz" >> $GITHUB_ENV
+          fi
       - name: Add ${{ matrix.platform }} package to release
         uses: actions/upload-release-asset@v1
-        env:
-          FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}.tar.gz
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/333

This adds building of `windows-amd64` binaries for all CLIs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
