### PR TITLE
Update Makefile to prevent recursion into charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Merge `ci/ci-values.yaml` with `values.yaml` before doing the schema validation.
+- Update `Makefile` to prevent recursion when looking for deps.
 
 ## [5.18.2] - 2023-01-31
 

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
@@ -6,7 +6,7 @@ YQ=docker run --rm -u $$(id -u) -v $${PWD}:/workdir mikefarah/yq:4.29.2
 HELM_DOCS=docker run --rm -u $$(id -u) -v $${PWD}:/helm-docs jnorwood/helm-docs:v1.11.0
 
 ifdef APPLICATION
-DEPS := $(shell find $(APPLICATION)/charts -regex "$(APPLICATION)/charts/[-A-Za-z]*/Chart.yaml" -printf "%h\n")
+DEPS := $(shell find $(APPLICATION)/charts -name "Chart.yaml" -maxdepth 2 -printf "%h\n")
 endif
 
 .PHONY: lint-chart check-env update-chart helm-docs update-deps $(DEPS)

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
@@ -6,7 +6,7 @@ YQ=docker run --rm -u $$(id -u) -v $${PWD}:/workdir mikefarah/yq:4.29.2
 HELM_DOCS=docker run --rm -u $$(id -u) -v $${PWD}:/helm-docs jnorwood/helm-docs:v1.11.0
 
 ifdef APPLICATION
-DEPS := $(shell find $(APPLICATION)/charts -name "Chart.yaml" -maxdepth 2 -printf "%h\n")
+DEPS := $(shell find $(APPLICATION)/charts -maxdepth 2 -name "Chart.yaml" -printf "%h\n")
 endif
 
 .PHONY: lint-chart check-env update-chart helm-docs update-deps $(DEPS)

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
@@ -6,7 +6,7 @@ YQ=docker run --rm -u $$(id -u) -v $${PWD}:/workdir mikefarah/yq:4.29.2
 HELM_DOCS=docker run --rm -u $$(id -u) -v $${PWD}:/helm-docs jnorwood/helm-docs:v1.11.0
 
 ifdef APPLICATION
-DEPS := $(shell find $(APPLICATION)/charts -name "Chart.yaml" -printf "%h\n")
+DEPS := $(shell find $(APPLICATION)/charts -regex "$(APPLICATION)/charts/[-A-Za-z]*/Chart.yaml" -printf "%h\n")
 endif
 
 .PHONY: lint-chart check-env update-chart helm-docs update-deps $(DEPS)


### PR DESCRIPTION
## Description

The current Makefile fails in some repos with dependencies inside dependencies. For example:

```
dep_name=kyvernoPlugin && \
new_version=`docker run --rm -u $(id -u) -v ${PWD}:/workdir mikefarah/yq:4.29.2 .version helm/kyverno/charts/$dep_name/Chart.yaml` && \
docker run --rm -u $(id -u) -v ${PWD}:/workdir mikefarah/yq:4.29.2 -i e "with(.dependencies[]; select(.name == \"$dep_name\") | .version = \"$new_version\")" helm/kyverno/Chart.yaml
Error: open helm/kyverno/charts/kyvernoPlugin/Chart.yaml: no such file or directory
make[1]: Leaving directory '/home/runner/work/kyverno-app/kyverno-app'
make[1]: *** [Makefile.gen.app.mk:36: helm/kyverno/charts/policy-reporter/charts/kyvernoPlugin] Error 1
make: *** [Makefile.gen.app.mk:30: update-chart] Error 2
Error: Process completed with exit code 2.
```

In this case the repo has a chart inside `helm/kyverno/charts/policy-reporter/charts/kyvernoPlugin` where it fails because then it tries to look for it inside `helm/kyverno/charts/kyvernoPlugin/Chart.yaml`.

I think we should prevent from looking inside `helm/$APP/charts/$SUB_CHART/charts/`, so this PR changes that.