### PR TITLE
Switch schema validation tool to `yajsv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switched values schema validator to [yajsv](https://github.com/neilpa/yajsv) v1.4.1.
+
 ## [5.13.1] - 2022-12-01
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -1,5 +1,5 @@
 {{{{ .Header }}}}
-name: 'Check if values and/or schema file has been updated'
+name: 'Values and schema'
 on:
   pull_request:
     branches:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check:
-    name: 'Check values.yaml and its schema in PR'
+    name: 'validate values.yaml against values.schema.json'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,13 +19,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install schema validator
+      - name: Install validator
         run: |
-          wget -O /usr/bin/yajsv https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.linux.amd64
-          chmod +x /usr/bin/yajsv
+          wget -q -O ${HOME}/yajsv https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.linux.amd64
+          chmod +x ${HOME}/yajsv
 
       - name: 'Check if values.yaml is a valid instance of values.schema.json'
         run: |
           HELM_DIR=$(dirname $(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} \
            | grep 'helm/[-a-z].*\/values\.' | head -1))
-          /usr/bin/yajsv -s ${HELM_DIR}/values.schema.json ${HELM_DIR}/values.yaml
+          ${HOME}/yajsv -s ${HELM_DIR}/values.schema.json ${HELM_DIR}/values.yaml

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -1,5 +1,5 @@
 {{{{ .Header }}}}
-name: 'Check if values schema file has been updated'
+name: 'Check if values and/or schema file has been updated'
 on:
   pull_request:
     branches:
@@ -19,13 +19,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install schema validator
+        run: |
+          wget -O /usr/bin/yajsv https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.linux.amd64
+          chmod +x /usr/bin/yajsv
+
       - name: 'Check if values.yaml is a valid instance of values.schema.json'
         run: |
           HELM_DIR=$(dirname $(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} \
            | grep 'helm/[-a-z].*\/values\.' | head -1))
-          VALUES_FILE=${HELM_DIR}/values.yaml
-          SCHEMA_FILE=${HELM_DIR}/values.schema.json
-          pip3 install json-spec==0.10.1
-          yq -o=json eval ${VALUES_FILE} > /tmp/values.json
-          json validate --schema-file=${SCHEMA_FILE} --document-file=/tmp/values.json
-          echo "PASSED: values.yaml and values.schema.json both appear to have been updated and the document is valid against the schema"
+          /usr/bin/yajsv -s ${HELM_DIR}/values.schema.json ${HELM_DIR}/values.yaml


### PR DESCRIPTION
This PR switches the schema validation to https://github.com/neilpa/yajsv

The [previous one](https://github.com/johnnoone/json-spec) had several problems:

- Did not work with the $schema dialect that `helm schema-gen` applies (`"$schema": "http://json-schema.org/schema#"`)
- Did not work with recent JSON Schema dialects, only supported up to draft 4.
- Did not dereference external schema

`yajsv` instead works with all JSON schema dialects. It also directly consumes YAML payloads.

### Checklist

- [x] Update changelog in CHANGELOG.md.
