### PR TITLE
Update actions/setup-go to v5 in generated workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add a new permission for workflows to be able to write in the repo
+- Update actions/setup-go to v5 in generated workflows
 
 ## [6.22.0] - 2024-03-11
 

--- a/pkg/gen/input/workflows/internal/file/cluster_app_documentation_validation.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/cluster_app_documentation_validation.yaml.template
@@ -25,7 +25,7 @@ jobs:
       GO_VERSION: 1.21.3
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v3.3.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -294,7 +294,7 @@ jobs:
           binary: "architect"
           version: "6.14.1"
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v3.3.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -140,7 +140,7 @@ jobs:
     env:
       architect_flags: "--organisation ${{ github.repository_owner }} --project ${{ needs.gather_facts.outputs.repo_name }}"
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '=1.18.1'
       - name: Install architect


### PR DESCRIPTION
The version we uses creates deprecation warnings, as it uses Node v16.

### Checklist

- [x] Update changelog in CHANGELOG.md.
