### PR TITLE
Exclude pre-commit workflow from renovate updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Exclude `.github/workflows/pre_commit_*.yaml` from renovate dependency updates, as this file is managed centrally.
+
 ## [6.5.0] - 2023-07-27
 
 ### Changed

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -53,7 +53,8 @@
   "dependencyDashboard": true,
   "ignorePaths": [
     ".github/workflows/zz_generated.*",
-    ".github/workflows/codeql-analysis.yml"
+    ".github/workflows/codeql-analysis.yml",
+    ".github/workflows/pre_commit_*.yaml"
   ],
   "ignoreDeps": [
     "architect",


### PR DESCRIPTION
This PR excludes another file form dependency upgrades, as this file is managed centrally.

### Checklist

- [x] Update changelog in CHANGELOG.md.
