### PR TITLE
Change `gen ami` command in order to work with aws-operator >= 14.22.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump release operator dependency to v4 to add support for dependencies on release apps.
 - Add some apps to the changelog apps list.
+- Change `gen ami` command in order to work with aws-operator >= 14.22.0 where AMI Ids have been moved to the config repo.
+
+### Fixed
+
+- Fix AMI ID detection for china in `gen ami` command.
 
 ## [6.7.0] - 2023-08-18
 

--- a/cmd/gen/ami/flag.go
+++ b/cmd/gen/ami/flag.go
@@ -7,30 +7,43 @@ import (
 )
 
 const (
-	flagArch           = "arch"
-	flagChannel        = "stable"
-	flagChinaDomain    = "china.domain"
-	flagDir            = "dir"
-	flagMinimumVersion = "minimum.version"
-	flagPrimaryDomain  = "primary.domain"
+	flagArch                    = "arch"
+	flagChannel                 = "stable"
+	flagChinaBucketName         = "china.bucket"
+	flagChinaBucketRegion       = "china.region"
+	flagChinaAWSAccessKeyID     = "aws.accesskeyid"
+	flagChinaAWSSecretAccessKey = "aws.secretaccesskey"
+	flagDir                     = "dir"
+	flagMinimumVersion          = "minimum.version"
+	flagPrimaryDomain           = "primary.domain"
+	flagKeepExisting            = "keep.existing"
 )
 
 type flag struct {
-	Arch           string
-	Channel        string
-	ChinaDomain    string
-	Dir            string
-	MinimumVersion string
-	PrimaryDomain  string
+	Arch                    string
+	Channel                 string
+	ChinaBucketName         string
+	ChinaBucketRegion       string
+	ChinaAWSAccessKeyID     string
+	ChinaAWSSecretAccessKey string
+	Dir                     string
+	MinimumVersion          string
+	PrimaryDomain           string
+	KeepExisting            string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Arch, flagArch, "amd64-usr", `Architecture of the image, e.g. "amd64-usr".`)
 	cmd.Flags().StringVar(&f.Channel, flagChannel, "stable", `Channel of the OS.`)
-	cmd.Flags().StringVar(&f.ChinaDomain, flagChinaDomain, "flatcar-prod-ami-import-cn-north-1.s3.cn-north-1.amazonaws.com.cn", `Domain to use as a source for AMIs in china.`)
+	cmd.Flags().StringVar(&f.ChinaBucketName, flagChinaBucketName, "flatcar-prod-ami-import-cn-north-1", `S3 bucket name to get version info in china.`)
+	cmd.Flags().StringVar(&f.ChinaBucketRegion, flagChinaBucketRegion, "cn-north-1", `Region containing S3 bucket to get version info in china.`)
+	cmd.Flags().StringVar(&f.ChinaAWSAccessKeyID, flagChinaAWSAccessKeyID, "", `AWS Access Key ID for china.`)
+	cmd.Flags().StringVar(&f.ChinaAWSSecretAccessKey, flagChinaAWSSecretAccessKey, "", `AWS Secret Access Key for china.`)
 	cmd.Flags().StringVar(&f.Dir, flagDir, "", `Directory/package where the generated code should be located.`)
 	cmd.Flags().StringVar(&f.MinimumVersion, flagMinimumVersion, "2191.5.0", `Minimum version of flatcar to use for generation, e.g. "2134.3.0".`)
 	cmd.Flags().StringVar(&f.PrimaryDomain, flagPrimaryDomain, "flatcar-linux.net", `Domain to use as a source for AMIs.`)
+	cmd.Flags().StringVar(&f.KeepExisting, flagKeepExisting, "", `Keep versions already defined in file specified.`)
+
 }
 
 func (f *flag) Validate() error {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/aws/aws-sdk-go v1.45.6
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/fatih/color v1.15.0
@@ -35,6 +36,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws/aws-sdk-go v1.44.29 h1:53YWlelsMiYmGxuTRpAq7Xp+pE+0esAVqNFiNyekU+A=
+github.com/aws/aws-sdk-go v1.44.29/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
@@ -97,6 +99,10 @@ github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7V
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -88,6 +88,8 @@ func isRegenerable(path string) bool {
 		return true
 	case base == "dependabot.yml":
 		return true
+	case base == "aws-ami.yaml.template":
+		return true
 	case strings.HasPrefix(base, internal.RegenerableFilePrefix):
 		return true
 	}

--- a/pkg/gen/input/ami/china.go
+++ b/pkg/gen/input/ami/china.go
@@ -1,0 +1,49 @@
+package ami
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/giantswarm/microerror"
+)
+
+func getChinaFlatcarRelease(config Config, version string) (map[string]string, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(config.ChinaAWSAccessKeyID, config.ChinaAWSSecretAccessKey, ""),
+		Region:      aws.String(config.ChinaBucketRegion),
+	})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	svc := s3.New(sess)
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(config.ChinaBucketName),
+		Key:    aws.String(fmt.Sprintf("%s/%s/%s.json", config.Channel, config.Arch, version)),
+	}
+
+	result, err := svc.GetObject(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchKey:
+				// Not found, but that's fine
+				fmt.Printf("Release %s not found in china\n", version)
+				return nil, nil
+			default:
+				return nil, microerror.Mask(aerr)
+			}
+		}
+		return nil, microerror.Mask(err)
+	}
+
+	chinaVersionAMI, err := scrapeVersionAMI(result.Body)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return chinaVersionAMI, nil
+}

