### PR TITLE
Ensure CI webhook secret is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Set the CI webhook secret
+- Made `generate-go` Make task show up in `make help` and added a note to the readme about the template generation.
 
 ## [6.25.0] - 2024-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set the CI webhook secret
+
 ## [6.25.0] - 2024-04-18
 
 ### Added

--- a/Makefile.zzz.custom.mk
+++ b/Makefile.zzz.custom.mk
@@ -1,4 +1,5 @@
-generate-go:
+.PHONY: generate-go
+generate-go: # Generate template files needed to run
 	go generate ./...
 
 $(SOURCES): generate-go

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Also see the [docs](docs/) folder for more details on some commands.
 ```nohighlight
 devctl version update
 ```
+
+### Development
+
+While running locally during development you may get some errors relating to `no matching files found` for some of the templates. If you do run `make generate-go` to generate these template files before running.

--- a/cmd/repo/setup/ciwebhooks/runner.go
+++ b/cmd/repo/setup/ciwebhooks/runner.go
@@ -75,7 +75,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			URL:         &r.flag.WebhookURL,
 			ContentType: github.String("json"),
 			InsecureSSL: github.String("0"),
-			Secret:      github.String(""),
+			Secret:      github.String(r.flag.WebhookSharedSecret),
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/30593

* Sets the CI webhook secret on the GitHub webhook configuration (doh! Forgot to pass it through previously)
* Added some notes about now needing to run `make generate-go` when running locally during development.

### Checklist

- [x] Update changelog in CHANGELOG.md.
