### PR TITLE
Bump github.com/marwan-at-work/mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Include replace directives in apptest generated go.mo
+- Bump `github.com/marwan-at-work/mod/cmd/mod` to `v0.7.1` in create release pr template, to fix compatibility with Go 1.23
 
 ### Changed
 

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -200,7 +200,7 @@ jobs:
       - name: Bump go module defined in go.mod if needed
         run: |
           if [ "${{ needs.gather_facts.outputs.needs_major_bump }}" = true ] && test -f "go.mod"; then
-            go install github.com/marwan-at-work/mod/cmd/mod@v0.5.0
+            go install github.com/marwan-at-work/mod/cmd/mod@v0.7.1
             mod upgrade
           fi
 {{{{ .StepSetUpGitIdentity }}}}


### PR DESCRIPTION
Currently, "Create release PR" fails for a major release. This update seems to fix it.

The error we see with 0.5.0:

```
$ mod upgrade
could not get go.mod file: could not parse go.mod file: go.mod:3: invalid go version '1.22.0': must match format 1.23
go.mod:5: unknown directive: toolchain
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
