### PR TITLE
Update, extend, and restructure devctl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,72 +2,34 @@
 
 # devctl
 
-Command line tool for the development daily business.
+Command line tool for the daily development business at Giant Swarm.
 
-## Installation
+## Quick start
 
-This project uses Go modules. Be sure to have it outside your `$GOPATH` or
-set `GO111MODULE=on` environment variable. Then regular `go install` should do
-the trick. Alternatively the following one-liner may help.
+### Installation
 
-```sh
-GO111MODULE=on go install -ldflags "-X 'github.com/giantswarm/devctl/pkg/project.gitSHA=$(git rev-parse HEAD)'" .
+```nohighlight
+go install github.com/giantswarm/devctl
 ```
 
-## Configuration
+### Configuration
 
-To be able to fully use `devctl` you need to set following environment variables.
+Most commands require credentials for GitHub write access to be available. Make sure you have the environment variable
 
-- `DEVCTL_GITHUB_ACCESS_TOKEN`: GitHub access token generated with your
-  personal account.
-
-## Usage
-
-For full capabilities, please check `devctl -h` for details on all functions.
-
-### Generating files
-
-This command is mostly used to distribute common files across multiple repositories, for example:
-
-- GitHub workflow via: `devctl gen workflows --flavour ...`
-- Makefiles: `devctl gen makefile --flavour ...`
-- Makefiles: `devctl gen renovate --language ...`
-- Makefiles: `devctl gen dependabot --ecosystems ...`
-
-These are distributed via https://github.com/giantswarm/github and configuration passed to the commands are kept
-within https://github.com/giantswarm/github/tree/master/repositories.
-
-### Generating releases
-
-The tool can be used to create legacy cluster releases, for example the ones stored in https://github.com/giantswarm/releases.
-
-```shell
-devctl release create --provider aws --base 18.0.1 --name 18.0.2 --component aws-operator@13.2.1-dev --overwrite
+```nohighlight
+GITHUB_TOKEN
 ```
 
-### Updating the tool
+set with a valid [personal access token](https://github.com/settings/tokens) as the value.
 
-There is a command that can be used to self-upgrade the tool.
+### Usage
 
-```shell
+Please check `devctl --help` for available commands and options.
+
+Also see the [docs](docs/) folder for more details on some commands.
+
+### Updating
+
+```nohighlight
 devctl version update
 ```
-
-## Troubleshooting
-
-`devctl` tries to check if there is a newer version available before every command execution. If you happen to see this error:
-
-```
-Error: GET https://api.github.com/repos/giantswarm/devctl/releases: 401 Bad credentials []
-```
-
-This means if you have probably either:
-
-- `GITHUB_TOKEN` variable set to a token with not enough permissions.
-- `github.token` configuration set to a token with not enough permissions. You can verify that with `git config --get --null github.token`.
-
-Workarounds:
-
-- Run `unset GITHUB_TOKEN`.
-- Run `git config --unset github.token`.
-- Set `GITHUB_TOKEN` to a token with enough permissions.

--- a/docs/flavours.md
+++ b/docs/flavours.md
@@ -1,0 +1,31 @@
+# Understanding flavours
+
+`devctl` understands different types of GitHub repositories, to make the right modifications for each type. App repos have different needs than Go libraries, for example.
+
+Flavours are not mutually exclusive. Some repos must be configured with multiple flavours. For example, an operator may carry the flavours `app` and `k8sapi`. Note: this configuration is usually persisted in our [repository configuration](https://github.com/giantswarm/github/tree/main/repositories).
+
+The following flavours are understood:
+
+## `app`
+
+An app, by the definition of the Giant Swarm app platform. Each app repository contains at lest one Helm chart.
+
+## `cli`
+
+A command line interface (CLI) component which is typically executed on-demand either by a user or within an automation system. CLIs are typically released with downloadable and executable binaries.
+
+## `cluster-app`
+
+A specific type of app repository which provides a values schema that aims to fulfill the requirements of the [RFC #55](https://github.com/giantswarm/rfc/pull/55).
+
+## `customer`
+
+A repository used to track mostly issues and provide project boards, shared with a customer.
+
+## `k8sapi`
+
+A repository that provides a Kubernetes API (usually one or several custom resource definitions).
+
+## `generic`
+
+A repository that does not fit any of the more specific flavours above.

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -1,0 +1,39 @@
+# Using the `gen` commands to generate files
+
+The `gen` command family is designed to create common files in repositories, adapted specifically for the repository [flavour](flavour.md) and/or programming language used.
+
+Files are written to the current directory. The assumption is that the current working directory is the root directory of a cloned repository.
+
+Usually these commands are executed via automation in the [giantswarm/github](https://github.com/giantswarm/github/actions/workflows/synchronize.yaml) repository, but this can also be done manually/locally.
+
+Note: the added files are not meant for later editing, as changes would be overwritten by a subsequent `devctl` execution.
+
+## Generating workflow files
+
+Creates common GitHub actions workflows (for CI/CD) in the `.github/workflows` directory.
+
+Example:
+
+```nohighlight
+devctl gen workflows --flavour cli
+```
+
+## Generating Makefiles
+
+Creates common `Makefile` and includes in the root directory.
+
+Example:
+
+```nohighlight
+devctl gen workflows --flavour cli --language go
+```
+
+## Generating renovate configuration
+
+Generates a `renovate.json` file in the repo root to configure [renovate](https://docs.renovatebot.com/), which automatically updates dependencies in the configured repository.
+
+```nohighlight
+devctl gen renovate --language LANGUAGE
+```
+
+Note: The `LANGUAGE` value is not validated currently. From code, as of writing this docs, `go` and `python` were the only values checked for. (Usability improvement welcome!)

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,14 @@
+# Creating vintage releases
+
+The tool can be used to create legacy cluster releases, for example the ones stored in [giantswarm/releases](https://github.com/giantswarm/releases).
+
+Example:
+
+```nohighlight
+devctl release create \
+    --provider aws \
+    --base 18.0.1 \
+    --name 18.0.2 \
+    --component aws-operator@13.2.1-dev \
+    --overwrite
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,18 @@
+# Troubleshooting
+
+`devctl` tries to check if there is a newer version available before every command execution. If you happen to see this error:
+
+```nohighlight
+Error: GET https://api.github.com/repos/giantswarm/devctl/releases: 401 Bad credentials []
+```
+
+This means if you have probably either:
+
+- The `GITHUB_TOKEN` environment variable is set to a token with not enough permissions.
+- The `github.token` configuration option in `git` is set to a token with not enough permissions. You can verify that with `git config --get --null github.token`.
+
+Workarounds:
+
+- Run `unset GITHUB_TOKEN`.
+- Run `git config --unset github.token`.
+- Set `GITHUB_TOKEN` to a token with enough permissions.


### PR DESCRIPTION
This PR updates the documentation in the README and moves details about some commands and troubleshooting info into the `docs` folder. I'm also extending the info on the `gen` commands and add a page to explain the repository flavours.