### PR TITLE
Add `repo setup renovate` command to give Renovate access to a repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `devctl repo setup renovate` to enable/disable Renovate for a repository.
+
 ## [6.11.0] - 2023-09-22
 
 ### Changed

--- a/cmd/repo/setup/command.go
+++ b/cmd/repo/setup/command.go
@@ -8,6 +8,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/devctl/cmd/repo/setup/renovate"
 )
 
 const (
@@ -37,6 +39,22 @@ func New(config Config) (*cobra.Command, error) {
 		config.Stdout = os.Stdout
 	}
 
+	var err error
+
+	var renovateCmd *cobra.Command
+	{
+		c := renovate.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		renovateCmd, err = renovate.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	f := &flag{}
 
 	r := &runner{
@@ -55,6 +73,8 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	f.Init(c)
+
+	c.AddCommand(renovateCmd)
 
 	return c, nil
 }

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -35,33 +35,36 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVar(&f.DryRun, "dry-run", false, "Dry-run or ready-only mode. Show what is being made but do not apply any change.")
+	// Persistent flags are also available to subcommands.
 	cmd.PersistentFlags().StringVar(&f.GithubTokenEnvVar, "github-token-envvar", "GITHUB_TOKEN", "Environment variable name for Github token.")
 
+	// Standard flags
+	cmd.Flags().BoolVar(&f.DryRun, "dry-run", false, "Dry-run or ready-only mode. Show what is being made but do not apply any change.")
+
 	// Features
-	cmd.PersistentFlags().BoolVar(&f.EnableWiki, "enable-wiki", false, "Enable wiki for this repo, false to remove it.")
-	cmd.PersistentFlags().BoolVar(&f.EnableIssues, "enable-issues", true, "Enable issues for this repo, or false to remove them.")
-	cmd.PersistentFlags().BoolVar(&f.EnableProjects, "enable-projects", false, "Enable projects for this repo, or false to remove them.")
-	cmd.PersistentFlags().BoolVar(&f.Archived, "archived", false, "Mark this repo as archived.")
+	cmd.Flags().BoolVar(&f.EnableWiki, "enable-wiki", false, "Enable wiki for this repo, false to remove it.")
+	cmd.Flags().BoolVar(&f.EnableIssues, "enable-issues", true, "Enable issues for this repo, or false to remove them.")
+	cmd.Flags().BoolVar(&f.EnableProjects, "enable-projects", false, "Enable projects for this repo, or false to remove them.")
+	cmd.Flags().BoolVar(&f.Archived, "archived", false, "Mark this repo as archived.")
 
 	// Merge settings
-	cmd.PersistentFlags().BoolVar(&f.AllowMergeCommit, "allow-mergecommit", false, "Allow merging pull requests with a merge commit, or false to prevent it.")
-	cmd.PersistentFlags().BoolVar(&f.AllowSquashMerge, "allow-squashmerge", true, "Allow squash-merging pull requests, or false to prevent it.")
-	cmd.PersistentFlags().BoolVar(&f.AllowRebaseMerge, "allow-rebasemerge", false, "Allow rebase-merging pull requests, or false to prevent it.")
+	cmd.Flags().BoolVar(&f.AllowMergeCommit, "allow-mergecommit", false, "Allow merging pull requests with a merge commit, or false to prevent it.")
+	cmd.Flags().BoolVar(&f.AllowSquashMerge, "allow-squashmerge", true, "Allow squash-merging pull requests, or false to prevent it.")
+	cmd.Flags().BoolVar(&f.AllowRebaseMerge, "allow-rebasemerge", false, "Allow rebase-merging pull requests, or false to prevent it.")
 
 	// Pull requests
-	cmd.PersistentFlags().BoolVar(&f.AllowUpdateBranch, "allow-updatebranch", true, "Whenever there are new changes available in the base branch, present an “update branch” option in the pull request.")
-	cmd.PersistentFlags().BoolVar(&f.AllowAutoMerge, "allow-automerge", true, "Allow auto-merge on pull requests, or false to forbid it.")
-	cmd.PersistentFlags().BoolVar(&f.DeleteBranchOnMerge, "delete-branch-on-merge", true, "Automatically delete head branches when PRs are merged, or false to prevent it.")
+	cmd.Flags().BoolVar(&f.AllowUpdateBranch, "allow-updatebranch", true, "Whenever there are new changes available in the base branch, present an “update branch” option in the pull request.")
+	cmd.Flags().BoolVar(&f.AllowAutoMerge, "allow-automerge", true, "Allow auto-merge on pull requests, or false to forbid it.")
+	cmd.Flags().BoolVar(&f.DeleteBranchOnMerge, "delete-branch-on-merge", true, "Automatically delete head branches when PRs are merged, or false to prevent it.")
 
 	// Permissions
-	cmd.PersistentFlags().StringToStringVar(&f.Permissions, "permissions", map[string]string{"Employees": "admin", "bots": "push"}, "Grant access to this repository using github_team_name=permission format. Multiple values can be provided as a comma separated list or using this flag multiple times. Permission can be one of: pull, push, admin, maintain, triage.")
+	cmd.Flags().StringToStringVar(&f.Permissions, "permissions", map[string]string{"Employees": "admin", "bots": "push"}, "Grant access to this repository using github_team_name=permission format. Multiple values can be provided as a comma separated list or using this flag multiple times. Permission can be one of: pull, push, admin, maintain, triage.")
 
 	// Branch
-	cmd.PersistentFlags().StringVar(&f.DefaultBranch, "default-branch", "main", "Default branch name")
-	cmd.PersistentFlags().BoolVar(&f.DisableBranchProtection, "disable-branch-protection", false, "Disable default branch protection")
-	cmd.PersistentFlags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
-	cmd.PersistentFlags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
+	cmd.Flags().StringVar(&f.DefaultBranch, "default-branch", "main", "Default branch name")
+	cmd.Flags().BoolVar(&f.DisableBranchProtection, "disable-branch-protection", false, "Disable default branch protection")
+	cmd.Flags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
+	cmd.Flags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/repo/setup/renovate/command.go
+++ b/cmd/repo/setup/renovate/command.go
@@ -1,0 +1,57 @@
+package renovate
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name            = "renovate"
+	description     = "Enable (or disable) Renovate for the repository"
+	longDescription = ""
+)
+
+type Config struct {
+	Logger *logrus.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     fmt.Sprintf("%s [--remove] REPOSITORY", name),
+		Short:   description,
+		Long:    longDescription,
+		RunE:    r.Run,
+		Args:    cobra.ExactArgs(1),
+		Example: "devctl setup renovate --remove giantswarm/myrepo",
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/repo/setup/renovate/command.go
+++ b/cmd/repo/setup/renovate/command.go
@@ -13,7 +13,14 @@ import (
 const (
 	name            = "renovate"
 	description     = "Enable (or disable) Renovate for the repository"
-	longDescription = ""
+	longDescription = `This command adds the given repository to the list of repos that Renovate will have access to,
+in order to allow for automatic dependency updates.
+
+NOTE: This does not add or remove any renovate configuration to the repository.
+For that, please check out:
+
+  devctl gen renovate --help
+`
 )
 
 type Config struct {

--- a/cmd/repo/setup/renovate/command.go
+++ b/cmd/repo/setup/renovate/command.go
@@ -55,7 +55,7 @@ func New(config Config) (*cobra.Command, error) {
 		Long:    longDescription,
 		RunE:    r.Run,
 		Args:    cobra.ExactArgs(1),
-		Example: "devctl setup renovate --remove giantswarm/myrepo",
+		Example: "  devctl setup renovate --remove giantswarm/myrepo",
 	}
 
 	f.Init(c)

--- a/cmd/repo/setup/renovate/error.go
+++ b/cmd/repo/setup/renovate/error.go
@@ -1,0 +1,25 @@
+package renovate
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidArgError = &microerror.Error{
+	Kind: "invalidArgError",
+}
+
+// IsInvalidArg asserts invalidArgError.
+func IsInvalidArg(err error) bool {
+	return microerror.Cause(err) == invalidArgError
+}
+
+var envVarNotFoundError = &microerror.Error{
+	Kind: "envVarNotFoundError",
+}

--- a/cmd/repo/setup/renovate/flag.go
+++ b/cmd/repo/setup/renovate/flag.go
@@ -1,0 +1,17 @@
+package renovate
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+	GithubTokenEnvVar string
+	Remove            bool
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.Remove, "remove", false, "Set this flag to remove Renovate with the repo. Otherwise it will be added.")
+	//cmd.PersistentFlags().StringVar(&f.GithubTokenEnvVar, "github-token-envvar", "GITHUB_TOKEN", "Environment variable name for Github token.")
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/repo/setup/renovate/flag.go
+++ b/cmd/repo/setup/renovate/flag.go
@@ -3,13 +3,11 @@ package renovate
 import "github.com/spf13/cobra"
 
 type flag struct {
-	GithubTokenEnvVar string
-	Remove            bool
+	Remove bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.Remove, "remove", false, "Set this flag to remove Renovate with the repo. Otherwise it will be added.")
-	//cmd.PersistentFlags().StringVar(&f.GithubTokenEnvVar, "github-token-envvar", "GITHUB_TOKEN", "Environment variable name for Github token.")
+	cmd.Flags().BoolVar(&f.Remove, "remove", false, "Set this flag to disable Renovate access for the repo. Otherwise it will be enabled.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/repo/setup/renovate/runner.go
+++ b/cmd/repo/setup/renovate/runner.go
@@ -54,7 +54,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var token string
 	var found bool
 	if token, found = os.LookupEnv(tokenEnv); !found {
-		return microerror.Maskf(envVarNotFoundError, "environment variable %#q was not found", r.flag.GithubTokenEnvVar)
+		return microerror.Maskf(envVarNotFoundError, "environment variable %#q was not found", tokenEnv)
 	}
 
 	c := githubclient.Config{

--- a/cmd/repo/setup/renovate/runner.go
+++ b/cmd/repo/setup/renovate/runner.go
@@ -1,0 +1,87 @@
+package renovate
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/devctl/pkg/githubclient"
+)
+
+type runner struct {
+	flag   *flag
+	logger *logrus.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	s := strings.Split(args[0], "/")
+	if len(s) != 2 {
+		return microerror.Maskf(invalidArgError, "expected owner/repo, got %s", args[0])
+	}
+
+	owner := s[0]
+	repo := s[1]
+
+	var tokenEnv string
+	flag := cmd.Flag("github-token-envvar")
+	if flag != nil {
+		tokenEnv = flag.Value.String()
+	}
+
+	var token string
+	var found bool
+	if token, found = os.LookupEnv(tokenEnv); !found {
+		return microerror.Maskf(envVarNotFoundError, "environment variable %#q was not found", r.flag.GithubTokenEnvVar)
+	}
+
+	c := githubclient.Config{
+		Logger:      r.logger,
+		AccessToken: token,
+	}
+
+	client, err := githubclient.New(c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	repository, err := client.GetRepository(ctx, owner, repo)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if r.flag.Remove {
+		r.logger.Printf("Removing %s/%s from repositories accessible by Renovate...", owner, *repository.Name)
+		err = client.RemoveRepoFromRenovatePermissions(ctx, owner, repository)
+	} else {
+		r.logger.Printf("Adding %s/%s to repositories accessible by Renovate...", owner, *repository.Name)
+		err = client.AddRepoToRenovatePermissions(ctx, owner, repository)
+	}
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/githubclient/error.go
+++ b/pkg/githubclient/error.go
@@ -28,3 +28,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var installationNotFoundError = &microerror.Error{
+	Kind: "installationNotFoundError",
+}
+
+// IsInstallationNotFound asserts installationNotFoundError.
+func IsInstallationNotFound(err error) bool {
+	return microerror.Cause(err) == installationNotFoundError
+}

--- a/pkg/githubclient/renovate.go
+++ b/pkg/githubclient/renovate.go
@@ -1,0 +1,85 @@
+package githubclient
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+	"github.com/google/go-github/v55/github"
+)
+
+const (
+	// App ID of the renovate installation.
+	renovateAppID = 2740
+
+	githubApiVersion = "2022-11-28"
+)
+
+func (c *Client) GetRenovateInstallation(ctx context.Context, org string) (*github.Installation, error) {
+	// Get app installations to detect the Renovate app.
+	realClient := c.getUnderlyingClient(ctx)
+	installations, _, err := realClient.Organizations.ListInstallations(ctx, org, &github.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, inst := range installations.Installations {
+		if *inst.AppID == renovateAppID {
+			return inst, nil
+		}
+	}
+
+	return nil, microerror.Mask(installationNotFoundError)
+}
+
+func (c *Client) AddRepoToRenovatePermissions(ctx context.Context, org string, repo *github.Repository) error {
+	inst, err := c.GetRenovateInstallation(ctx, org)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	path := fmt.Sprintf("/user/installations/%d/repositories/%d", inst.GetID(), repo.GetID())
+	realClient := c.getUnderlyingClient(ctx)
+
+	req, err := realClient.NewRequest(http.MethodPut, path, nil, github.WithVersion(githubApiVersion))
+	if err != nil {
+		return err
+	}
+
+	resp, err := realClient.Do(ctx, req, nil)
+	if err != nil {
+		c.logger.Printf("response: %v", resp)
+		return err
+	}
+
+	log.Printf("response status: %q", resp.Status)
+
+	return nil
+}
+
+func (c *Client) RemoveRepoFromRenovatePermissions(ctx context.Context, org string, repo *github.Repository) error {
+	inst, err := c.GetRenovateInstallation(ctx, org)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	path := fmt.Sprintf("/user/installations/%d/repositories/%d", inst.GetID(), repo.GetID())
+	realClient := c.getUnderlyingClient(ctx)
+
+	req, err := realClient.NewRequest(http.MethodDelete, path, nil, github.WithVersion(githubApiVersion))
+	if err != nil {
+		return err
+	}
+
+	resp, err := realClient.Do(ctx, req, nil)
+	if err != nil {
+		c.logger.Printf("response: %v", resp)
+		return err
+	}
+
+	c.logger.Printf("response status: %q", resp.Status)
+
+	return nil
+}

--- a/pkg/githubclient/renovate.go
+++ b/pkg/githubclient/renovate.go
@@ -17,6 +17,8 @@ const (
 	githubApiVersion = "2022-11-28"
 )
 
+// Add repository to the Renovate installation. Corresponds to
+// https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#add-a-repository-to-an-app-installation
 func (c *Client) AddRepoToRenovatePermissions(ctx context.Context, org string, repo *github.Repository) error {
 	path := fmt.Sprintf("/user/installations/%d/repositories/%d", renovateInstallationID, repo.GetID())
 	realClient := c.getUnderlyingClient(ctx)
@@ -37,6 +39,8 @@ func (c *Client) AddRepoToRenovatePermissions(ctx context.Context, org string, r
 	return nil
 }
 
+// Remove repository from the Renovate installation. Corresponds to
+// https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#remove-a-repository-from-an-app-installation
 func (c *Client) RemoveRepoFromRenovatePermissions(ctx context.Context, org string, repo *github.Repository) error {
 	path := fmt.Sprintf("/user/installations/%d/repositories/%d", renovateInstallationID, repo.GetID())
 	realClient := c.getUnderlyingClient(ctx)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28335

This PR adds a new subcommand `devctl repo setup renovate` with the following description:

```nohighlight
This command adds the given repository to the list of repos that Renovate will have access to,
in order to allow for automatic dependency updates.

NOTE: This does not add or remove any renovate configuration to the repository.
For that, please check out:

  devctl gen renovate --help

Usage:
  devctl repo setup renovate [--remove] REPOSITORY [flags]

Examples:
  devctl setup renovate --remove giantswarm/myrepo

Flags:
  -h, --help     help for renovate
      --remove   Set this flag to disable Renovate access for the repo. Otherwise it will be enabled.

Global Flags:
      --github-token-envvar string   Environment variable name for Github token. (default "GITHUB_TOKEN")
      --log-level string             logging level (default "info")
```

This does the same as adding or removing an item to/from [this list](https://github.com/organizations/giantswarm/settings/installations/17164699):

![image](https://github.com/giantswarm/devctl/assets/273727/48dcc3bf-b8df-4542-8e70-f24c776409be)


There is a change included in the parent command, changing most flags from being persistent to just being normal flags. Otherwise all these flags would also show up in the child command, where they don't have any function.