### PR TITLE
Rework helm schema check to make it smarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Align git author identities throughout PR automation workflows
+- Completely rework check_values_schema action to cut down on noise
 
 ## [5.7.0] - 2022-06-23
 

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -13,31 +13,66 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VALUES_FILE_CHANGED="false"
-          SCHEMA_FILE_CHANGED="false"
-
           echo "Comparing ${GITHUB_BASE_REF}...${GITHUB_HEAD_REF}"
 
-          changed_files=$(gh api "repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF}" --jq ".files[] | .filename")
-
+          # check if repo contains a schema file
           if grep -q "values.schema.json" <<< $(git ls-tree -r --name-only ${GITHUB_SHA}); then
 
-            if grep -q "values.yaml" <<< "${changed_files}" ; then
-              VALUES_FILE_CHANGED="true"
+            # get a list of files changed in the PR
+            CHANGED_FILES=$(gh api repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF} \
+              --jq ".files[].filename")
+
+            # check if values.yaml was modified by this PR
+            if grep -q "values.yaml" <<< "${CHANGED_FILES}" ; then
+
+              # get the path to values.yaml
+              VALUES_FILE=$(gh api repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF} \
+                --jq ".files[].filename" | grep "values.yaml")
+
+              # fetch branches so we can use them to compare
+              git fetch &> /dev/null
+
+              # calculate hash of the keys from values.yaml from the default branch
+              DEFAULT_BRANCH_SHA=$(git show origin/${GITHUB_BASE_REF}:${VALUES_FILE} | yq -o=json \
+                | jq -r '[paths | join(".")]' | sha1sum | awk '{print $1}')
+
+              # calculate hash of the keys from values.yaml from this branch
+              THIS_BRANCH_SHA=$(git show origin/${GITHUB_HEAD_REF}:${VALUES_FILE} | yq -o=json \
+                | jq -r '[paths | join(".")]' | sha1sum | awk '{print $1}')
+
+              # compare hashes of the values files
+              if [[ "${DEFAULT_BRANCH_SHA}" != "${THIS_BRANCH_SHA}" ]]; then
+
+                # values file structure has been modified so we need to ensure the schema
+                # file is also updated
+
+                if grep -q "values.schema.json" <<< "${CHANGED_FILES}" ; then
+                  # we assume that the schema has been updated, nothing to do
+                  echo "PASSED: values.yaml and values.schema.json both appear to have been updated"
+                  exit 0
+                else
+                  # schema must be updated
+                  echo "FAILED: values.yaml was updated but values.schema.json hasn't been regenerated"
+                  echo "Please refer to this document: {{{{ .SchemaDocsURL }}}}"
+                  exit 1
+                fi
+
+              else
+                # values file structure hasn't changed, nothing to do
+                echo "values.yaml structure hasn't been changed by this PR"
+                exit 0
+              fi
+
+            else
+              # values file not included in PR, nothing to see here
+              echo "values.yaml not included in this PR"
+              exit 0
             fi
 
-            if grep -q "values.schema.json" <<< "${changed_files}" ; then
-              SCHEMA_FILE_CHANGED="true"
-            fi
+          else
 
-            if [ $VALUES_FILE_CHANGED != $SCHEMA_FILE_CHANGED ]; then
-              echo "FAILED: values.yaml was updated but values.schema.json hasn't been regenerated"
-              echo "Please refer to this document: {{{{ .SchemaDocsURL }}}}"
-              exit 1
-            fi
-
-            echo "PASSED: values.yaml and values.schema.json both appear to have been updated"
+            # if grep returns negative then there isn't a values.schema.json to check
+            echo "No values.schema.json file found in branch '${GITHUB_BASE_REF}', nothing to check"
             exit 0
-          fi
 
-          echo "INFO: values.schema.json not present in this repo - nothing to do"
+          fi

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -22,12 +22,13 @@ jobs:
             CHANGED_FILES=$(gh api repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF} \
               --jq ".files[].filename")
 
-            # check if values.yaml was modified by this PR
-            if grep -q "values.yaml" <<< "${CHANGED_FILES}" ; then
+            # check if values.yaml in main chart was modified by this PR
+            # (this won't check values files in subcharts)
+            if grep -q 'helm\/[-a-z].*\/values.yaml' <<< "${CHANGED_FILES}" ; then
 
               # get the path to values.yaml
               VALUES_FILE=$(gh api repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF} \
-                --jq ".files[].filename" | grep "values.yaml")
+                --jq ".files[].filename" | grep 'helm\/[-a-z].*\/values.yaml')
 
               # fetch branches so we can use them to compare
               git fetch &> /dev/null

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -33,12 +33,14 @@ jobs:
               git fetch &> /dev/null
 
               # calculate hash of the keys from values.yaml from the default branch
-              DEFAULT_BRANCH_SHA=$(git show origin/${GITHUB_BASE_REF}:${VALUES_FILE} | yq -o=json \
-                | jq -r '[paths | join(".")]' | sha1sum | awk '{print $1}')
+              DEFAULT_BRANCH_SHA=$(git show origin/${GITHUB_BASE_REF}:${VALUES_FILE} \
+                | yq -P 'sort_keys(..)' -o=json | jq -r '[paths | join(".")]' \
+                | sha1sum | awk '{print $1}')
 
               # calculate hash of the keys from values.yaml from this branch
-              THIS_BRANCH_SHA=$(git show origin/${GITHUB_HEAD_REF}:${VALUES_FILE} | yq -o=json \
-                | jq -r '[paths | join(".")]' | sha1sum | awk '{print $1}')
+              THIS_BRANCH_SHA=$(git show origin/${GITHUB_HEAD_REF}:${VALUES_FILE} \
+                | yq -P 'sort_keys(..)' -o=json | jq -r '[paths | join(".")]' \
+                | sha1sum | awk '{print $1}')
 
               # compare hashes of the values files
               if [[ "${DEFAULT_BRANCH_SHA}" != "${THIS_BRANCH_SHA}" ]]; then


### PR DESCRIPTION
This PR:

- reworks the helm schema check action to try and cut down on false positives.

#### Rationale

The current version of the schema check is dumb (I know, I wrote it), because it just checks to see if the values file has been altered in the PR and fails if the schema file hasn't been updated. There are many reasons to change a values file (e,g, comments) which mean the file is altered but there is no corresponding change in the schema file. Consequently, this CI check creates a lot of noise and often gets ignored.

This PR makes it much smarter. Instead of just checking if the file is in the PR, it also checks to see if the yaml structure has been changed by comparing it to the values file in the main/master branch. This is achieved with some jq magic which outputs a list of all keys in the file (including nested keys), like so:

```
[
  "name",
  "namespace",
  "image",
  "image.repository",
  "userID",
  "groupID",
  "Installation",
  "Installation.V1",
  "Installation.V1.Registry",
  "Installation.V1.Registry.Domain",
  "port",
  "protocol"
]
```

It then calculates the sha1 hash of the keys and compares it to the hash of the values file in the main/master branch. If the hashes differ then it makes sure the schema file is included in the PR and fails if it isn't.

This isn't perfect, but it's vastly better than the current check.

### Checklist

- [x] Update changelog in CHANGELOG.md.
