### PR TITLE
Only populate main branch for GitHub Url generation

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -296,7 +296,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ env.TAG }}
-          fetch-depth: 0 # devctl specific, we need the whole git history for generating the correct urls in header templates
+      # devctl specific, we need the whole git history of branch `main` for generating the correct urls in header templates
+      - name: Fetch main branch
+        run: "git fetch origin main --unshallow"
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}
       - name: Specify package file name based on platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only fetch `main` branch in GitHub actions workflow for devctl releases
+
 ## [6.26.1] - 2024-04-25
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -302,7 +302,9 @@ jobs:
         with:
           ref: ${{ env.TAG }}
 {{{{- if .IsDevctl }}}}
-          fetch-depth: 0 # devctl specific, we need the whole git history for generating the correct urls in header templates
+      # devctl specific, we need the whole git history of branch `main` for generating the correct urls in header templates
+      - name: Fetch main branch
+        run: "git fetch origin main --unshallow"
 {{{{- end }}}}
       - name: Create ${{ matrix.platform }} package
         run: make package-${{ matrix.platform }}


### PR DESCRIPTION
Follow up to #942 and #894 

Only fetch `main` branch in git history. Otherwise all changes on all branches are considered for generating the GitHub url in headers.

### Checklist

- [x] Update changelog in CHANGELOG.md.
