### PR TITLE
repo setup: filter aliyun checks out of required checks for PR merge

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -35,4 +35,7 @@ CVE-2021-42576 until=2023-06-30
 
 # pkg:golang/github.com/labstack/echo/v4@v4.1.11
 # We need to upgrade our operators to a version of operatorkit with up-to-date dependencies.
-sonatype-2020-1258
+sonatype-2020-1258 until=2023-06-30
+
+# pkg:golang/k8s.io/apiserver@v0.20.12
+CVE-2020-8561 until=2023-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- repo setup: filter aliyun checks out of required checks for PR merge
+
 ## [5.20.0] - 2023-03-22
 
 ## [5.20.0] - 2023-03-22

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -28,7 +28,8 @@ type flag struct {
 	Permissions map[string]string
 
 	// Branch protection
-	Checks []string
+	Checks       []string
+	ChecksFilter string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -56,6 +57,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Branch protection
 	cmd.PersistentFlags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string.")
+	cmd.PersistentFlags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -56,7 +56,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringToStringVar(&f.Permissions, "permissions", map[string]string{"Employees": "admin", "bots": "push"}, "Grant access to this repository using github_team_name=permission format. Multiple values can be provided as a comma separated list or using this flag multiple times. Permission can be one of: pull, push, admin, maintain, triage.")
 
 	// Branch protection
-	cmd.PersistentFlags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string.")
+	cmd.PersistentFlags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
 	cmd.PersistentFlags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
 }
 

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -57,7 +57,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Branch protection
 	cmd.PersistentFlags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string.")
