### PR TITLE
Do not duplicate release info in `releases.json` when re-creating a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not duplicate release info in `releases.json` when re-creating a release
+
 ## [7.1.1] - 2025-01-23
 
 ### Fixed

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -182,6 +183,11 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		ChangelogUrl:     fmt.Sprintf("https://github.com/giantswarm/releases/blob/master/%s/%s/README.md", provider, releaseDirectory),
 		IsStable:         true,
 	}
+
+	// Replace if it's already there
+	releasesJson.Releases = slices.DeleteFunc(releasesJson.Releases, func(releaseJson ReleaseJsonInfo) bool {
+		return releaseJson.Version == newReleaseInfo.Version
+	})
 
 	releasesJson.Releases = append(releasesJson.Releases, newReleaseInfo)
 


### PR DESCRIPTION
My common workflow is

```
rm -rf capa/v29.6.0; devctl release create --provider aws --name 29.6.0 --base 29.5.0 # [... new component versions ...]
```

and I assume people will do this more often now that a single command can create the desired outcome without manual work.

This however appends multiple times to `releases.json` instead of being idempotent. This change overwrites the previously-inserted version in the above case.

### Checklist

- [x] Update changelog in CHANGELOG.md.
