### PR TITLE
repo setup: add --dry-run mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--dry-run` flag to `devctl repo setup` command.
+
 ### Fixed
 
 - repo setup: better select checks required for PR merge

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -5,6 +5,7 @@ import (
 )
 
 type flag struct {
+	DryRun            bool
 	GithubTokenEnvVar string
 
 	// Features
@@ -31,6 +32,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(&f.DryRun, "dry-run", false, "Dry-run or ready-only mode. Show what is being made but do not apply any change.")
 	cmd.PersistentFlags().StringVar(&f.GithubTokenEnvVar, "github-token-envvar", "GITHUB_TOKEN", "Environement variable name for Github token.")
 
 	// Features

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -52,6 +52,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	c := githubclient.Config{
+		DryRun:      r.flag.DryRun,
 		Logger:      r.logger,
 		AccessToken: token,
 	}

--- a/pkg/githubclient/client.go
+++ b/pkg/githubclient/client.go
@@ -10,12 +10,14 @@ import (
 )
 
 type Config struct {
+	DryRun bool
 	Logger *logrus.Logger
 
 	AccessToken string
 }
 
 type Client struct {
+	dryRun bool
 	logger *logrus.Logger
 
 	accessToken string
@@ -31,6 +33,7 @@ func New(config Config) (*Client, error) {
 	}
 
 	c := &Client{
+		dryRun: config.DryRun,
 		logger: config.Logger,
 
 		accessToken: config.AccessToken,

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -100,10 +100,14 @@ func (c *Client) SetRepositorySettings(ctx context.Context, repository, reposito
 	// HTTP 422 This organization does not allow private repository forking
 	repository.AllowForking = nil
 
-	underlyingClient := c.getUnderlyingClient(ctx)
-	repository, _, err := underlyingClient.Repositories.Edit(ctx, *repository.Owner.Login, *repository.Name, repository)
-	if err != nil {
-		return nil, microerror.Mask(err)
+	if !c.dryRun {
+		var err error
+
+		underlyingClient := c.getUnderlyingClient(ctx)
+		repository, _, err = underlyingClient.Repositories.Edit(ctx, repository.GetOwner().GetLogin(), repository.GetName(), repository)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	c.logger.Debug("configured repository settings")
@@ -127,9 +131,11 @@ func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *githu
 
 		c.logger.Debugf("grant %q permission to %q", permission, teamSlug)
 
-		_, err := underlyingClient.Teams.AddTeamRepoBySlug(ctx, org, teamSlug, owner, repo, opt)
-		if err != nil {
-			return microerror.Mask(err)
+		if !c.dryRun {
+			_, err := underlyingClient.Teams.AddTeamRepoBySlug(ctx, org, teamSlug, owner, repo, opt)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		}
 
 		c.logger.Debugf("granted %q permission to %q", permission, teamSlug)
@@ -185,10 +191,12 @@ func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *
 	b, _ := json.MarshalIndent(opts, "", "  ")
 	c.logger.Debugf("branch protection settings\n%s", b)
 
-	underlyingClient := c.getUnderlyingClient(ctx)
-	_, _, err = underlyingClient.Repositories.UpdateBranchProtection(ctx, owner, repo, default_branch, opts)
-	if err != nil {
-		return microerror.Mask(err)
+	if !c.dryRun {
+		underlyingClient := c.getUnderlyingClient(ctx)
+		_, _, err = underlyingClient.Repositories.UpdateBranchProtection(ctx, owner, repo, default_branch, opts)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	c.logger.Debugf("configured protection for %q branch", default_branch)


### PR DESCRIPTION
This PR adds --dry-run flag to devctl repo setup command, to allow running the command without applying any changes.

### Checklist

- [x] Update changelog in CHANGELOG.md.
