### PR TITLE
Bump github.com/marwan-at-work/mod/cmd/mod to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `github.com/marwan-at-work/mod/cmd/mod` to `v0.5.0` in create release pr template
+
 ## [5.21.1] - 2023-04-06
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -200,7 +200,7 @@ jobs:
       - name: Bump go module defined in go.mod if needed
         run: |
           if [ "${{ needs.gather_facts.outputs.needs_major_bump }}" = true ] && test -f "go.mod"; then
-            go install github.com/marwan-at-work/mod/cmd/mod@v0.4.2
+            go install github.com/marwan-at-work/mod/cmd/mod@v0.5.0
             mod upgrade
           fi
 {{{{ .StepSetUpGitIdentity }}}}


### PR DESCRIPTION
The old version can run into errors - e.g. opsctl - when bumping major version:

```
Unexpected package creation during export data loading
```

See: https://github.com/giantswarm/opsctl/actions/runs/4686619772/jobs/8304912137

### Checklist

- [x] Update changelog in CHANGELOG.md.
