### PR TITLE
Bump go module also when releasing a major version with a suffix

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -2,19 +2,30 @@
 # Taken from: https://github.com/giantswarm/opsctl/pull/1072/files#diff-bbe4a7fb12c43622bce7c6840c770e9995be614626a219942ca138403629cb69R1
 CVE-2019-10743 until=2021-10-17
 
-CVE-2022-29946 until=2022-07-30
-CVE-2021-32026 until=2022-07-30
-CVE-2022-29153 until=2022-07-30
-CVE-2022-29153 until=2022-07-30
-CVE-2022-24687 until=2022-07-30
-CVE-2021-23772 until=2022-07-30
-CVE-2021-42576 until=2022-07-30
-CVE-2020-26892 until=2022-07-30
-CVE-2021-3127  until=2022-07-30
-CVE-2022-24450 until=2022-07-30
-CVE-2020-26521 until=2022-07-30
-CVE-2020-28466 until=2022-07-30
+CVE-2022-29946 until=2022-12-31
+CVE-2021-32026 until=2022-12-31
+
+# pkg:golang/github.com/nats-io/nats-server/v2@v2.1.2
+# it's required by go-kit which is pulled by mane GS libraries
+CVE-2020-26892 until=2022-12-31
+CVE-2022-24450 until=2022-12-31
+CVE-2020-26521 until=2022-12-31
+CVE-2020-28466 until=2022-12-31
+CVE-2021-3127  until=2022-12-31
 
 sonatype-2020-1258 until=2022-07-30
 
 sonatype-2021-1485 until=2022-12-31
+
+# Hashicorp consul /api and /sdk are no longer intended for public use and don't have newer tags.
+# Waiting for direct dependencies to move away from them.
+CVE-2022-29153 until=2022-12-31
+CVE-2022-24687 until=2022-12-31
+
+# pkg:golang/github.com/kataras/iris/v12@v12.1.8
+CVE-2021-23772 until=2022-10-03
+CVE-2021-42576 until=2022-10-03
+
+# pkg:golang/github.com/labstack/echo/v4@v4.1.11
+# We need to upgrade our operators to a version of operatorkit with up-to-date dependencies.
+sonatype-2020-1258

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bump go module also when releasing a version with a suffix like `-alpha1`.
+
 ## [5.9.0] - 2022-07-14
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -92,7 +92,7 @@ jobs:
             version_major=$(echo "${version}" | cut -d "." -f 1)
             version_minor=$(echo "${version}" | cut -d "." -f 2)
             version_patch=$(echo "${version}" | cut -d "." -f 3)
-            if [[ $version_minor = 0 && $version_patch = 0 ]]; then
+            if [[ $version_minor = 0 && $version_patch =~ ^0.* ]]; then
               echo "::set-output name=is_major::true"
             fi
           fi

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -92,6 +92,8 @@ jobs:
             version_major=$(echo "${version}" | cut -d "." -f 1)
             version_minor=$(echo "${version}" | cut -d "." -f 2)
             version_patch=$(echo "${version}" | cut -d "." -f 3)
+            # This will help us detect versions with suffixes as majors, i.e 3.0.0-alpha1.
+            # Even though it's a pre-release, it's still a major.
             if [[ $version_minor = 0 && $version_patch =~ ^0.* ]]; then
               echo "::set-output name=is_major::true"
             fi


### PR DESCRIPTION
When creating a new release with a suffix like `1.2.3-alpha1`, the automation did not identify this as a major release, so it didn't bump the go module version.

I changed the check to cover this case.

### Checklist

- [x] Update changelog in CHANGELOG.md.
