### PR TITLE
Simplify the schema check action for helm + check the do the actual check

### DIFF
--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -1,81 +1,30 @@
 {{{{ .Header }}}}
 name: 'Check if values schema file has been updated'
 on: pull_request
+    branches:
+      - master
+      - main
+    paths:
+      - 'helm/**/values.yaml'
+      - 'helm/**/values.schema.json'
 
 jobs:
   check:
     name: 'Check values.yaml and its schema in PR'
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout'
+      - name: Checkout
         uses: actions/checkout@v3
-      - name: 'Check if values.schema.json was updated'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          fetch-depth: 0
+
+      - name: 'Check if values.json is a valid instance of values.schema.json'
         run: |
-          echo "Comparing ${GITHUB_BASE_REF}...${GITHUB_HEAD_REF}"
-
-          # check if repo contains a schema file
-          if grep -q "values.schema.json" <<< $(git ls-tree -r --name-only ${GITHUB_SHA}); then
-
-            # get a list of files changed in the PR
-            CHANGED_FILES=$(gh api repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF} \
-              --jq ".files[].filename")
-
-            # check if values.yaml in main chart was modified by this PR
-            # (this won't check values files in subcharts)
-            if grep -q 'helm\/[-a-z].*\/values.yaml' <<< "${CHANGED_FILES}" ; then
-
-              # get the path to values.yaml
-              VALUES_FILE=$(gh api repos/{owner}/{repo}/compare/${GITHUB_BASE_REF}...${GITHUB_HEAD_REF} \
-                --jq ".files[].filename" | grep 'helm\/[-a-z].*\/values.yaml')
-
-              # fetch branches so we can use them to compare
-              git fetch &> /dev/null
-
-              # calculate hash of the keys from values.yaml from the default branch
-              DEFAULT_BRANCH_SHA=$(git show origin/${GITHUB_BASE_REF}:${VALUES_FILE} \
-                | yq -P 'sort_keys(..)' -o=json | jq -r '[paths | join(".")]' \
-                | sha1sum | awk '{print $1}')
-
-              # calculate hash of the keys from values.yaml from this branch
-              THIS_BRANCH_SHA=$(git show origin/${GITHUB_HEAD_REF}:${VALUES_FILE} \
-                | yq -P 'sort_keys(..)' -o=json | jq -r '[paths | join(".")]' \
-                | sha1sum | awk '{print $1}')
-
-              # compare hashes of the values files
-              if [[ "${DEFAULT_BRANCH_SHA}" != "${THIS_BRANCH_SHA}" ]]; then
-
-                # values file structure has been modified so we need to ensure the schema
-                # file is also updated
-
-                if grep -q "values.schema.json" <<< "${CHANGED_FILES}" ; then
-                  # we assume that the schema has been updated, nothing to do
-                  echo "PASSED: values.yaml and values.schema.json both appear to have been updated"
-                  exit 0
-                else
-                  # schema must be updated
-                  echo "FAILED: values.yaml was updated but values.schema.json hasn't been regenerated"
-                  echo "Please refer to this document: {{{{ .SchemaDocsURL }}}}"
-                  exit 1
-                fi
-
-              else
-                # values file structure hasn't changed, nothing to do
-                echo "values.yaml structure hasn't been changed by this PR"
-                exit 0
-              fi
-
-            else
-              # values file not included in PR, nothing to see here
-              echo "values.yaml not included in this PR"
-              exit 0
-            fi
-
-          else
-
-            # if grep returns negative then there isn't a values.schema.json to check
-            echo "No values.schema.json file found in branch '${GITHUB_BASE_REF}', nothing to check"
-            exit 0
-
-          fi
+          HELM_DIR=$(dirname $(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} \
+           | grep 'helm/[-a-z].*\/values\.' | head -1))
+          VALUES_FILE=${HELM_DIR}/values.yaml
+          SCHEMA_FILE=${HELM_DIR}/values.schema.json
+          pip3 install json-spec==0.10.1
+          yq -o=json eval ${VALUES_FILE} > /tmp/values.json
+          json validate --schema-file=${SCHEMA_FILE} --document-file=/tmp/values.json
+          echo "PASSED: values.yaml and values.schema.json both appear to have been updated and the document is valid against the schema"


### PR DESCRIPTION
I like the idea of these checks so I borrowed it for my own repo couple of weeks ago: https://github.com/k8gb-io/k8gb/blob/master/.github/workflows/helm_check-values-schema.yaml

However, I changed it in a way to actutaly perform the validation against the schema, because the previous logic just assumes it passes.

At the same time, this way it's much more simpler, leaving a lot of checks (what files were changed and what not) for the action itself (the paths glob).

Also not using the `gh` cli, but using pure `git` since the repo has been cloned&fetched anyway => saving a call to gh api

Signed-off-by: Jiri Kremser <jiri.kremser@gmail.com>

### Checklist

- [ ] Update changelog in CHANGELOG.md.
