### PR TITLE
Make renovate ignore the module `github.com/imdario/mergo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Let renovate ignore dependency `github.com/imdario/mergo`
+- Let renovate ignore dependency `github.com/imdario/mergo`.
 
 ## [6.8.0] - 2023-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Let renovate ignore dependency `github.com/imdario/mergo`
+
 ## [6.8.0] - 2023-09-12
 
 ### Changed

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -57,9 +57,10 @@
     ".github/workflows/pre_commit_*.yaml"
   ],
   "ignoreDeps": [
+    "actions/setup-go",
     "architect",
-    "zricethezav/gitleaks-action",
-    "actions/setup-go"
+    "github.com/imdario/mergo",
+    "zricethezav/gitleaks-action"
   ],
   "regexManagers": [
     {


### PR DESCRIPTION
The module got renamed, but Renovate tries to update it to v1.0.0 using the old name, which fails.

As the module is in use in 166 repos, we exclude this globally to prevent extra handling of this.

### Checklist

- [x] Update changelog in CHANGELOG.md.