--- a/pkg/gen/input/ami/config.go
+++ b/pkg/gen/input/ami/config.go
@@ -5,14 +5,19 @@ import (
 )
 
 type Config struct {
-	Arch        string
-	Channel     string
-	ChinaDomain string
+	Arch                    string
+	Channel                 string
+	ChinaBucketName         string
+	ChinaBucketRegion       string
+	ChinaAWSAccessKeyID     string
+	ChinaAWSSecretAccessKey string
 	// Dir is the name of the directory where the files of the resource
 	// should be generated.
 	Dir            string
 	MinimumVersion string
 	PrimaryDomain  string
+	// If KeepExisting is not empty, releases find in the file won't be overridden.
+	KeepExisting string
 }
 
 func (c *Config) Validate() error {
@@ -22,8 +27,17 @@ func (c *Config) Validate() error {
 	if c.Channel == "" {
 		return microerror.Maskf(invalidConfigError, "%T.Channel must not be empty", c)
 	}
-	if c.ChinaDomain == "" {
-		return microerror.Maskf(invalidConfigError, "%T.ChinaDomain must not be empty", c)
+	if c.ChinaBucketName == "" {
+		return microerror.Maskf(invalidConfigError, "%T.ChinaBucketName must not be empty", c)
+	}
+	if c.ChinaBucketRegion == "" {
+		return microerror.Maskf(invalidConfigError, "%T.ChinaBucketRegion must not be empty", c)
+	}
+	if c.ChinaAWSAccessKeyID == "" {
+		return microerror.Maskf(invalidConfigError, "%T.ChinaAWSAccessKeyID must not be empty", c)
+	}
+	if c.ChinaAWSSecretAccessKey == "" {
+		return microerror.Maskf(invalidConfigError, "%T.ChinaAWSSecretAccessKey must not be empty", c)
 	}
 	if c.Dir == "" {
 		return microerror.Maskf(invalidConfigError, "%T.Dir must not be empty", c)

--- a/pkg/gen/input/ami/error.go
+++ b/pkg/gen/input/ami/error.go
@@ -19,3 +19,7 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+func IsS3NotFoundError(err error) bool {
+	return false
+}

--- a/pkg/gen/input/ami/funcs.go
+++ b/pkg/gen/input/ami/funcs.go
@@ -88,7 +88,7 @@ func getAMIInfoString(config Config) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	return fmt.Sprintf("%s", result), nil
+	return string(result), nil
 }
 
 func scrapeVersions(source io.Reader) ([]string, error) {

--- a/pkg/gen/input/ami/internal/file/ami.go
+++ b/pkg/gen/input/ami/internal/file/ami.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/giantswarm/devctl/pkg/gen/input"

--- a/pkg/gen/input/ami/internal/file/ami.go
+++ b/pkg/gen/input/ami/internal/file/ami.go
@@ -17,8 +17,6 @@ func NewAMIInput(p params.Params) input.Input {
 		},
 	}
 
-	fmt.Println(i.Path)
-
 	return i
 }
 

--- a/pkg/gen/input/ami/internal/file/ami.go
+++ b/pkg/gen/input/ami/internal/file/ami.go
@@ -1,38 +1,25 @@
 package file
 
 import (
+	"fmt"
+	"path"
+
 	"github.com/giantswarm/devctl/pkg/gen/input"
 	"github.com/giantswarm/devctl/pkg/gen/input/ami/internal/params"
 )
 
 func NewAMIInput(p params.Params) input.Input {
 	i := input.Input{
-		Path:         params.RegenerableFileName(p, "ami.go"),
+		Path:         path.Join(p.Dir, "aws-ami.yaml.template"),
 		TemplateBody: amiTemplate,
 		TemplateData: map[string]interface{}{
-			"Header":        params.Header("//"),
 			"AMIInfoString": params.AMIInfoString(p),
-			"Package":       params.Package(p),
 		},
 	}
+
+	fmt.Println(i.Path)
 
 	return i
 }
 
-var amiTemplate = `{{ .Header }}
-
-package {{ .Package }}
-
-import "encoding/json"
-
-var amiInfo = map[string]map[string]string{}
-
-var amiJSON = []byte({{ .AMIInfoString }})
-
-func init() {
-	err := json.Unmarshal(amiJSON, &amiInfo)
-	if err != nil {
-		panic(err)
-	}
-}
-`
+var amiTemplate = `{{ .AMIInfoString }}`


### PR DESCRIPTION
…0 where AMI Ids have been moved to the config repo.

towards: https://github.com/giantswarm/giantswarm/issues/27990

### Checklist

- [x] Update changelog in CHANGELOG.md.
