### PR TITLE
`devctl gen renovate`: make `--interval` optional, remove default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `devctl gen renovate`: make `--interval` optional, remove default value
+
 ## [6.10.0] - 2023-09-15
 
 ### Changed

--- a/cmd/gen/renovate/flag.go
+++ b/cmd/gen/renovate/flag.go
@@ -16,14 +16,11 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.Interval, flagInterval, "i", "after 6am on thursday", "Check for daily, weekly or monthly updates.")
+	cmd.Flags().StringVarP(&f.Interval, flagInterval, "i", "", "Check for daily, weekly or monthly updates.")
 	cmd.Flags().StringVarP(&f.Language, flagLanguage, "l", "", "Language for Renovate to  monitor for new versions , e.g. go, docker.")
 }
 
 func (f *flag) Validate() error {
-	if f.Interval == "" {
-		return microerror.Maskf(invalidFlagError, "--%s cannot be empty", flagInterval)
-	}
 	if f.Language == "" {
 		return microerror.Maskf(invalidFlagError, "--%s cannot be empty", flagLanguage)
 	}

--- a/pkg/gen/input/renovate/internal/file/renovate.json.template
+++ b/pkg/gen/input/renovate/internal/file/renovate.json.template
@@ -1,4 +1,3 @@
-{{- $interval := .Interval -}}
 {{- $language := .Language -}}
 {{- $reviewer := .Reviewer -}}
 {
@@ -69,6 +68,8 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }
-  ],
-  "schedule": [ {{ $interval | printf "%q" }} ]
+  ]
+{{- if ne .Interval "" }},
+  "schedule": [ {{ .Interval | printf "%q" }} ]
+{{- end }}
 }


### PR DESCRIPTION
This PR removes the default schedule from generated renovate configuration, as we [decided](https://gigantic.slack.com/archives/C2MS2VB37/p1695305905409149) we want renovate to work on all days.

### Checklist

- [x] Update changelog in CHANGELOG.md.
