### PR TITLE
Add LLM agent rule generation

### DIFF
--- a/cmd/gen/command.go
+++ b/cmd/gen/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/devctl/v7/cmd/gen/ami"
 	"github.com/giantswarm/devctl/v7/cmd/gen/apptest"
 	"github.com/giantswarm/devctl/v7/cmd/gen/dependabot"
+	"github.com/giantswarm/devctl/v7/cmd/gen/llm"
 	"github.com/giantswarm/devctl/v7/cmd/gen/makefile"
 	"github.com/giantswarm/devctl/v7/cmd/gen/renovate"
 	"github.com/giantswarm/devctl/v7/cmd/gen/workflows"
@@ -54,6 +55,20 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var apptestCmd *cobra.Command
+	{
+		c := apptest.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		apptestCmd, err = apptest.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var dependabotCmd *cobra.Command
 	{
 		c := dependabot.Config{
@@ -63,6 +78,20 @@ func New(config Config) (*cobra.Command, error) {
 		}
 
 		dependabotCmd, err = dependabot.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var llmCmd *cobra.Command
+	{
+		c := llm.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		llmCmd, err = llm.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -109,20 +138,6 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
-	var apptestCmd *cobra.Command
-	{
-		c := apptest.Config{
-			Logger: config.Logger,
-			Stderr: config.Stderr,
-			Stdout: config.Stdout,
-		}
-
-		apptestCmd, err = apptest.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	f := &flag{}
 
 	r := &runner{
@@ -143,6 +158,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	c.AddCommand(amiCmd)
 	c.AddCommand(dependabotCmd)
+	c.AddCommand(llmCmd)
 	c.AddCommand(makefileCmd)
 	c.AddCommand(renovateCmd)
 	c.AddCommand(workflowsCmd)

--- a/cmd/gen/llm/command.go
+++ b/cmd/gen/llm/command.go
@@ -1,0 +1,59 @@
+package llm
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name             = "llm"
+	shortDescription = `Generates rules for LLM assistants.`
+	longDescription  = `Generates rules for LLM assistants.
+
+devctl gen llm --flavour app --language go
+
+A base rule set is always generated. Some flavour- and language-specific rule sets are also supported.
+`
+)
+
+type Config struct {
+	Logger micrologger.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: shortDescription,
+		Long:  longDescription,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/gen/llm/error.go
+++ b/cmd/gen/llm/error.go
@@ -1,0 +1,21 @@
+package llm
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}

--- a/cmd/gen/llm/flag.go
+++ b/cmd/gen/llm/flag.go
@@ -1,0 +1,34 @@
+package llm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/devctl/v7/pkg/gen"
+)
+
+const (
+	flagFlavour  = "flavour"
+	flagLanguage = "language"
+)
+
+type flag struct {
+	Flavours gen.FlavourSlice
+	Language string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`The type of project that you want to generate rules for. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
+	cmd.Flags().StringVarP(&f.Language, flagLanguage, "l", "", "Language of the repo, for generating additional language-specific rules.")
+}
+
+func (f *flag) Validate() error {
+	if len(f.Flavours) == 0 {
+		return microerror.Maskf(invalidFlagError, "--%s must be one of: %s", flagFlavour, strings.Join(gen.AllFlavours(), ", "))
+	}
+
+	return nil
+}

--- a/cmd/gen/llm/runner.go
+++ b/cmd/gen/llm/runner.go
@@ -1,0 +1,85 @@
+package llm
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/devctl/v7/pkg/gen"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input/llm"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	var llmInput *llm.LLM
+	{
+		c := llm.Config{
+			Flavours: r.flag.Flavours,
+			Language: r.flag.Language,
+		}
+
+		llmInput, err = llm.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	inputs := []input.Input{
+		llmInput.BaseLLMRules(),
+	}
+
+	// Add additional rules files for different flavours and languages
+	if r.flag.Language == "go" {
+		inputs = append(inputs, llmInput.GoSpecificRules())
+	}
+
+	// if r.flag.Language == "typescript" || r.flag.Language == "javascript" {
+	// 	inputs = append(inputs, llmInput.TypeScriptRules())
+	// }
+
+	// if r.flag.Flavours.Contains(gen.FlavourApp) {
+	// 	inputs = append(inputs, llmInput.AppRules())
+	// }
+
+	// if r.flag.Flavours.Contains(gen.FlavourClusterApp) {
+	// 	inputs = append(inputs, llmInput.ClusterAppRules())
+	// }
+
+	err = gen.Execute(
+		ctx,
+		inputs...,
+	)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/gen/input/llm/internal/file/base_llm_rules.go
+++ b/pkg/gen/input/llm/internal/file/base_llm_rules.go
@@ -1,0 +1,30 @@
+package file
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/devctl/v7/pkg/gen/input"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input/llm/internal/params"
+)
+
+//go:embed base_llm_rules.mdc.template
+var baseLLMRulesTemplate string
+
+//go:generate go run ../../../update-template-sha.go base_llm_rules.mdc.template
+//go:embed base_llm_rules.mdc.template.sha
+var baseLLMRulesTemplateSha string
+
+func NewBaseLLMRulesInput(p params.Params) input.Input {
+	i := input.Input{
+		Path:         params.RegenerableFileName(p, "base-llm-rules.mdc"),
+		TemplateBody: baseLLMRulesTemplate,
+		// SkipRegenCheck: true,
+		TemplateData: map[string]interface{}{
+			"Header":       params.Header(baseLLMRulesTemplateSha),
+			"IsLanguageGo": params.IsLanguageGo(p),
+			"Language":     p.Language,
+		},
+	}
+
+	return i
+}

--- a/pkg/gen/input/llm/internal/file/base_llm_rules.mdc.template
+++ b/pkg/gen/input/llm/internal/file/base_llm_rules.mdc.template
@@ -1,0 +1,45 @@
+{{.Header}}
+---
+description: Instructions for AI/LLM assistants
+alwaysApply: true
+---
+
+# Instructions for AI/LLM assistants
+
+You are an AI assistant acting as an expert software developer and platform engineer working on Giant Swarm platform components. Your task is to act as a pair programmer and help others working in this codebase to keep the code delightful to work with. This includes ensuring that the code adheres to Giant Swarm's quality standards, keeping the project well-architected and organized, and maintaining supporting documentation, diagrams, and rules for other AI assistants.
+
+# Persona: Senior Giant Swarm Platform Engineer
+
+- **Technical Depth**: You are a domain expert in Go (formerly, golang), Helm, Kubernetes APIs and development, software design patterns, software architecture, Go application security, software testing, and software performance optimization,
+- **Problem-Solver**: You approach issues methodically, prioritizing safety and stability. You first investigate deeply with the tools provided to you, before suggesting changes. You find and fix the root cause, not the symptoms.
+- **Clear Communicator**: You explain complex topics clearly and provide actionable steps.
+- **Collaborative**: You guide users, suggest diagnostic paths, and help them think through problems.
+- **Best Practices**: You adhere to Giant Swarm operational and technical standards.
+
+# Reviewer Guidelines
+
+## Core Behaviors
+
+- Unless directed by the user, never use or recommend external linters, code analysis, or other tooling which isn't already recommended in Giant Swarm agent rules or style guides.
+- Always adhere to the central coding guidelines and best practices maintained at: **https://github.com/giantswarm/fmt/**.
+- Prioritize readability, maintainability, and security.
+- Write comprehensive tests and documentation.
+
+### Release Management  
+- Follow the changelog and release guidelines from @https://github.com/giantswarm/fmt/tree/main/releases
+- Use semantic versioning and conventional commits
+
+## Language-Specific Guidelines
+
+Additional language-specific rules can be found in the general style guide and in the other rules files in this repository.
+
+{{if .IsLanguageGo}}
+### Go Development
+- Go code must always adhere to the Go language-specific development guidelines and patterns rules in this repository.
+
+### Go Application Security
+- Ensure all Go dependencies are up to date.
+- Follow best security practices for Go applications.
+{{ end }}
+---
+For detailed guidelines and examples, always refer to: **https://github.com/giantswarm/fmt/** 

--- a/pkg/gen/input/llm/internal/file/go_rules.go
+++ b/pkg/gen/input/llm/internal/file/go_rules.go
@@ -1,0 +1,27 @@
+package file
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/devctl/v7/pkg/gen/input"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input/llm/internal/params"
+)
+
+//go:embed go_rules.mdc.template
+var goRulesTemplate string
+
+//go:generate go run ../../../update-template-sha.go go_rules.mdc.template
+//go:embed go_rules.mdc.template.sha
+var goRulesTemplateSha string
+
+func NewGoSpecificRulesInput(p params.Params) input.Input {
+	i := input.Input{
+		Path:         params.RegenerableFileName(p, "go-llm-rules.mdc"),
+		TemplateBody: goRulesTemplate,
+		TemplateData: map[string]interface{}{
+			"Header": params.Header(goRulesTemplateSha),
+		},
+	}
+
+	return i
+}

--- a/pkg/gen/input/llm/internal/file/go_rules.mdc.template
+++ b/pkg/gen/input/llm/internal/file/go_rules.mdc.template
@@ -1,0 +1,14 @@
+{{.Header}}
+---
+description: Go language-specific development guidelines and patterns
+globs: ["**/*.go"]
+---
+
+These guidelines apply to Go code and supplement any other general development instructions or workflows.
+
+# Go Code Guidelines
+
+- All Go code is expected to adhere to the rules outlined in the Giant Swarm style guide located at @https://github.com/giantswarm/fmt/tree/main/go.
+- Always fetch and fully understand the style guide before reviewing any code.
+- The Giant Swarm style guide linked above must always be considered definitive. ALL rules and provisions contained in the style guide MUST be met.
+- When applying the style guide, always list all instances of a particular issue, grouped by the finding type.

--- a/pkg/gen/input/llm/internal/params/key.go
+++ b/pkg/gen/input/llm/internal/params/key.go
@@ -1,0 +1,25 @@
+package params
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/devctl/v7/pkg/gen/internal"
+)
+
+func RegenerableFileName(p Params, suffix string) string {
+	return internal.RegenerableFileName(p.Dir, suffix)
+}
+
+func IsLanguageGo(p Params) bool {
+	return p.Language == "go"
+}
+
+func Header(githubUrl string) string {
+	return fmt.Sprintf(`
+<!--
+DO NOT EDIT. Generated with devctl.
+This file is maintained at:
+%s
+Manual changes will be overwritten.
+-->`, githubUrl)
+}

--- a/pkg/gen/input/llm/internal/params/types.go
+++ b/pkg/gen/input/llm/internal/params/types.go
@@ -1,0 +1,15 @@
+package params
+
+import "github.com/giantswarm/devctl/v7/pkg/gen"
+
+type Params struct {
+	// Dir is the name of the directory where the files of the resource
+	// should be generated.
+	Dir string
+
+	// Flavours is the type of project that the rules are for.
+	Flavours gen.FlavourSlice
+
+	// Language is the language of the repo that the rules are for.
+	Language string
+}

--- a/pkg/gen/input/llm/llm.go
+++ b/pkg/gen/input/llm/llm.go
@@ -1,0 +1,38 @@
+package llm
+
+import (
+	"github.com/giantswarm/devctl/v7/pkg/gen"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input/llm/internal/file"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input/llm/internal/params"
+)
+
+type Config struct {
+	Flavours gen.FlavourSlice
+	Language string
+}
+
+type LLM struct {
+	params params.Params
+}
+
+func New(config Config) (*LLM, error) {
+	l := &LLM{
+		params: params.Params{
+			Dir: ".cursor/rules",
+
+			Flavours: config.Flavours,
+			Language: config.Language,
+		},
+	}
+
+	return l, nil
+}
+
+func (l *LLM) BaseLLMRules() input.Input {
+	return file.NewBaseLLMRulesInput(l.params)
+}
+
+func (l *LLM) GoSpecificRules() input.Input {
+	return file.NewGoSpecificRulesInput(l.params)
+}


### PR DESCRIPTION
2025 hAIve sprint hackathon

Generates a base set of LLM rules that try to get LLMs to use our central style guide located in `fmt`.

Supports additional generation of language- or flavour-specific rules. It is not the intent to store specific rules here in devctl -- rather, these specific rulesets should be used to direct / target the agent to resources elsewhere.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
