### PR TITLE
Fix generated headers: Fetch whole git history for devctl

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -296,6 +296,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ env.TAG }}
+          fetch-depth: 0 # devctl specific, we need the whole git history for generating the correct urls in header templates
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Specify package file name based on platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add logic to fetch the whole git history when generating the "Create Release" GitHub actions workflow file for devctl.
+- Fetch whole git history for releases to fix GitHub Urls in templated file headers.
+
 ## [6.26.0] - 2024-04-24
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	_ "embed"
+	"strings"
 
 	"github.com/giantswarm/devctl/v6/pkg/gen/input"
 	"github.com/giantswarm/devctl/v6/pkg/gen/input/workflows/internal/params"
@@ -27,6 +28,7 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 			"EnableFloatingMajorVersionTags": params.EnableFloatingMajorVersionTags(p),
 			"IsFlavourCLI":                   params.IsFlavourCLI(p),
 			"StepSetUpGitIdentity":           params.StepSetUpGitIdentity(),
+			"IsDevctl":                       strings.HasPrefix(createReleaseTemplateSha, "https://github.com/giantswarm/devctl"),
 		},
 	}
 

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -301,6 +301,9 @@ jobs:
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           ref: ${{ env.TAG }}
+{{{{- if .IsDevctl }}}}
+          fetch-depth: 0 # devctl specific, we need the whole git history for generating the correct urls in header templates
+{{{{- end }}}}
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Specify package file name based on platform


### PR DESCRIPTION
This PR is a fix and follow up to #894

I suspect missing git history causing wrong git urls generated. As of now the header urls contain the commit of the release. We want the commit which last changed a file.

### Checklist

- [x] Update changelog in CHANGELOG.md.
