### PR TITLE
Add permissions field for Input struct and set windows code signing script permissions to 0755

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added file system permissions field to file generation `Input` struct. If not set, the default value remains: `0644`.
+- Added executable flags for generated `windows-code-signing.sh` script.
+
 ### Fixed
 
-- Fixed windows-code-signing.sh template for shell-lint pre-commit hook and make it executable
+- Fixed quotation in generated `windows-code-signing.sh` to prevent globbing and word splitting issues.
 
 ## [5.2.0] - 2022-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed windows-code-signing.sh template for shell-lint pre-commit hook and make it executable
+
 ## [5.2.0] - 2022-04-20
 
 ### Added

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -2,6 +2,7 @@ package gen
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -53,7 +54,12 @@ func execute(ctx context.Context, file input.Input) error {
 		return nil
 	}
 
-	w, err := os.OpenFile(file.Path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	var permissions fs.FileMode = 0644
+	if file.Permissions != 0 {
+		permissions = file.Permissions
+	}
+
+	w, err := os.OpenFile(file.Path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, permissions)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
+++ b/pkg/gen/input/makefile/internal/file/makefile_gen_go_mk.go
@@ -28,6 +28,7 @@ func NewMakefileGenGoMkInput(p params.Params) []input.Input {
 	if params.IsFlavourCLI(p) {
 		inputs = append(inputs, input.Input{
 			Path:         ".github/zz_generated.windows-code-signing.sh",
+			Permissions:  0755,
 			TemplateBody: windowsCodeSigningShellScriptTemplate,
 			TemplateData: map[string]interface{}{
 				"Header": params.Header("#"),

--- a/pkg/gen/input/makefile/internal/file/windows-code-signing.sh.template
+++ b/pkg/gen/input/makefile/internal/file/windows-code-signing.sh.template
@@ -27,27 +27,27 @@ mkdir -p certs
 
 echo "${CODE_SIGNING_CERT_BUNDLE_BASE64}" | base64 -d > certs/code-signing.p12
 
-mv ${APPLICATION}-v${VERSION}-windows-amd64.exe ${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe
+mv "${APPLICATION}-v${VERSION}-windows-amd64.exe" "${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe"
 
 docker pull --quiet ${SIGNCODE_UTIL}
 
 docker run --rm \
-	-v ${PWD}/certs:/mnt/certs \
-	-v ${PWD}:/mnt/binaries \
+	-v "${PWD}/certs:/mnt/certs" \
+	-v "${PWD}:/mnt/binaries" \
 	${SIGNCODE_UTIL} \
 	sign \
 	-pkcs12 /mnt/certs/code-signing.p12 \
 	-n "Giant Swarm CLI tool ${APPLICATION}" \
-	-i https://github.com/giantswarm/${APPLICATION} \
+	-i "https://github.com/giantswarm/${APPLICATION}" \
 	-t http://timestamp.digicert.com -verbose \
-	-in /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe \
-	-out /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe \
+	-in "/mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe" \
+	-out "/mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe" \
 	-pass "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}"
 
 echo "Verifying the signed binary"
 
 docker run --rm \
-	-v ${PWD}:/mnt/binaries \
+	-v "${PWD}:/mnt/binaries" \
 	${SIGNCODE_UTIL} \
 	verify \
-	/mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe
+	"/mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe"

--- a/pkg/gen/input/types.go
+++ b/pkg/gen/input/types.go
@@ -11,7 +11,7 @@ type Input struct {
 	// Path is the absolute path of the file to be generated from this
 	// Input.
 	Path string
-	// Permissions to generate the file with
+	// Permissions to generate the file with.
 	Permissions fs.FileMode
 	// TemplateBody is the Go text template from which the file is
 	// generated.

--- a/pkg/gen/input/types.go
+++ b/pkg/gen/input/types.go
@@ -1,5 +1,9 @@
 package input
 
+import (
+	"io/fs"
+)
+
 type Input struct {
 	// If delete is true, the file will be deleted if it exists. Allows
 	// for files to be moved/renamed.
@@ -7,6 +11,8 @@ type Input struct {
 	// Path is the absolute path of the file to be generated from this
 	// Input.
 	Path string
+	// Permissions to generate the file with
+	Permissions fs.FileMode
 	// TemplateBody is the Go text template from which the file is
 	// generated.
 	TemplateBody string


### PR DESCRIPTION
### Context
The generated script for `.github/zz_generated.windows-code-signing.sh` did not have proper quoting and the executable flags were missing from the file.

### Checklist

- [x] Update changelog in CHANGELOG.md.
