### PR TITLE
Adapt for golangci-lint v2

### DIFF
--- a/cmd/replace/runner.go
+++ b/cmd/replace/runner.go
@@ -91,7 +91,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				return nil
 			}
 
-			fmt.Fprintf(r.stderr, "Processing file %q.\n", file)
+			_, _ = fmt.Fprintf(r.stderr, "Processing file %q.\n", file)
 			err = r.processFile(file, regex, replacement)
 			if err != nil {
 				return microerror.Mask(err)
@@ -119,7 +119,7 @@ func (r *runner) processFile(fileName string, regex *regexp.Regexp, replacement 
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	content, err := io.ReadAll(f)
 	if err != nil {
@@ -131,7 +131,7 @@ func (r *runner) processFile(fileName string, regex *regexp.Regexp, replacement 
 	// When --inplace flag isn't specified print replacement to stdout and
 	// return.
 	if !r.flag.InPlace {
-		fmt.Fprintf(r.stdout, "%s", replaced)
+		_, _ = fmt.Fprintf(r.stdout, "%s", replaced)
 
 		return nil
 	}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -95,10 +95,10 @@ func (r *runner) persistentPreRun(ctx context.Context, cmd *cobra.Command, args 
 
 	latestVersion, err := updaterService.GetLatest()
 	if updater.IsHasNewVersion(err) {
-		fmt.Fprintf(r.stderr, "If you know what you are doing you can disable this check by exporting %s=%s\n", env.DevctlUnsafeForceVersion.Key(), project.Version())
-		fmt.Fprintf(r.stderr, "Current version:  %s\n", project.Version())
-		fmt.Fprintf(r.stderr, "Latest version:   %s\n", latestVersion)
-		fmt.Fprintf(r.stderr, "Please update your %s with \"%s version update\"\n", project.Name(), project.Name())
+		_, _ = fmt.Fprintf(r.stderr, "If you know what you are doing you can disable this check by exporting %s=%s\n", env.DevctlUnsafeForceVersion.Key(), project.Version())
+		_, _ = fmt.Fprintf(r.stderr, "Current version:  %s\n", project.Version())
+		_, _ = fmt.Fprintf(r.stderr, "Latest version:   %s\n", latestVersion)
+		_, _ = fmt.Fprintf(r.stderr, "Please update your %s with \"%s version update\"\n", project.Name(), project.Name())
 
 		return microerror.Mask(err)
 	} else if err != nil {

--- a/cmd/version/check/runner.go
+++ b/cmd/version/check/runner.go
@@ -63,21 +63,21 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	_, err = updaterService.GetLatest()
 	if updater.IsHasNewVersion(err) {
-		color.New(color.Bold, color.FgYellow).Fprintf(r.stderr, "There's a new version available!\n") //nolint:errcheck
-		fmt.Fprintf(r.stderr, "Run \"%s version update\" to update to the latest version.\n", project.Name())
+		_, _ = color.New(color.Bold, color.FgYellow).Fprintf(r.stderr, "There's a new version available!\n")
+		_, _ = fmt.Fprintf(r.stderr, "Run \"%s version update\" to update to the latest version.\n", project.Name())
 
 		os.Exit(125)
 	} else if updater.IsVersionNotFound(err) {
-		color.New(color.Bold, color.FgRed).Fprintf(r.stderr, "Checking for the latest version failed or your platform is unsupported.\n") //nolint:errcheck
-		fmt.Fprintf(r.stderr, "Make sure your GitHub token has access to the %s repository.\n", project.Name())
+		_, _ = color.New(color.Bold, color.FgRed).Fprintf(r.stderr, "Checking for the latest version failed or your platform is unsupported.\n")
+		_, _ = fmt.Fprintf(r.stderr, "Make sure your GitHub token has access to the %s repository.\n", project.Name())
 
 		return microerror.Mask(err)
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 
-	color.New(color.Bold, color.FgGreen).Fprintf(r.stdout, "You are already using the latest version.\n") //nolint:errcheck
-	fmt.Fprintf(r.stdout, "There are no newer versions available.\n")
+	_, _ = color.New(color.Bold, color.FgGreen).Fprintf(r.stdout, "You are already using the latest version.\n")
+	_, _ = fmt.Fprintf(r.stdout, "There are no newer versions available.\n")
 
 	return nil
 }

--- a/cmd/version/runner.go
+++ b/cmd/version/runner.go
@@ -37,11 +37,11 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	fmt.Fprintf(r.stdout, "Version:        %s\n", project.Version())
-	fmt.Fprintf(r.stdout, "Git Commit:     %s\n", project.GitSHA())
-	fmt.Fprintf(r.stdout, "Go Version:     %s\n", runtime.Version())
-	fmt.Fprintf(r.stdout, "OS / Arch:      %s / %s\n", runtime.GOOS, runtime.GOARCH)
-	fmt.Fprintf(r.stdout, "Source:         %s\n", project.Source())
+	_, _ = fmt.Fprintf(r.stdout, "Version:        %s\n", project.Version())
+	_, _ = fmt.Fprintf(r.stdout, "Git Commit:     %s\n", project.GitSHA())
+	_, _ = fmt.Fprintf(r.stdout, "Go Version:     %s\n", runtime.Version())
+	_, _ = fmt.Fprintf(r.stdout, "OS / Arch:      %s / %s\n", runtime.GOOS, runtime.GOARCH)
+	_, _ = fmt.Fprintf(r.stdout, "Source:         %s\n", project.Source())
 
 	return nil
 }

--- a/cmd/version/update/runner.go
+++ b/cmd/version/update/runner.go
@@ -63,8 +63,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	// Get the latest version number.
 	latestVersion, err := updaterService.GetLatest()
 	if updater.IsHasNewVersion(err) {
-		fmt.Fprintf(r.stdout, "Update to %s has been started.\n", latestVersion)
-		fmt.Fprintf(r.stdout, "Fetching latest built binary...\n")
+		_, _ = fmt.Fprintf(r.stdout, "Update to %s has been started.\n", latestVersion)
+		_, _ = fmt.Fprintf(r.stdout, "Fetching latest built binary...\n")
 
 		// Install the latest available version.
 		err = updaterService.InstallLatest()
@@ -72,18 +72,18 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 
-		color.New(color.FgGreen).Fprintf(r.stdout, "Updated successfully.\n") //nolint:errcheck
+		_, _ = color.New(color.FgGreen).Fprintf(r.stdout, "Updated successfully.\n")
 
 		return nil
 	} else if updater.IsVersionNotFound(err) {
-		fmt.Fprintf(r.stderr, "Checking for the latest version failed or your platform is unsupported.\n")
-		fmt.Fprintf(r.stderr, "Make sure your GitHub token has access to the %s repository.\n", project.Name())
+		_, _ = fmt.Fprintf(r.stderr, "Checking for the latest version failed or your platform is unsupported.\n")
+		_, _ = fmt.Fprintf(r.stderr, "Make sure your GitHub token has access to the %s repository.\n", project.Name())
 
 		return microerror.Mask(err)
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else {
-		fmt.Fprintf(r.stdout, "You are already using the latest version.\n")
+		_, _ = fmt.Fprintf(r.stdout, "You are already using the latest version.\n")
 
 		return nil
 	}

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -35,7 +35,7 @@ func execute(ctx context.Context, file input.Input) error {
 	// itself is a directory. Error if it is.
 	{
 		dir := path.Dir(file.Path)
-		err := os.MkdirAll(dir, 0755)
+		err := os.MkdirAll(dir, 0750)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -63,7 +63,7 @@ func execute(ctx context.Context, file input.Input) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	err = internal.Execute(ctx, w, file)
 	if err != nil {

--- a/pkg/gen/input/ami/funcs.go
+++ b/pkg/gen/input/ami/funcs.go
@@ -96,10 +96,10 @@ func scrapeVersions(source io.Reader) ([]string, error) {
 	var versions []string
 	for {
 		tt := z.Next()
-		switch {
-		case tt == html.ErrorToken:
+		switch tt {
+		case html.ErrorToken:
 			return versions, nil
-		case tt == html.StartTagToken:
+		case html.StartTagToken:
 			t := z.Token()
 			if t.Data != "a" {
 				continue

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -63,7 +63,7 @@ func (c *Client) GetRepository(ctx context.Context, owner, repo string) (*github
 
 	repository, response, err := underlyingClient.Repositories.Get(ctx, owner, repo)
 	if err != nil {
-		if response != nil && response.Response != nil && response.Response.StatusCode == http.StatusNotFound {
+		if response != nil && response.Response != nil && response.StatusCode == http.StatusNotFound {
 			return nil, microerror.Mask(notFoundError)
 		}
 		return nil, microerror.Mask(err)

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -340,7 +340,7 @@ func getLatestFlatcarRelease() (string, error) {
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	type release struct {
 		Channel string

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -359,7 +359,7 @@ func ParseChangelog(componentName, currentVersion, endVersion string) (*Version,
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -97,7 +97,7 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 	}
 
 	// Release directory
-	err = os.Mkdir(releasePath, 0755)
+	err = os.Mkdir(releasePath, 0750)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -165,6 +165,7 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 
 	// Update releases.json
 	releasesJSONPath := filepath.Join(providerDirectory, "releases.json")
+	releasesJSONPath = filepath.Clean(releasesJSONPath)
 	releasesData, err := os.ReadFile(releasesJSONPath)
 	if err != nil {
 		return microerror.Mask(err)
@@ -179,7 +180,7 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 	newReleaseInfo := ReleaseJsonInfo{
 		Version:          newVersion.String(),
 		IsDeprecated:     false,
-		ReleaseTimestamp: now.Time.Format(time.RFC3339),
+		ReleaseTimestamp: now.Format(time.RFC3339),
 		ChangelogUrl:     fmt.Sprintf("https://github.com/giantswarm/releases/blob/master/%s/%s/README.md", provider, releaseDirectory),
 		IsStable:         true,
 	}

--- a/pkg/release/kustomize.go
+++ b/pkg/release/kustomize.go
@@ -56,6 +56,7 @@ replacements:
 func addToKustomization(providerDirectory string, release v1alpha1.Release) error {
 	path := filepath.Join(providerDirectory, "kustomization.yaml")
 	var providerKustomization kustomizationFile
+	path = filepath.Clean(path)
 	providerKustomizationData, err := os.ReadFile(path)
 	if err != nil {
 		return microerror.Mask(err)
@@ -89,6 +90,7 @@ func addToKustomization(providerDirectory string, release v1alpha1.Release) erro
 func removeFromKustomization(providerDirectory string, release v1alpha1.Release) error {
 	path := filepath.Join(providerDirectory, "kustomization.yaml")
 	var providerKustomization kustomizationFile
+	path = filepath.Clean(path)
 	providerKustomizationData, err := os.ReadFile(path)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -130,6 +130,7 @@ func findRelease(providerDirectory string, targetVersion semver.Version) (v1alph
 		return v1alpha1.Release{}, "", releaseNotFoundError
 	}
 
+	releaseYAMLPath = filepath.Clean(releaseYAMLPath)
 	releaseYAML, err := os.ReadFile(releaseYAMLPath)
 	if err != nil {
 		return v1alpha1.Release{}, "", microerror.Mask(err)

--- a/pkg/updater/cache.go
+++ b/pkg/updater/cache.go
@@ -52,6 +52,7 @@ func (c *cache) Persist(cacheDir string) error {
 func (c *cache) Restore(fromPath string) error {
 	in := filepath.Join(fromPath, cacheFileName)
 
+	in = filepath.Clean(in)
 	serialized, err := os.ReadFile(in)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32968

There is one left which I don't know how to mitigate:

```nohighlight
cmd/replace/runner.go:119:12: G304: Potential file inclusion via variable (gosec)
        f, err := os.OpenFile(fileName, flag, 0)
                  ^
```