### PR TITLE
Fix "Compare Helm Rendering" workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix "Compare Helm Rendering" workflow to use correct CI values path when rendering the default branch version.
+
 ## [6.3.0] - 2023-06-01
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/helm_render_diff.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/helm_render_diff.yaml.template
@@ -89,7 +89,7 @@ jobs:
         run: |
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm dependency build old/helm/${{ github.event.repository.name }}
-          helm template -n org-giantswarm -f "helm/${{ github.event.repository.name }}/ci/ci-values.yaml" -f "${{ matrix.values }}" "old/helm/${{ github.event.repository.name }}" > /tmp/${{ matrix.values }}/render-old.yaml
+          helm template -n org-giantswarm -f "old/helm/${{ github.event.repository.name }}/ci/ci-values.yaml" -f "${{ matrix.values }}" "old/helm/${{ github.event.repository.name }}" > /tmp/${{ matrix.values }}/render-old.yaml
       - name: get the diffs
         uses: mathiasvr/command-output@v1
         id: diff


### PR DESCRIPTION
This PR fixes the problem that helm diff comparison, when rendering the default branch version, does not use the default branch's CI values, but the current branches instead. This yielded differences where there should not be any.

### Checklist

- [x] Update changelog in CHANGELOG.md.
