### PR TITLE
Use GITHUB_SHA in values checking workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Merge `ci/ci-values.yaml` with `values.yaml` before doing the schema validation.
 - Update `Makefile` to prevent recursion when looking for deps.
+- Use `GITHUB_SHA` in values validation workflow in git diff. This makes the action work with contributions from external repositories.
 
 ## [5.18.2] - 2023-01-31
 

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -27,7 +27,7 @@ jobs:
 
       - name: 'Check if values.yaml is a valid instance of values.schema.json'
         run: |
-          HELM_DIR=$(git diff --name-only origin/${GITHUB_BASE_REF} origin/${GITHUB_HEAD_REF} \
+          HELM_DIR=$(git diff --name-only origin/${GITHUB_BASE_REF} ${GITHUB_SHA} \
            | grep 'helm/[-a-z].*\/' | head -1 | awk -F '/' '{print $1"/"$2}')
           VALUES=${HELM_DIR}/values.yaml
           if [ -f ${HELM_DIR}/ci/ci-values.yaml ]; then


### PR DESCRIPTION
The GitHub actions workflow for checking values.yaml validity against its schema does not work for contributions from external repositories. This PR changes to using `GITHUB_SHA` for the `git diff` call in the action. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
