### PR TITLE
Include cluster-test-catalog in Compare Helm Rendering action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include cluster-test-catalog in "Compare Helm Rendering" action, so we can more easily test dev builds of subcharts.
+
 ## [6.18.3] - 2024-01-31
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/helm_render_diff.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/helm_render_diff.yaml.template
@@ -99,6 +99,9 @@ jobs:
           mkdir -p /tmp/${{ matrix.values }}
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog/
+          # We also cluster-test-catalog so we can more easily test dev builds of subcharts.
+          # Charts from cluster-test-catalog should be used only for testing purposes.
+          helm repo add cluster-test-catalog https://giantswarm.github.io/cluster-test-catalog/
           helm dependency build helm/${{ github.event.repository.name }}
           helm template -n org-giantswarm -f "helm/${{ github.event.repository.name }}/ci/ci-values.yaml" -f "${{ matrix.values }}" "helm/${{ github.event.repository.name }}" > /tmp/${{ matrix.values }}/render-new.yaml
       - uses: actions/checkout@v4

--- a/pkg/gen/input/workflows/internal/file/helm_render_diff.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/helm_render_diff.yaml.template
@@ -99,9 +99,11 @@ jobs:
           mkdir -p /tmp/${{ matrix.values }}
           # TODO split files by "API"_"KIND"_"NAMESPACE|clusterwide"_"NAME"
           helm repo add cluster-catalog https://giantswarm.github.io/cluster-catalog/
-          # We also cluster-test-catalog so we can more easily test dev builds of subcharts.
+
+          # We also add cluster-test-catalog so we can more easily test dev builds of subcharts.
           # Charts from cluster-test-catalog should be used only for testing purposes.
           helm repo add cluster-test-catalog https://giantswarm.github.io/cluster-test-catalog/
+
           helm dependency build helm/${{ github.event.repository.name }}
           helm template -n org-giantswarm -f "helm/${{ github.event.repository.name }}/ci/ci-values.yaml" -f "${{ matrix.values }}" "helm/${{ github.event.repository.name }}" > /tmp/${{ matrix.values }}/render-new.yaml
       - uses: actions/checkout@v4


### PR DESCRIPTION
Include cluster-test-catalog in "Compare Helm Rendering" action, so we can more easily test dev builds of subcharts in cluster-\<provider\> apps.

### Checklist

- [x] Update changelog in CHANGELOG.md.
