### PR TITLE
Update Go and architect in Create release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Go and architect in "Create release PR" workflow template
+
 ## [6.27.1] - 2024-08-22
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.yaml.template
@@ -142,12 +142,12 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '=1.18.1'
+          go-version: '=1.23'
       - name: Install architect
         uses: giantswarm/install-binary-action@c37eb401e5092993fc76d545030b1d1769e61237 # v3.0.0
         with:
           binary: "architect"
-          version: "6.11.0"
+          version: "6.17.0"
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:


### PR DESCRIPTION
Looks like the Go version used in the workflow is too old. My attempt to make a major release still failed:

https://github.com/giantswarm/kubectl-gs/actions/runs/10506062426/job/29104935865

```
err: exit status 1: stderr: go: errors parsing go.mod:
/home/runner/work/kubectl-gs/kubectl-gs/go.mod:3: invalid go version '1.22.0': must match format 1.23
/home/runner/work/kubectl-gs/kubectl-gs/go.mod:5: unknown directive: toolchain
```

Also the architect-version is behind, so I'm updating it along the way.

### Checklist

- [x] Update changelog in CHANGELOG.md.
