### PR TITLE
Improve create_release_pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve `create_release_pr.yaml.template` by supporting more cases regarding `-app` suffix in repositories and chart names. 
+
 ## [5.18.2] - 2023-01-31
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -160,25 +160,24 @@ jobs:
           # Check chart directory.
           if [ ! -d "${chart}" ]
           then
-            echo "Could not find chart directory '${chart}', adding app suffix."
-
-            # Add app suffix.
-            chart="helm/${repository}-app"
-
-            # Check chart directory with app suffix.
-            if [ ! -d "${chart}" ]
-            then
+            if [[ ${chart} == *-app ]]; then
               echo "Could not find chart directory '${chart}', removing app suffix."
-
+            
               # Remove app suffix.
               chart="helm/${repository%-app}"
+            else
+              echo "Could not find chart directory '${chart}', adding app suffix."
 
-              if [ ! -d "${chart}" ]
-              then
-                # Print error.
-                echo "Could not find chart directory '${chart}', doing nothing."
-              fi
+              # Add app suffix.
+              chart="helm/${repository}-app"
             fi
+            
+            if [ ! -d "${chart}" ]
+            then
+              # Print error.
+              echo "Could not find chart directory '${chart}', doing nothing."
+            fi
+
           fi
 
           # Define chart YAML.


### PR DESCRIPTION
We noticed that the chart version for https://github.com/giantswarm/cluster-api-provider-cloud-director-app is not updated by CI automatically. Then I checked the CI logs and found this.

![Screenshot 2023-02-01 at 13 36 36](https://user-images.githubusercontent.com/6574144/216019894-d9462dc8-3ff8-45e8-9d62-aee45c2f7de7.png)

Basically, we have different cases regarding repo name vs app name
1. AppName = RepoName
2. AppName = RepoName+"-app"
3. AppName+"-app" = RepoName

1 and 2 are already handled. 3 is not handled in the current form. This PR handles it too. 

Also note that it is not only a problem in https://github.com/giantswarm/cluster-api-provider-cloud-director-app. I checked other providers and they are the same too. Example https://github.com/giantswarm/cluster-api-provider-aws-app

### Checklist

- [x] Update changelog in CHANGELOG.md.
