### PR TITLE
Enable Renovate access to the repo by default when doing repo setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Edited Gitleaks to use our own repo, which removed the deprecated `set-output` command.
+- Enable Renovate to access the repo by default as part of `devctl repo setup`
 
 ## [6.13.0] - 2023-10-05
 

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -32,6 +32,9 @@ type flag struct {
 	DisableBranchProtection bool
 	Checks                  []string
 	ChecksFilter            string
+
+	// Renovate
+	SetupRenovate bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -65,6 +68,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.DisableBranchProtection, "disable-branch-protection", false, "Disable default branch protection")
 	cmd.Flags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
 	cmd.Flags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
+
+	// Renovate
+	cmd.Flags().BoolVar(&f.SetupRenovate, "renovate", true, "Sets up renovate for the repo")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -117,6 +117,14 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
+	if r.flag.SetupRenovate {
+		r.logger.Printf("Adding %s/%s to repositories accessible by Renovate...", owner, *repository.Name)
+		err = client.AddRepoToRenovatePermissions(ctx, owner, repository)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	r.logger.Info("completed repository setup")
 
 	return nil


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28585

Enables Renovate access to repos by default when performing `devctl repo setup`.

### Checklist

- [x] Update changelog in CHANGELOG.md.
