### PR TITLE
branch renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a bug where open pull-request are not correctly detected
+
 ## [5.20.1] - 2023-03-24
 
 ### Fixed
@@ -28,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - repo setup: better select checks required for PR merge
+- Fix unsafe pointer access in pkg/githubclient/client_repository.go
 
 ## [5.19.0] - 2023-02-21
 

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -121,8 +121,10 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          if gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.branch }} | grep -i 'state:[[:space:]]*open' >/dev/null; then
-            gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.branch }}
+          head="${{ steps.gather_facts.outputs.branch }}"
+          branch="${head#refs/heads/}" # Strip "refs/heads/" prefix.
+          if gh pr view --repo "${{ github.repository }}" "${branch}" --json state --jq .state | grep -i 'open' > /dev/null; then
+            gh pr view --repo "${{ github.repository }}" "${branch}"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -117,9 +117,9 @@ func (c *Client) SetRepositorySettings(ctx context.Context, repository, reposito
 }
 
 func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *github.Repository, permissions map[string]string) error {
-	org := *repository.Organization.Login
-	owner := *repository.Owner.Login
-	repo := *repository.Name
+	org := repository.GetOrganization().GetLogin()
+	owner := repository.GetOwner().GetLogin()
+	repo := repository.GetName()
 
 	c.logger.Info("grant permission on repository")
 	c.logger.Debugf("permissions\n%v", permissions)
@@ -148,9 +148,9 @@ func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *githu
 }
 
 func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *github.Repository, checkNames []string, checksFilter *regexp.Regexp) (err error) {
-	owner := *repository.Owner.Login
-	repo := *repository.Name
-	default_branch := *repository.DefaultBranch
+	owner := repository.GetOwner().GetLogin()
+	repo := repository.GetName()
+	default_branch := repository.GetDefaultBranch()
 
 	False := false
 
@@ -206,8 +206,8 @@ func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *
 }
 
 func (c *Client) getGithubChecks(ctx context.Context, repository *github.Repository, branch string, checksFilter *regexp.Regexp) ([]string, error) {
-	owner := *repository.Owner.Login
-	repo := *repository.Name
+	owner := repository.GetOwner().GetLogin()
+	repo := repository.GetName()
 
 	// Tags have specific workflows, that are not run in PRs.
 	// So, we need to find checks for a commit that is not tagged.
@@ -288,8 +288,8 @@ func (c *Client) SetRepositoryDefaultBranch(ctx context.Context, repository *git
 
 // getTags retrieves list of tags
 func (c *Client) getTags(ctx context.Context, repository *github.Repository) ([]*github.RepositoryTag, error) {
-	owner := *repository.Owner.Login
-	repo := *repository.Name
+	owner := repository.GetOwner().GetLogin()
+	repo := repository.GetName()
 
 	underlyingClient := c.getUnderlyingClient(ctx)
 
@@ -317,8 +317,8 @@ func (c *Client) getTags(ctx context.Context, repository *github.Repository) ([]
 // getLatestNonTagCommit gets latest commit that is not tagged
 // because we want one that is not a release
 func (c *Client) getLatestNonTagCommit(ctx context.Context, repository *github.Repository, branch string, tags []*github.RepositoryTag) (string, error) {
-	owner := *repository.Owner.Login
-	repo := *repository.Name
+	owner := repository.GetOwner().GetLogin()
+	repo := repository.GetName()
 
 	underlyingClient := c.getUnderlyingClient(ctx)
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "devctl"
 	source      = "https://github.com/giantswarm/devctl"
-	version     = "5.20.1"
+	version     = "5.20.2-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
This might be controversial but here is a PR to make sure default branch are renamed to `main` in our repositories.

This is achieved via the github API rename branch method : https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#rename-a-branch

Github mainly takes care of :
- urls containing old branch name are redirected
- branch protection are updated
- base branch for PR are updated

But this has potential to break the followings:
- raw file URLs
- GitHub Actions workflows
- CircleCI jobs

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#about-renaming-branches

Given those details I still think we should have this otherwise we will always linger into the despair's of un-aligned default branch naming.

### Checklist

- [x] Update changelog in CHANGELOG.md.
