### PR TITLE
Added a default providers array to apptest config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a default providers array to E2E apptest config
+
 ## [6.23.0] - 2024-03-15
 
 ### Changed

--- a/pkg/gen/input/apptest/internal/file/config.yaml.template
+++ b/pkg/gen/input/apptest/internal/file/config.yaml.template
@@ -1,3 +1,7 @@
 appName: {{ .appName | printf "%q" }}
 repoName: {{ .repoName | printf "%q" }}
 appCatalog: {{ .catalog | printf "%q" }}
+
+# CAPI providers to test against when triggering `/run app-test-suites` from a PR
+providers:
+- capa


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3268

Include the `providers` property on the apptest config file to indicate what providers are tested against.

### Checklist

- [x] Update changelog in CHANGELOG.md.
