### PR TITLE
Validate documentation generated from JSON schema (for cluster apps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Validate documentation generated from JSON schema (for cluster apps)
+
 ## [6.16.0] - 2023-11-08
 
 ### Changed

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -77,6 +77,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	if r.flag.Flavours.Contains(gen.FlavourClusterApp) {
+		inputs = append(inputs, workflowsInput.ClusterAppDocumentationValidation())
 		inputs = append(inputs, workflowsInput.ClusterAppSchemaValidation())
 		inputs = append(inputs, workflowsInput.HelmRenderDiff())
 	}

--- a/pkg/gen/input/workflows/internal/file/cluster_app_documentation_validation.go
+++ b/pkg/gen/input/workflows/internal/file/cluster_app_documentation_validation.go
@@ -1,0 +1,27 @@
+package file
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/devctl/v6/pkg/gen/input"
+	"github.com/giantswarm/devctl/v6/pkg/gen/input/workflows/internal/params"
+)
+
+//go:embed cluster_app_documentation_validation.yaml.template
+var clusterAppDocumentationValidationTemplate string
+
+func NewClusterAppDocumentationValidation(p params.Params) input.Input {
+	i := input.Input{
+		Path:         params.RegenerableFileName(p, "documentation_validation.yaml"),
+		TemplateBody: clusterAppDocumentationValidationTemplate,
+		TemplateDelims: input.InputTemplateDelims{
+			Left:  "{{{{",
+			Right: "}}}}",
+		},
+		TemplateData: map[string]interface{}{
+			"Header": params.Header("#"),
+		},
+	}
+
+	return i
+}

--- a/pkg/gen/input/workflows/internal/file/cluster_app_documentation_validation.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/cluster_app_documentation_validation.yaml.template
@@ -1,0 +1,40 @@
+{{{{ .Header }}}}
+
+# This workflow validates the documentation generated from the JSON schema of the cluster-app
+# which is located in `helm/*/values.schema.json`. Specifically, it checks whether the changes
+# from `make generate-docs` were committed.
+
+name: Documentation validation
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    paths:
+      - 'helm/**/values.yaml'
+      - 'helm/**/values.schema.json'
+      - '**/*.md'  # if someone manually edited a file that should contain the generated documentation
+
+  push: {}
+
+jobs:
+  validate:
+    name: Validate documentation
+    runs-on: ubuntu-latest
+    env:
+      GO_VERSION: 1.21.3
+    steps:
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3.3.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: "Run 'make generate-docs' and check for differences"
+        run: |
+          make generate-docs
+
+          if ! git diff --exit-code; then
+            echo "ERROR: You need to commit the changes made by \"make generate-docs\"."
+            exit 1
+          fi

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -57,6 +57,10 @@ func (w *Workflows) UpdateChart() input.Input {
 	return file.NewUpdateChartInput(w.params)
 }
 
+func (w *Workflows) ClusterAppDocumentationValidation() input.Input {
+	return file.NewClusterAppDocumentationValidation(w.params)
+}
+
 func (w *Workflows) ClusterAppSchemaValidation() input.Input {
 	return file.NewClusterAppSchemaValidation(w.params)
 }


### PR DESCRIPTION
We often forget to run `make generate-docs`, so it should automatically be checked for PRs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
