### PR TITLE
Releases: Fix candidate name logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Releases: Fix candidate name logic.
+
 ## [7.5.0] - 2025-07-28
 
 ### Added

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -376,11 +376,12 @@ func getLatestGithubRelease(owner string, name string) (string, error) {
 
 	client := github.NewClient(tc)
 
-	candidateNames := []string{name}
+	// Makes sure both `my-fancy-controller` and `my-fancy-controller-app` are getting looked up as `my-fancy-controller-app` and `my-fancy-controller`.
+	var candidateNames []string
 	if strings.HasSuffix(name, "-app") {
-		candidateNames = append(candidateNames, strings.TrimSuffix(name, "-app"))
+		candidateNames = []string{name, strings.TrimSuffix(name, "-app")}
 	} else {
-		candidateNames = append(candidateNames, fmt.Sprintf("%s-app", name))
+		candidateNames = []string{fmt.Sprintf("%s-app", name), name}
 	}
 
 	version := ""


### PR DESCRIPTION
This change makes sure the logic always first tries `something-app` before `something` when finding the latest GitHub Release of an app. Without this change https://github.com/giantswarm/cloud-provider-vsphere would have precedence over https://github.com/giantswarm/cloud-provider-vsphere-app for the `cloud-provider-vsphere` app in the Release CR.