### PR TITLE
Makefile.gen.go: -trimpath for binary size and reproducibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `-trimpath` flag to `go build` in generated Makefile for Go.
+
 ## [6.26.4] - 2024-06-13
 
 - Updates in referenced actions and dependencies

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -64,15 +64,15 @@ $(APPLICATION)-windows-amd64.exe: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 
 $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	@echo "====> $@"
-	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ .
 
 $(APPLICATION)-v$(VERSION)-%-arm64: $(SOURCES)
 	@echo "====> $@"
-	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ .
 
 $(APPLICATION)-v$(VERSION)-windows-amd64.exe: $(SOURCES)
 	@echo "====> $@"
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ .
 
 {{- if .IsFlavourCLI }}
 


### PR DESCRIPTION
### Summary

Adds the `-trimpath` flag to the generated Makefile for Go projects.

Go's `-trimpath` feature removes the local segments from dependency paths when building. This can reduce binary size by megabytes (for some projects) and generally aids reproducability.

This is the help entry for the compiler feature:
```
	-trimpath
		remove all file system paths from the resulting executable.
		Instead of absolute file system paths, the recorded file names
		will begin either a module path@version (when using modules),
		or a plain import path (when using the standard library, or GOPATH).
```

The feature should be stable, at least since [Go1.18](https://github.com/golang/go/milestone/201), and a handful of our projects are already using it.

I could find only one known issue when using the feature: LDFLAGS are currently not retained, e.g. not displayed in `go version -m {SOME_BINARY}`. However, this should mostly matter when enabling `CGO`, which our Makefiles explicitly disable.

**EDIT:** I stole this trick from here: https://github.com/gohugoio/hugo/issues/12406#issuecomment-2225799993

### Checklist

- [x] Update changelog in CHANGELOG.md.
