### PR TITLE
use `head` instead of branch in update_chart workflow

### DIFF
--- a/pkg/gen/input/workflows/internal/file/update_chart.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/update_chart.yaml.template
@@ -59,8 +59,8 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
         run: |
-          if gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.branch }} | grep -i 'state:[[:space:]]*open' >/dev/null; then
-            gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.branch }}
+          if gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.head }} | grep -i 'state:[[:space:]]*open' >/dev/null; then
+            gh pr view --repo ${{ github.repository }} ${{ steps.gather_facts.outputs.head }}
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
branch is actually refs/heads/<branch_name>
head is just <branch_name>

Signed-off-by: Matias Charriere <matias@giantswarm.io>

### Checklist

- [ ] Update changelog in CHANGELOG.md.
