### PR TITLE
Add devctl repo setup `--disable-branch-protection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--disable-branch-protetion` flag to `devctl repo setup`, to allow disabling github branch protection.
+
 ## [5.21.1] - 2023-04-06
 
 ### Changed

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -28,9 +28,10 @@ type flag struct {
 	Permissions map[string]string
 
 	// Branch
-	DefaultBranch string
-	Checks        []string
-	ChecksFilter  string
+	DefaultBranch           string
+	DisableBranchProtection bool
+	Checks                  []string
+	ChecksFilter            string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -58,6 +59,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Branch
 	cmd.PersistentFlags().StringVar(&f.DefaultBranch, "default-branch", "main", "Default branch name")
+	cmd.PersistentFlags().BoolVar(&f.DisableBranchProtection, "disable-branch-protection", false, "Disable default branch protection")
 	cmd.PersistentFlags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
 	cmd.PersistentFlags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
 }

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -105,9 +105,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	err = client.SetRepositoryBranchProtection(ctx, repository, r.flag.Checks, ChecksFilterRegexp)
-	if err != nil {
-		return microerror.Mask(err)
+	if r.flag.DisableBranchProtection {
+		err = client.RemoveRepositoryBranchProtection(ctx, repository)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	} else {
+		err = client.SetRepositoryBranchProtection(ctx, repository, r.flag.Checks, ChecksFilterRegexp)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	r.logger.Info("completed repository setup")


### PR DESCRIPTION
### What

Add a flag to allow disabling Github branch protection with `devctl repo setup`.

This fixes an issue where pushing to catalog repositories fails when branch protection is set

### Why

:red_circle: Failed `push-to-capz-app-collection` CI run
```
====> Attempt 4: Running: git push
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 36 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 376 bytes | 376.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.        
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: At least 1 approving review is required by reviewers with write access.        
To github.com:giantswarm/capz-app-collection.git
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs to 'github.com:giantswarm/capz-app-collection.git'
Giving up after 4 failures.
Error pushing changes. See known errors in:
https://github.com/giantswarm/architect-orb/blob/master/README.md#push-to-app-collection

Exited with code exit status 1
```
source: https://app.circleci.com/pipelines/github/giantswarm/prometheus-rules/2907/workflows/fa327dfd-c9ee-49b8-aa1e-3c5bfeaadfd6/jobs/4146


This was resolved by removing the `main` branch protection in [`capz-app-collection` repository](https://github.com/giantswarm/capz-app-collection/settings/branches)
![image](https://user-images.githubusercontent.com/6536819/231221963-b6ad0c11-3b22-4eb6-aa94-c8ec124b3996.png)

:green_circle:  Successful `push-to-capz-app-collection` CI run
```
====> Attempt 1: Running: git push
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 36 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 376 bytes | 376.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.        
To github.com:giantswarm/capz-app-collection.git
   ce33139..2a13b1c  main -> main

CircleCI received exit code 0
```
https://app.circleci.com/pipelines/github/giantswarm/prometheus-rules/2907/workflows/2f550511-585b-4258-ade0-a600c564d981/jobs/4147

### Note

Other attempts trying to use different settings did not worked ` Restrict who can push to matching branches` and ` Allow specified actors to bypass required pull requests` 

It seems like removing the ` Require a pull request before merging` setting would work, but this sounds absurd to leave branch protection only with ` Require status checks to pass before merging` and not the pull request requirement. Also felt more straightforward to disable the whole protection .

### Checklist

- [x] Update changelog in CHANGELOG.md.