### PR TITLE
Bump ubuntu to v22.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped Ubuntu in Github workflow runners to v22.04
+
 ## [6.6.0] - 2023-08-14
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -12,7 +12,7 @@ on:
 jobs:
   debug_info:
     name: Debug info
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print github context JSON
         run: |
@@ -21,7 +21,7 @@ jobs:
           EOF
   gather_facts:
     name: Gather facts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       project_go_path: ${{ steps.get_project_go_path.outputs.path }}
       ref_version: ${{ steps.ref_version.outputs.refversion }}
@@ -81,7 +81,7 @@ jobs:
           echo "refversion=${refversion}" >> $GITHUB_OUTPUT
   update_project_go:
     name: Update project.go
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ needs.gather_facts.outputs.version != '' && needs.gather_facts.outputs.project_go_path != '' && needs.gather_facts.outputs.ref_version != 'true' }}
     needs:
       - gather_facts
@@ -140,7 +140,7 @@ jobs:
           hub pull-request -f  -m "${{ env.title }}" -b ${{ env.base }} -h ${{ env.branch }} -r ${{ github.actor }}
   create_release:
     name: Create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.version }}
@@ -187,7 +187,7 @@ jobs:
 
   ensure_floating_major_version_tags:
     name: Ensure floating major version tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - gather_facts
       - create_release
@@ -199,7 +199,7 @@ jobs:
 
   create-release-branch:
     name: Create release branch
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.version }}
@@ -261,7 +261,7 @@ jobs:
 
   create_and_upload_build_artifacts:
     name: Create and upload build artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -27,7 +27,7 @@ on:
 jobs:
   debug_info:
     name: Debug info
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print github context JSON
         run: |
@@ -36,7 +36,7 @@ jobs:
           EOF
   gather_facts:
     name: Gather facts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       repo_name: ${{ steps.gather_facts.outputs.repo_name }}
       branch: ${{ steps.gather_facts.outputs.branch }}
@@ -133,7 +133,7 @@ jobs:
           fi
   create_release_pr:
     name: Create release PR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.skip != 'true' }}

--- a/pkg/gen/input/workflows/internal/file/ensure_major_version_tags.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/ensure_major_version_tags.yaml.template
@@ -6,7 +6,7 @@ on:
 jobs:
   debug_info:
     name: Debug info
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print github context JSON
         run: |
@@ -15,7 +15,7 @@ jobs:
           EOF
   ensure_major_version_tags:
     name: Ensure major version tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: giantswarm/floating-tags-action@v1

--- a/pkg/gen/input/workflows/internal/file/update_chart.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/update_chart.yaml.template
@@ -18,7 +18,7 @@ on:
 jobs:
   debug_info:
     name: Debug info
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Print github context JSON
         run: |
@@ -27,7 +27,7 @@ jobs:
           EOF
   gather_facts:
     name: Gather facts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       repo_name: ${{ steps.gather_facts.outputs.repo_name }}
       branch: ${{ steps.gather_facts.outputs.branch }}
@@ -69,7 +69,7 @@ jobs:
           fi
   create_update_pr:
     name: Create update PR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.skip != 'true' }}


### PR DESCRIPTION
This PR bumps the Ubuntu version of generated Github action runners from v20.04 to v22.04.

### Checklist

- [x] Update changelog in CHANGELOG.md.
