### PR TITLE
Workflows: Skip release creation if already exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Workflows: Skip release creation if already exists.
+
 ## [7.5.1] - 2025-07-31
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -188,6 +188,7 @@ jobs:
         with:
           body: ${{ steps.changelog_reader.outputs.changes }}
           tag: "v${{ needs.gather_facts.outputs.version }}"
+          skipIfReleaseExists: true
 
 {{{{- if .EnableFloatingMajorVersionTags }}}}
 


### PR DESCRIPTION
In case we are creating a `release-vx.y.z` branch for back-porting something to an older version, this workflow currently fails, because the commit the minor release was created from gets pushed again and so the workflow runs again, but the release already exists.

According to upstream's documentation, one can use this flag to just skip release creation in case it already exists.