### PR TITLE
Add make target 'generate-docs' for cluster apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- For flavor `cluster-app`, the make target `generate-docs` is added, to generate Markdown documentation on values.
+
 ## [6.1.1] - 2023-05-11
 
 ### Fixed

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.cluster_app.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.cluster_app.mk.template
@@ -4,6 +4,7 @@
 
 VALUES=$(shell find ./helm -maxdepth 2 -name values.yaml)
 VALUES_SCHEMA=$(shell find ./helm -maxdepth 2 -name values.schema.json)
+CHART_README=$(shell find ./helm -maxdepth 2 -name README.md)
 
 .PHONY: normalize-schema
 normalize-schema: ## Normalize the JSON schema
@@ -14,6 +15,11 @@ normalize-schema: ## Normalize the JSON schema
 validate-schema: ## Validate the JSON schema
 	go install github.com/giantswarm/schemalint/v2@v2
 	schemalint verify $(VALUES_SCHEMA) --rule-set=cluster-app
+
+.PHONY: generate-docs
+generate-docs: ## Generate values documentation from schema
+	go install github.com/giantswarm/schemadocs@latest
+	schemadocs generate $(VALUES_SCHEMA) -o $(CHART_README)
 
 .PHONY: generate-values
 generate-values: ## Generate values.yaml from schema


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1733

This PR adds the make target `make generate-docs` to the Makefile for repos of flavor `cluster-app`. This facilitates updating the docs for cluster app maintainers.

### Checklist

- [x] Update changelog in CHANGELOG.md.