-	cmd.PersistentFlags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored.")
+	cmd.PersistentFlags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -70,7 +70,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var ChecksFilterRegexp *regexp.Regexp
 	if r.flag.ChecksFilter != "" {
-		ChecksFilterRegexp, err := regexp.Compile(r.flag.ChecksFilter)
+		ChecksFilterRegexp, err = regexp.Compile(r.flag.ChecksFilter)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -68,14 +68,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	ChecksFilterRegexp, err := regexp.Compile(r.flag.ChecksFilter)
-	if err != nil {
-		return microerror.Mask(err)
+	var ChecksFilterRegexp *regexp.Regexp
+	if r.flag.ChecksFilter != "" {
+		ChecksFilterRegexp, err := regexp.Compile(r.flag.ChecksFilter)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
-	if r.flag.ChecksFilter == "" {
-		ChecksFilterRegexp = nil
-	}
-
 	repositorySettings := &github.Repository{
 		HasWiki:     &r.flag.EnableWiki,
 		HasIssues:   &r.flag.EnableIssues,

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -72,6 +72,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	if r.flag.ChecksFilter == "" {
+		ChecksFilterRegexp = nil
+	}
 
 	repositorySettings := &github.Repository{
 		HasWiki:     &r.flag.EnableWiki,

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/giantswarm/microerror"
@@ -67,6 +68,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
+	ChecksFilterRegexp, err := regexp.Compile(r.flag.ChecksFilter)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	repositorySettings := &github.Repository{
 		HasWiki:     &r.flag.EnableWiki,
 		HasIssues:   &r.flag.EnableIssues,
@@ -92,7 +98,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	err = client.SetRepositoryBranchProtection(ctx, repository, r.flag.Checks)
+	err = client.SetRepositoryBranchProtection(ctx, repository, r.flag.Checks, ChecksFilterRegexp)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -147,7 +147,7 @@ func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *githu
 	return nil
 }
 
-func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *github.Repository, checkNames []string) (err error) {
+func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *github.Repository, checkNames []string, checksFilter *regexp.Regexp) (err error) {
 	owner := *repository.Owner.Login
 	repo := *repository.Name
 	default_branch := *repository.DefaultBranch
@@ -166,7 +166,7 @@ func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *
 	}
 
 	if checkNames == nil {
-		checkNames, err = c.getGithubChecks(ctx, repository, default_branch)
+		checkNames, err = c.getGithubChecks(ctx, repository, default_branch, checksFilter)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -205,7 +205,7 @@ func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *
 	return nil
 }
 
-func (c *Client) getGithubChecks(ctx context.Context, repository *github.Repository, branch string) ([]string, error) {
+func (c *Client) getGithubChecks(ctx context.Context, repository *github.Repository, branch string, checksFilter *regexp.Regexp) ([]string, error) {
 	owner := *repository.Owner.Login
 	repo := *repository.Name
 
@@ -248,13 +248,13 @@ func (c *Client) getGithubChecks(ctx context.Context, repository *github.Reposit
 	var checks []string
 	for _, combinedStatus := range allCombinedStatus {
 		for _, status := range combinedStatus.Statuses {
-			if filterCheck(status.GetContext()) {
+			if !checksFilter.MatchString(status.GetContext()) {
 				checks = append(checks, status.GetContext())
 			}
 		}
 	}
 
-	c.logger.Debugf("found %d commit statuses for ref %q:\n%v", len(checks), ref, checks)
+	c.logger.Debugf("found %d commit statuses for ref %q:", len(checks), ref)
 	for id, check := range checks {
 		c.logger.Debugf(" - checks[%d] = %q", id, check)
 	}
@@ -262,21 +262,7 @@ func (c *Client) getGithubChecks(ctx context.Context, repository *github.Reposit
 	return checks, nil
 }
 
-// Returns false if check should be ignored
-func filterCheck(checkName string) bool {
-	// List keywords for checks that should be ignored
-	var ignoredCheckKeywords = []string{"aliyun"}
-
-	for _, ignoredCheckKeyword := range ignoredCheckKeywords {
-		matched, _ := regexp.MatchString(ignoredCheckKeyword, checkName)
-		if matched {
-			return false
-		}
-	}
-	return true
-}
-
-// Retrieve list of tags
+// getTags retrieves list of tags
 func (c *Client) getTags(ctx context.Context, repository *github.Repository) ([]*github.RepositoryTag, error) {
 	owner := *repository.Owner.Login
 	repo := *repository.Name
@@ -304,7 +290,7 @@ func (c *Client) getTags(ctx context.Context, repository *github.Repository) ([]
 	return allTags, nil
 }
 
-// Gets latest commit that is not tagged
+// getLatestNonTagCommit gets latest commit that is not tagged
 // because we want one that is not a release
 func (c *Client) getLatestNonTagCommit(ctx context.Context, repository *github.Repository, branch string, tags []*github.RepositoryTag) (string, error) {
 	owner := *repository.Owner.Login

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"regexp"
 
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-github/v44/github"
@@ -247,13 +248,32 @@ func (c *Client) getGithubChecks(ctx context.Context, repository *github.Reposit
 	var checks []string
 	for _, combinedStatus := range allCombinedStatus {
 		for _, status := range combinedStatus.Statuses {
-			checks = append(checks, *status.Context)
+			if filterCheck(status.GetContext()) {
+				checks = append(checks, status.GetContext())
+			}
 		}
 	}
 
 	c.logger.Debugf("found %d commit statuses for ref %q:\n%v", len(checks), ref, checks)
+	for id, check := range checks {
+		c.logger.Debugf(" - checks[%d] = %q", id, check)
+	}
 
 	return checks, nil
+}
+
+// Returns false if check should be ignored
+func filterCheck(checkName string) bool {
+	// List keywords for checks that should be ignored
+	var ignoredCheckKeywords = []string{"aliyun"}
+
+	for _, ignoredCheckKeyword := range ignoredCheckKeywords {
+		matched, _ := regexp.MatchString(ignoredCheckKeyword, checkName)
+		if matched {
+			return false
+		}
+	}
+	return true
 }
 
 // Retrieve list of tags

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -248,7 +248,7 @@ func (c *Client) getGithubChecks(ctx context.Context, repository *github.Reposit
 	var checks []string
 	for _, combinedStatus := range allCombinedStatus {
 		for _, status := range combinedStatus.Statuses {
-			if !checksFilter.MatchString(status.GetContext()) {
+			if checksFilter == nil || !checksFilter.MatchString(status.GetContext()) {
 				checks = append(checks, status.GetContext())
 			}
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24617

Aliyun jobs are and not systematically triggered.
So we should keep them as optional when updating list of required checks for PRs. 

I tried to do it so that we could add more exclusions later.

### Checklist

- [x] Update changelog in CHANGELOG.md.
