### PR TITLE
Merge ci/ci-values.yaml with values.yaml before doing the schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Merge `ci/ci-values.yaml` with `values.yaml` before doing the schema validation.
+
 ## [5.18.2] - 2023-01-31
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -32,7 +32,9 @@ jobs:
           VALUES=${HELM_DIR}/values.yaml
           if [ -f ${HELM_DIR}/ci/ci-values.yaml ]; then
             # merge ci-values.yaml into values.yaml (providing required values)
+            echo -e "\nMerged values:\n=============="
             yq '. *= load("'${HELM_DIR}'/ci/ci-values.yaml")' ${HELM_DIR}/values.yaml | tee ${HELM_DIR}/combined-values.yaml
+            echo -e "\n==============\n"
             VALUES=${HELM_DIR}/combined-values.yaml
           fi
 


### PR DESCRIPTION
https://gigantic.slack.com/archives/C3C7ZQXC1/p1675684812303489?thread_ts=1675675698.472269&cid=C3C7ZQXC1

note:
```
dirname $(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} \
           | grep 'helm/[-a-z]*\/values\.' | head -1
```
had to be changed, because the `dirname` command could have been run on a wrong argument, example: `helm/default-apps-cloud-director/ci/ci-values.yaml`. This would set the wrong `HELM_DIR` path.

I have tested this logic on my forked repo here: https://github.com/jkremser/default-apps-cloud-director/pulls

Signed-off-by: Jiri Kremser <jiri.kremser@gmail.com>

### Checklist

- [x] Update changelog in CHANGELOG.md.
