### PR TITLE
Use images from gsoci.azurecr.io instead of Quay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use alpine and signcode images from gsoci.azurecr.io
+
 ## [6.18.1] - 2024-01-10
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/alpine:3.19.0
+FROM gsoci.azurecr.io/giantswarm/alpine:3.19.0
 
 COPY ./devctl /usr/bin/devctl
 

--- a/pkg/gen/input/makefile/internal/file/windows-code-signing.sh.template
+++ b/pkg/gen/input/makefile/internal/file/windows-code-signing.sh.template
@@ -5,7 +5,7 @@
 APPLICATION=$1
 VERSION=$2
 
-SIGNCODE_UTIL=quay.io/giantswarm/signcode-util:1.1.1
+SIGNCODE_UTIL=gsoci.azurecr.io/giantswarm/signcode-util:1.1.1
 
 echo "APPLICATION=${APPLICATION}"
 echo "VERSION=${VERSION}"


### PR DESCRIPTION
Towrds using gsoci.azurecr.io as the primary registry for all public images.

### Checklist

- [x] Update changelog in CHANGELOG.md.
