### PR TITLE
Don't try to update version field in architect managed Chart.yaml files

### DIFF
--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -173,7 +173,10 @@ jobs:
           # Check chart YAML.
           if [ -f "${chart_yaml}" ]
           then
-            yq -i '.version = "${{ needs.gather_facts.outputs.version }}"' "${chart_yaml}"
+            # check if version in Chart.yaml is templated using architect
+            if [ $(grep -c "^version:.*\.Version.*$" "${chart_yaml}") = "0" ]; then
+              yq -i '.version = "${{ needs.gather_facts.outputs.version }}"' "${chart_yaml}"
+            fi
           fi
 
       - name: Bump go module defined in go.mod if needed


### PR DESCRIPTION
This PR is a follow up to #431

It contains an additional check to Chart.yaml files to see if its managed by architect, which uses a special `[[ .Version ]]` template instead of the actual version.

Many Giant Swarm operators use this, for example [app-operator](https://github.com/giantswarm/app-operator/blob/master/helm/app-operator/Chart.yaml#L6=)
