### PR TITLE
Don't specify renovate reviewers as we rely on Github CODEOWNERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove reviewer from renovate file as we rely on Github `CODEOWNERS` file instead.
+
 ## [6.1.1] - 2023-05-11
 
 ### Fixed

--- a/cmd/gen/renovate/flag.go
+++ b/cmd/gen/renovate/flag.go
@@ -8,19 +8,16 @@ import (
 const (
 	flagInterval = "interval"
 	flagLanguage = "language"
-	flagReviewer = "reviewer"
 )
 
 type flag struct {
 	Interval string
 	Language string
-	Reviewer string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Interval, flagInterval, "i", "after 6am on thursday", "Check for daily, weekly or monthly updates.")
 	cmd.Flags().StringVarP(&f.Language, flagLanguage, "l", "", "Language for Renovate to  monitor for new versions , e.g. go, docker.")
-	cmd.Flags().StringVarP(&f.Reviewer, flagReviewer, "r", "", "Reviewer you want to assign automatically when Renovate creates a PR, e.g. giantswarm/team-firecracker.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gen/renovate/runner.go
+++ b/cmd/gen/renovate/runner.go
@@ -46,7 +46,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		c := renovate.Config{
 			Interval: r.flag.Interval,
 			Language: r.flag.Language,
-			Reviewer: r.flag.Reviewer,
 		}
 
 		renovateInput, err = renovate.New(c)

--- a/pkg/gen/input/renovate/internal/file/renovate.go
+++ b/pkg/gen/input/renovate/internal/file/renovate.go
@@ -18,7 +18,6 @@ func NewCreateRenovateInput(p params.Params) input.Input {
 		TemplateData: map[string]interface{}{
 			"Interval": params.Interval(p),
 			"Language": params.Language(p),
-			"Reviewer": params.Reviewer(p),
 		},
 	}
 

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -4,9 +4,6 @@
 {
   "extends": [
     "config:base"
-    {{- if $reviewer }},
-    ":reviewer({{ $reviewer | printf "team:%s" }})"
-    {{- end }}
   ],
   "labels": ["dependencies", "renovate"],
   {{- if eq $language "go" }}

--- a/pkg/gen/input/renovate/internal/params/key.go
+++ b/pkg/gen/input/renovate/internal/params/key.go
@@ -7,7 +7,3 @@ func Interval(p Params) string {
 func Language(p Params) string {
 	return p.Language
 }
-
-func Reviewer(p Params) string {
-	return p.Reviewer
-}

--- a/pkg/gen/input/renovate/internal/params/types.go
+++ b/pkg/gen/input/renovate/internal/params/types.go
@@ -7,6 +7,4 @@ type Params struct {
 	// Interval to check for daily, weekly, or monthly updates (default: weekly).
 	Interval string
 	Language string
-	// Reviewer is a set of people or teams who are assigned as reviewers.
-	Reviewer string
 }

--- a/pkg/gen/input/renovate/renovate.go
+++ b/pkg/gen/input/renovate/renovate.go
@@ -9,7 +9,6 @@ import (
 type Config struct {
 	Interval string
 	Language string
-	Reviewer string
 }
 
 type Renovate struct {
@@ -23,7 +22,6 @@ func New(config Config) (*Renovate, error) {
 
 			Interval: config.Interval,
 			Language: config.Language,
-			Reviewer: config.Reviewer,
 		},
 	}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    ":reviewer(team:team-honeybadger)"
+    "config:base"
   ],
   "labels": ["dependencies", "renovate"],
   "packageRules": [


### PR DESCRIPTION
We currently have the reviewer team in two places, the renovate configuration file and the Github CODEOWNERS file. I think we should only have it in one place.

### Checklist

- [X] Update changelog in CHANGELOG.md.
