### PR TITLE
Don't automatically upgrade go version with renovate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Constraint go version, so it's not automatically upgraded by renovate.
+- Constrain go version to 1.18, so it's not automatically upgraded by renovate.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Constraint go version, so it's not automatically upgraded by renovate.
+
 ### Fixed
 
 - Bump go module also when releasing a version with a suffix like `-alpha1`.

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -10,6 +10,9 @@
   ],
   "labels": ["dependencies"],
   {{- if eq $language "go" }}
+  "constraints": {
+    "go": "1.18"
+  },
   "packageRules": [
     {
       "matchPackagePatterns": [".*giantswarm.*"],


### PR DESCRIPTION
In one of our operators, the go version was upgraded in `go.mod` and our CI (which uses go 1.18) stopped working with
```
go: go.mod file indicates go 1.19, but maximum version supported by tidy is 1.18
```

There is currently [not an easy way to disable go version upgrades in renovate](https://github.com/renovatebot/renovate/issues/16715), so one potential solution is to constraint which versions we use. I would add another step to [our upgrade guide](https://intranet.giantswarm.io/docs/dev-and-releng/how-to-update-golang-in-ci-tools/) so that we also upgrade the renovate template constraint.

### Checklist

- [X] Update changelog in CHANGELOG.md.
