### PR TITLE
Remove version from generated header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pin generated GitHub Action workflows to SHAs.
 - Rename GitHub Action `jungwinter` to `winterjung`.
+- Header of generated files no longer includes devctl version number.
 
 ## [6.23.2] - 2024-03-21
 

--- a/pkg/gen/internal/key.go
+++ b/pkg/gen/internal/key.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/giantswarm/devctl/v6/pkg/project"
 )
 
 const (
@@ -26,9 +24,7 @@ func FileName(dir, name string) string {
 
 func Header(comment string) string {
 	return strings.Join([]string{
-		comment + " DO NOT EDIT. Generated with:",
-		comment,
-		comment + "    devctl@" + project.Version(),
+		comment + " DO NOT EDIT. Generated with devctl.",
 		comment,
 	}, "\n")
 }


### PR DESCRIPTION
This change removes the version number from the generated header.

Before this, many "Align files" PRs consist of meaningless changes like this one:

![image](https://github.com/giantswarm/devctl/assets/273727/7adc2dcf-de98-48d2-a847-83f6dff8093c)

### Checklist

- [x] Update changelog in CHANGELOG.md.
