### PR TITLE
Align git author identities in workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Align git author identities throughout PR automation workflows
+
 ## [5.7.0] - 2022-06-23
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -22,6 +22,7 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 			"Header":                         params.Header("#"),
 			"EnableFloatingMajorVersionTags": params.EnableFloatingMajorVersionTags(p),
 			"IsFlavourCLI":                   params.IsFlavourCLI(p),
+			"StepSetUpGitIdentity":           params.StepSetUpGitIdentity(),
 		},
 	}
 

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -117,11 +117,10 @@ jobs:
             echo "error: no changes in \"$file\"" >&2
             exit 1
           fi
+{{{{ .StepSetUpGitIdentity }}}}
       - name: Commit changes
         run: |
           file="${{ needs.gather_facts.outputs.project_go_path }}"
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
           git add $file
           git commit -m "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
       - name: Push changes
@@ -164,10 +163,10 @@ jobs:
         with:
           version: ${{ needs.gather_facts.outputs.version }}
           path: ./CHANGELOG.md
+{{{{ .StepSetUpGitIdentity }}}}
       - name: Create tag
         run: |
           version="${{ needs.gather_facts.outputs.version }}"
-          git config --local user.name "github-actions"
           git tag "v$version" ${{ github.sha }}
       - name: Push tag
         env:

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -19,7 +19,8 @@ func NewCreateReleasePRInput(p params.Params) input.Input {
 			Right: "}}}}",
 		},
 		TemplateData: map[string]interface{}{
-			"Header": params.Header("#"),
+			"Header":               params.Header("#"),
+			"StepSetUpGitIdentity": params.StepSetUpGitIdentity(),
 		},
 	}
 

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -185,12 +185,11 @@ jobs:
             go install github.com/marwan-at-work/mod/cmd/mod@v0.4.2
             mod upgrade
           fi
+{{{{ .StepSetUpGitIdentity }}}}
       - name: Create release commit
         env:
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
           git add -A
           git commit -m "Release v${{ env.version }}"
       - name: Push changes

--- a/pkg/gen/input/workflows/internal/params/key_common.go
+++ b/pkg/gen/input/workflows/internal/params/key_common.go
@@ -9,6 +9,10 @@ func Header(comment string) string {
 	return internal.Header(comment)
 }
 
+func StepSetUpGitIdentity() string {
+	return internal.StepSetUpGitIdentity()
+}
+
 func EnableFloatingMajorVersionTags(p Params) bool {
 	return p.EnableFloatingMajorVersionTags
 }

--- a/pkg/gen/internal/key.go
+++ b/pkg/gen/internal/key.go
@@ -33,6 +33,15 @@ func Header(comment string) string {
 	}, "\n")
 }
 
+func StepSetUpGitIdentity() string {
+	return strings.Join([]string{
+		"      - name: Set up git identity",
+		"        run: |",
+		`          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"`,
+		`          git config --local user.name "github-actions[bot]"`,
+	}, "\n")
+}
+
 // Package returns Go package name for the give directory.
 func Package(dir string) string {
 	abs, err := filepath.Abs(dir)


### PR DESCRIPTION
This PR aligns the identity used in git commits done by the release automation workflows.

Before:
![image](https://user-images.githubusercontent.com/1494211/175324021-4396afab-1d12-402b-b1cb-7edfb6911028.png)


After:
![image](https://user-images.githubusercontent.com/1494211/175323955-3199bb7b-5d14-4b13-a619-27941ac56361.png)


### Checklist

-  [x] Update changelog in CHANGELOG.md.
