### PR TITLE
Add `cluster-*` charts as choosable values for `devctl release create --component`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cluster-*` charts as choosable values for `devctl release create --component`
+
 ## [6.27.2] - 2024-08-22
 
 ### Changed

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -294,6 +294,36 @@ var knownComponentParseParams = map[string]parseParams{
 		start:     commonStartPattern,
 		end:       commonEndPattern,
 	},
+	"cluster-aws": {
+		tag:       "https://github.com/giantswarm/cluster-aws/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-aws/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
+	"cluster-azure": {
+		tag:       "https://github.com/giantswarm/cluster-azure/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-azure/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
+	"cluster-cloud-director": {
+		tag:       "https://github.com/giantswarm/cluster-cloud-director/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-cloud-director/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
+	"cluster-eks": {
+		tag:       "https://github.com/giantswarm/cluster-eks/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-eks/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
+	"cluster-vsphere": {
+		tag:       "https://github.com/giantswarm/cluster-vsphere/releases/tag/v{{.Version}}",
+		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-vsphere/v{{.Version}}/CHANGELOG.md",
+		start:     commonStartPattern,
+		end:       commonEndPattern,
+	},
 }
 
 // Data about a component passed into templates that depend on versions


### PR DESCRIPTION
Before:

```
$ cd ~/dev/gs/releases && devctl release create --provider capa --name 25.1.1 --base 25.1.0 --component cluster-aws@2.1.0-ad1571df5d47455b16359b9fbed78991f66817a9
Error: Unknown component: cluster-aws
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
