### PR TITLE
Use taylorbot instead of default github-action identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change github identity to taylorbot in generated workflows
+
 ### Fixed
 
 - Fix a bug where open pull-request are not correctly detected

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -125,13 +125,13 @@ jobs:
           git commit -m "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
       - name: Push changes
         env:
-          REMOTE_REPO: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          REMOTE_REPO: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
           branch: "${{ github.ref }}-version-bump"
         run: |
           git push "${REMOTE_REPO}" HEAD:${{ env.branch }}
       - name: Create PR
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
           base: "${{ github.ref }}"
           branch: "${{ github.ref }}-version-bump"
           version: "${{ needs.gather_facts.outputs.version }}"
@@ -170,14 +170,14 @@ jobs:
           git tag "v$version" ${{ github.sha }}
       - name: Push tag
         env:
-          REMOTE_REPO: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          REMOTE_REPO: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
         run: |
           git push "${REMOTE_REPO}" --tags
       - name: Create release
         id: create_gh_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
         with:
           body: ${{ steps.changelog_reader.outputs.changes }}
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
@@ -272,7 +272,7 @@ jobs:
           - linux-arm64
           - windows-amd64
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
       GO_VERSION: 1.19.6
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -62,7 +62,7 @@ jobs:
 
           version="$(echo $head | awk -F# '{print $NF}')"
           if [[ $version =~ ^major|minor|patch$ ]]; then
-            gh auth login --with-token <<<$(echo -n ${{ secrets.GITHUB_TOKEN }})
+            gh auth login --with-token <<<$(echo -n ${{ secrets.TAYLORBOT_GITHUB_ACTION }})
             gh_api_get_latest_release_version()
             {
               if ! version="$(gh api "repos/$1/releases/latest" --jq '.tag_name[1:] | split(".") | .[0], .[1], .[2]')"
@@ -119,7 +119,7 @@ jobs:
       - name: Check if PR exists
         id: pr_exists
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
         run: |
           head="${{ steps.gather_facts.outputs.branch }}"
           branch="${head#refs/heads/}" # Strip "refs/heads/" prefix.
@@ -210,12 +210,12 @@ jobs:
           git commit -m "Release v${{ env.version }}"
       - name: Push changes
         env:
-          remote_repo: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
         run: |
           git push "${remote_repo}" HEAD:${{ needs.gather_facts.outputs.branch }}
       - name: Create PR
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |

--- a/pkg/gen/input/workflows/internal/file/update_chart.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/update_chart.yaml.template
@@ -57,7 +57,7 @@ jobs:
       - name: Check if PR exists
         id: pr_exists
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
         run: |
           if gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.branch }} | grep -i 'state:[[:space:]]*open' >/dev/null; then
             gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.branch }}
@@ -112,12 +112,12 @@ jobs:
           git commit -m "Sync chart with upstream."
       - name: Push changes
         env:
-          remote_repo: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          remote_repo: "https://${{ github.actor }}:${{ secrets.TAYLORBOT_GITHUB_ACTION }}@github.com/${{ github.repository }}.git"
         run: |
           git push "${remote_repo}" HEAD:${{ needs.gather_facts.outputs.branch }}
       - name: Update PR
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
           base: "${{ needs.gather_facts.outputs.base }}"
         run: |
           hub pull-request -f -m "Update chart from upstream" -m "This PR was created by the \`update-chart\` automated workflow." -m "**:warning: Make sure all tests have passed before merging.**" -l "automated-update" -a ${{ github.actor }} -b ${{ env.base }} -h ${{ needs.gather_facts.outputs.branch }}

--- a/pkg/gen/internal/key.go
+++ b/pkg/gen/internal/key.go
@@ -37,8 +37,8 @@ func StepSetUpGitIdentity() string {
 	return strings.Join([]string{
 		"      - name: Set up git identity",
 		"        run: |",
-		`          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"`,
-		`          git config --local user.name "github-actions[bot]"`,
+		`          git config --local user.email "dev@giantswarm.io"`,
+		`          git config --local user.name "taylorbot"`,
 	}, "\n")
 }
 


### PR DESCRIPTION
This PR replace the default identity used by all our github actions with taylorbot.

### Problem

Actual github action are never run on release PR. So we usually need to create an empty commit in order to actually trigger github actions.

Example:
Note the absence of check mark next to the commit created by github-action.
![image](https://user-images.githubusercontent.com/6536819/228067993-da7dca7b-addd-4283-b7d1-ec03bec1eb93.png)
source: https://github.com/giantswarm/github/pull/826

This is due to a limitation in github itself
```
if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
```
source: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

### Solution

The workaround proposed here make use of a different identity, our beloved [taylorbot](https://github.com/taylorbot), to actually execute github actions like commit, push and create release.

Test:
Note the presence of check mark next to the commit create by taylorbot, bonus we get our logo everywhere :)
![image](https://user-images.githubusercontent.com/6536819/228068822-29667400-7864-4236-a0e8-8a28d79e7445.png)
source: https://github.com/giantswarm/theo-test/pull/9

In order to get this working I also: (I need to document this)

- created a github token (with repo and read:org permissions) under taylorbot account https://github.com/settings/tokens/1146048704
![image](https://user-images.githubusercontent.com/6536819/228069760-06432c1e-96d4-4251-a2fa-e9b3b6b05b9c.png)

- added a new `TAYLORBOT_GITHUB_ACTION` secret available to all repositories in our organization https://github.com/organizations/giantswarm/settings/secrets/actions

### TODOs

### Checklist

- [x] Update changelog in CHANGELOG.md.