### PR TITLE
Improve release component auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `devctl release create`: Improve auto-detection of component versions to be more generic and maintainable.
+
+### Fixed
+
+- `devctl release create`: Fix auto-detection for Azure provider components.
+- `devctl release create --bumpall`: Fix an issue where dependencies were dropped for automatically bumped apps.
+- `devctl release create`: Stop parsing component changelogs when the specified `endVersion` is not found, preventing huge outputs.
+
 ## [7.6.0] - 2025-08-27
+
+### Added
+
+- `devctl release create`: Add `--yes`/`-y` flag to skip confirmation prompt for `--bumpall`.
 
 ### Changed
 
-- `devctl release create`:
-  - Drop `karpenter-nodepools` from AWS releases v32.0.0 and higher.
-  - Add generic support for dropping apps from releases based on release version.
-  - Add support for defining app dependencies via the `--app` flag.
-  - Improve help text with more detailed and accurate examples.
-- `devctl release create --bumpall`:
-  - Improve UX by coloring bumped versions green and removed apps red in the summary table.
-  - Display app dependencies in the summary table.
+- `devctl release create --bumpall`: Automatically bump `cloud-provider-*` and `cluster-autoscaler` to match the release minor version.
+
+### Fixed
+
+- `devctl release create --bumpall`: Fix an issue where dependencies were dropped for automatically bumped apps.
+- `devctl release create`: Stop parsing component changelogs when the specified `endVersion` is not found, preventing huge outputs.
 
 ## [7.5.3] - 2025-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,18 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.6.0] - 2025-08-27
 
-### Added
-
-- `devctl release create`: Add `--yes`/`-y` flag to skip confirmation prompt for `--bumpall`.
-
 ### Changed
 
-- `devctl release create --bumpall`: Automatically bump `cloud-provider-*` and `cluster-autoscaler` to match the release minor version.
-
-### Fixed
-
-- `devctl release create --bumpall`: Fix an issue where dependencies were dropped for automatically bumped apps.
-- `devctl release create`: Stop parsing component changelogs when the specified `endVersion` is not found, preventing huge outputs.
+- `devctl release create`:
+  - Drop `karpenter-nodepools` from AWS releases v32.0.0 and higher.
+  - Add generic support for dropping apps from releases based on release version.
+  - Add support for defining app dependencies via the `--app` flag.
+  - Improve help text with more detailed and accurate examples.
+- `devctl release create --bumpall`:
+  - Improve UX by coloring bumped versions green and removed apps red in the summary table.
+  - Display app dependencies in the summary table.
 
 ## [7.5.3] - 2025-08-26
 

--- a/cmd/release/create/flag.go
+++ b/cmd/release/create/flag.go
@@ -16,6 +16,7 @@ const (
 	flagProvider  = "provider"
 	flagReleases  = "releases"
 	flagBumpAll   = "bumpall"
+	flagYes       = "yes"
 )
 
 type flag struct {
@@ -27,6 +28,7 @@ type flag struct {
 	Overwrite  bool
 	Provider   string
 	Releases   string
+	Yes        bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -38,6 +40,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.BumpAll, flagBumpAll, false, `If true, automatically get a list of updated components and apps.`)
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", `Target provider for the new release.`)
 	cmd.Flags().StringVar(&f.Releases, flagReleases, ".", `Path to releases repository. Defaults to current working directory.`)
+	cmd.Flags().BoolVarP(&f.Yes, flagYes, "y", false, `If true, skip confirmation prompt.`)
 }
 
 func (f *flag) Validate() error {

--- a/cmd/release/create/runner.go
+++ b/cmd/release/create/runner.go
@@ -40,7 +40,7 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 func (r *runner) run(_ context.Context, cmd *cobra.Command, _ []string) error {
 	creationCommand := fmt.Sprintf("%v", strings.Join(os.Args, " "))
 
-	err := release.CreateRelease(r.flag.Name, r.flag.Base, r.flag.Releases, r.flag.Provider, r.flag.Components, r.flag.Apps, r.flag.Overwrite, creationCommand, r.flag.BumpAll)
+	err := release.CreateRelease(r.flag.Name, r.flag.Base, r.flag.Releases, r.flag.Provider, r.flag.Components, r.flag.Apps, r.flag.Overwrite, creationCommand, r.flag.BumpAll, r.flag.Yes)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/giantswarm/devctl/v7/pkg/githubclient"
+	"github.com/giantswarm/devctl/v7/pkg/release/changelog"
 )
 
 type componentVersion struct {
@@ -42,7 +43,7 @@ type appVersion struct {
 
 // BumpAll takes all apps and components in the `input` release and looks up on github for the latest version of each.
 // If the version is not specified in the `manuallyRequestedComponents` or `manuallyRequestedApps` it will be bumped to the latest version.
-func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manuallyRequestedApps []string, appsToDrop map[string]bool) ([]string, []string, error) {
+func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manuallyRequestedApps []string, appsToDrop map[string]bool, yes bool) ([]string, []string, error) {
 	requestedComponents := map[string]componentVersion{}
 	requestedApps := map[string]appVersion{}
 
@@ -121,8 +122,12 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 				req.UpstreamVersion = splitted[2]
 			}
 
-			if len(splitted) > 3 && splitted[3] != "" {
-				req.DependsOn = strings.Split(splitted[3], ",")
+			if len(splitted) > 3 {
+				if splitted[3] != "" {
+					req.DependsOn = strings.Split(splitted[3], ",")
+				} else {
+					req.DependsOn = []string{}
+				}
 			}
 
 			requestedApps[splitted[0]] = req
@@ -136,7 +141,11 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 				v.Version = req.Version
 				v.UpstreamVersion = req.UpstreamVersion
 				v.UserRequested = true
-				v.DependsOn = req.DependsOn
+				if req.DependsOn != nil {
+					v.DependsOn = req.DependsOn
+				} else {
+					v.DependsOn = app.DependsOn
+				}
 			} else {
 				version, err := findNewestApp(app.Name, app.ComponentVersion != "")
 				if err != nil {
@@ -181,18 +190,20 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 		return nil, nil, microerror.Mask(err)
 	}
 
-	var char rune
-	for string(char) != "y" && string(char) != "Y" && string(char) != "n" && string(char) != "N" {
-		fmt.Print("Do you want to continue? (y/n)")
-		reader := bufio.NewReader(os.Stdin)
-		char, _, err = reader.ReadRune()
-		if err != nil {
-			return nil, nil, microerror.Mask(err)
+	if !yes {
+		var char rune
+		for string(char) != "y" && string(char) != "Y" && string(char) != "n" && string(char) != "N" {
+			fmt.Print("Do you want to continue? (y/n)")
+			reader := bufio.NewReader(os.Stdin)
+			char, _, err = reader.ReadRune()
+			if err != nil {
+				return nil, nil, microerror.Mask(err)
+			}
 		}
-	}
 
-	if string(char) == "n" || string(char) == "N" {
-		return nil, nil, nil
+		if string(char) == "n" || string(char) == "N" {
+			return nil, nil, nil
+		}
 	}
 
 	fmt.Println("Generating release")
@@ -460,12 +471,23 @@ func getLatestGithubRelease(owner string, name string) (string, error) {
 
 	client := github.NewClient(tc)
 
-	// Makes sure both `my-fancy-controller` and `my-fancy-controller-app` are getting looked up as `my-fancy-controller-app` and `my-fancy-controller`.
 	var candidateNames []string
-	if strings.HasSuffix(name, "-app") {
-		candidateNames = []string{name, strings.TrimSuffix(name, "-app")}
-	} else {
-		candidateNames = []string{fmt.Sprintf("%s-app", name), name}
+	{
+		var repo string
+		var newOwner string
+		newOwner, repo = changelog.GetRepoName(name)
+		if repo != "" {
+			owner = newOwner
+			candidateNames = []string{repo}
+		} else {
+			owner = "giantswarm"
+			// Fallback to old logic if not in map.
+			if strings.HasSuffix(name, "-app") {
+				candidateNames = []string{name, strings.TrimSuffix(name, "-app")}
+			} else {
+				candidateNames = []string{fmt.Sprintf("%s-app", name), name}
+			}
+		}
 	}
 
 	version := ""
@@ -494,9 +516,9 @@ func getLatestGithubRelease(owner string, name string) (string, error) {
 	return version, nil
 }
 
-// getKubernetesVersionForMinor fetches the latest patch version for a given Kubernetes minor version
+// getLatestReleaseForMinor fetches the latest patch version for a given minor version of a component.
 // e.g., for minorVersion "1.31", it might return "1.31.9"
-func getKubernetesVersionForMinor(minorVersion string) (string, error) {
+func getLatestReleaseForMinor(owner, repo, minorVersion string) (string, error) {
 	token := os.Getenv("OPSCTL_GITHUB_TOKEN")
 
 	ctx := context.Background()
@@ -507,34 +529,68 @@ func getKubernetesVersionForMinor(minorVersion string) (string, error) {
 
 	client := github.NewClient(tc)
 
-	// Get all releases from kubernetes repository
-	opt := &github.ListOptions{
-		PerPage: 100, // Get more releases to ensure we find the latest patch
+	var candidateNames []string
+	{
+		var repoName string
+		var newOwner string
+		newOwner, repoName = changelog.GetRepoName(repo)
+		if repoName != "" {
+			owner = newOwner
+			candidateNames = []string{repoName}
+		} else {
+			// Fallback to old logic if not in map.
+			if strings.HasSuffix(repo, "-app") {
+				candidateNames = []string{repo, strings.TrimSuffix(repo, "-app")}
+			} else {
+				candidateNames = []string{fmt.Sprintf("%s-app", repo), repo}
+			}
+		}
 	}
 
 	var latestVersion string
 	var latestSemver semver.Version
+	var lastErr error
 
-	for {
-		releases, resp, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", opt)
-		if err != nil {
-			return "", microerror.Mask(err)
+	for _, repoCandidate := range candidateNames {
+		// Get all releases from the repository
+		opt := &github.ListOptions{
+			PerPage: 100, // Get more releases to ensure we find the latest patch
 		}
 
-		for _, release := range releases {
+		var releasesForCandidate []*github.RepositoryRelease
+		for {
+			releases, resp, err := client.Repositories.ListReleases(ctx, owner, repoCandidate, opt)
+			if err != nil {
+				// Check for 404 Not Found, and try the next candidate repo.
+				if ghErr, ok := err.(*github.ErrorResponse); ok && ghErr.Response.StatusCode == http.StatusNotFound {
+					lastErr = err
+					goto nextCandidate
+				}
+				// For other errors, we fail.
+				return "", microerror.Mask(err)
+			}
+
+			releasesForCandidate = append(releasesForCandidate, releases...)
+
+			if resp.NextPage == 0 {
+				break
+			}
+			opt.Page = resp.NextPage
+		}
+
+		for _, release := range releasesForCandidate {
 			if release.Name == nil {
 				continue
 			}
 
-			// Handle the "Kubernetes v1.x.y" format from kubernetes/kubernetes releases
 			versionStr := *release.Name
-			// Strip "Kubernetes " prefix if present
+			// Strip "Kubernetes " prefix if present (for kubernetes/kubernetes)
 			versionStr = strings.TrimPrefix(versionStr, "Kubernetes ")
 			// Strip "v" prefix if present
 			versionStr = strings.TrimPrefix(versionStr, "v")
 
-			// Skip pre-releases and versions that don't start with the desired minor version
-			if strings.Contains(versionStr, "-") || !strings.HasPrefix(versionStr, minorVersion+".") {
+			// Allow our -gs extensions.
+			if (strings.Contains(versionStr, "-") && !strings.Contains(versionStr, "-gs")) || !strings.HasPrefix(versionStr, minorVersion+".") {
 				continue
 			}
 
@@ -544,7 +600,8 @@ func getKubernetesVersionForMinor(minorVersion string) (string, error) {
 			}
 
 			// Check if this version matches our target minor version and is newer than what we found
-			if fmt.Sprintf("%d.%d", version.Major, version.Minor) == minorVersion {
+			currentMinor := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+			if currentMinor == minorVersion {
 				if latestVersion == "" || version.GT(latestSemver) {
 					latestSemver = version
 					latestVersion = versionStr
@@ -552,14 +609,19 @@ func getKubernetesVersionForMinor(minorVersion string) (string, error) {
 			}
 		}
 
-		if resp.NextPage == 0 {
+		// If we found a version, we can break from the candidate loop.
+		if latestVersion != "" {
 			break
 		}
-		opt.Page = resp.NextPage
+
+	nextCandidate:
 	}
 
 	if latestVersion == "" {
-		return "", microerror.Mask(fmt.Errorf("no stable release found for Kubernetes minor version %s", minorVersion))
+		if lastErr != nil {
+			return "", microerror.Mask(lastErr)
+		}
+		return "", microerror.Mask(fmt.Errorf("no stable release found for %s/%s minor version %s", owner, repo, minorVersion))
 	}
 
 	return latestVersion, nil
@@ -589,20 +651,25 @@ func extractKubernetesMinorFromReleaseName(releaseName string) string {
 	return kubernetesMinor
 }
 
-// autoDetectKubernetesVersion attempts to automatically detect and fetch the appropriate
-// Kubernetes version based on the release name pattern
-func autoDetectKubernetesVersion(releaseName string) (string, error) {
+// autoDetectVersion attempts to automatically detect and fetch the appropriate
+// version based on the release name pattern
+func autoDetectVersion(releaseName, componentName string) (string, error) {
 	kubernetesMinor := extractKubernetesMinorFromReleaseName(releaseName)
 	if kubernetesMinor == "" {
 		return "", microerror.Mask(fmt.Errorf("could not extract Kubernetes minor version from release name: %s", releaseName))
 	}
 
-	latestKubernetesVersion, err := getKubernetesVersionForMinor(kubernetesMinor)
+	owner, repoName := changelog.GetRepoName(componentName)
+	if repoName == "" {
+		return "", microerror.Mask(fmt.Errorf("could not get repository for app %s", componentName))
+	}
+
+	latestVersion, err := getLatestReleaseForMinor(owner, repoName, kubernetesMinor)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
 
-	return latestKubernetesVersion, nil
+	return latestVersion, nil
 }
 
 func getLatestFlatcarRelease() (string, error) {

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -22,328 +22,351 @@ const (
 	commonEndPattern = "(?m)^\\[.*\\]:.*$"
 )
 
-type parseParams struct {
-	tag          string
-	changelog    string
-	start        string
-	intermediate string
-	end          string
+type ParseParams struct {
+	Tag          string
+	Changelog    string
+	Start        string
+	Intermediate string
+	End          string
+	AutoDetect   bool
 }
 
 // Parameters defining how to parse and extract release info about all known components
-var knownComponentParseParams = map[string]parseParams{
+var KnownComponents = map[string]ParseParams{
 	// CAPA Provider Specific
 	"aws-ebs-csi-driver": {
-		tag:       "https://github.com/giantswarm/aws-ebs-csi-driver-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/aws-ebs-csi-driver-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"aws-ebs-csi-driver-servicemonitors": {
-		tag:       "https://github.com/giantswarm/aws-ebs-csi-driver-servicemonitors-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-servicemonitors-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/aws-ebs-csi-driver-servicemonitors-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/aws-ebs-csi-driver-servicemonitors-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"aws-nth-bundle": {
-		tag:       "https://github.com/giantswarm/aws-nth-bundle/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/aws-nth-bundle/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/aws-nth-bundle/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/aws-nth-bundle/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"aws-pod-identity-webhook": {
-		tag:       "https://github.com/giantswarm/aws-pod-identity-webhook/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/aws-pod-identity-webhook/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/aws-pod-identity-webhook/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/aws-pod-identity-webhook/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cluster-aws": {
-		tag:       "https://github.com/giantswarm/cluster-aws/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-aws/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cluster-aws/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cluster-aws/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cloud-provider-aws": {
-		tag:       "https://github.com/giantswarm/aws-cloud-controller-manager-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/aws-cloud-controller-manager-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/aws-cloud-controller-manager-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/aws-cloud-controller-manager-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 	"irsa-servicemonitors": {
-		tag:       "https://github.com/giantswarm/irsa-servicemonitors-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/irsa-servicemonitors-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/irsa-servicemonitors-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/irsa-servicemonitors-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 
 	// EKS Provider Specific
 	"cluster-eks": {
-		tag:       "https://github.com/giantswarm/cluster-eks/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-eks/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cluster-eks/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cluster-eks/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"karpenter-bundle": {
-		tag:       "https://github.com/giantswarm/karpenter-bundle/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/karpenter-bundle/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/karpenter-bundle/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/karpenter-bundle/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"karpenter-nodepools": {
-		tag:       "https://github.com/giantswarm/karpenter-nodepools/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/karpenter-nodepools/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/karpenter-nodepools/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/karpenter-nodepools/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 
 	// CAPZ Provider Specific
 	"cluster-azure": {
-		tag:       "https://github.com/giantswarm/cluster-azure/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-azure/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cluster-azure/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cluster-azure/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"azure-cloud-controller-manager": {
-		tag:       "https://github.com/giantswarm/azure-cloud-controller-manager-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/azure-cloud-controller-manager-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/azure-cloud-controller-manager-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/azure-cloud-controller-manager-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 	"azure-cloud-node-manager": {
-		tag:       "https://github.com/giantswarm/azure-cloud-node-manager-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/azure-cloud-node-manager-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/azure-cloud-node-manager-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/azure-cloud-node-manager-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 	"azuredisk-csi-driver": {
-		tag:       "https://github.com/giantswarm/azuredisk-csi-driver-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/azuredisk-csi-driver-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/azuredisk-csi-driver-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/azuredisk-csi-driver-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 	"azurefile-csi-driver": {
-		tag:       "https://github.com/giantswarm/azurefile-csi-driver-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/azurefile-csi-driver-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/azurefile-csi-driver-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/azurefile-csi-driver-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 
 	// CAPV Provider Specific
 	"cluster-vsphere": {
-		tag:       "https://github.com/giantswarm/cluster-vsphere/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-vsphere/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cluster-vsphere/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cluster-vsphere/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cloud-provider-vsphere": {
-		tag:       "https://github.com/giantswarm/cloud-provider-vsphere-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cloud-provider-vsphere-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/cloud-provider-vsphere-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/cloud-provider-vsphere-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 
 	// CAPVCD Provider Specific
 	"cluster-cloud-director": {
-		tag:       "https://github.com/giantswarm/cluster-cloud-director/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-cloud-director/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cluster-cloud-director/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cluster-cloud-director/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cloud-provider-cloud-director": {
-		tag:       "https://github.com/giantswarm/cloud-provider-cloud-director-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cloud-provider-cloud-director-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/cloud-provider-cloud-director-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/cloud-provider-cloud-director-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 
 	// Common Apps
 	"capi-node-labeler": {
-		tag:       "https://github.com/giantswarm/capi-node-labeler-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/capi-node-labeler-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/capi-node-labeler-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/capi-node-labeler-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cert-exporter": {
-		tag:       "https://github.com/giantswarm/cert-exporter/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cert-exporter/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cert-exporter/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cert-exporter/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cert-manager": {
-		tag:       "https://github.com/giantswarm/cert-manager-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cert-manager-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cert-manager-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cert-manager-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cert-manager-crossplane-resources": {
-		tag:       "https://github.com/giantswarm/cert-manager-crossplane-resources/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cert-manager-crossplane-resources/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cert-manager-crossplane-resources/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cert-manager-crossplane-resources/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"chart-operator-extensions": {
-		tag:       "https://github.com/giantswarm/chart-operator-extensions/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/chart-operator-extensions/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/chart-operator-extensions/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/chart-operator-extensions/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cilium": {
-		tag:       "https://github.com/giantswarm/cilium-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cilium-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cilium-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cilium-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cilium-crossplane-resources": {
-		tag:       "https://github.com/giantswarm/cilium-crossplane-resources/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cilium-crossplane-resources/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cilium-crossplane-resources/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cilium-crossplane-resources/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cilium-servicemonitors": {
-		tag:       "https://github.com/giantswarm/cilium-servicemonitors-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cilium-servicemonitors-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cilium-servicemonitors-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cilium-servicemonitors-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cilium-prerequisites": {
-		tag:       "https://github.com/giantswarm/cilium-prerequisites/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cilium-prerequisites/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/cilium-prerequisites/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/cilium-prerequisites/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"cluster-autoscaler": {
-		tag:       "https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/cluster-autoscaler-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:        "https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v{{.Version}}",
+		Changelog:  "https://raw.githubusercontent.com/giantswarm/cluster-autoscaler-app/v{{.Version}}/CHANGELOG.md",
+		Start:      commonStartPattern,
+		End:        commonEndPattern,
+		AutoDetect: true,
 	},
 	"coredns": {
-		tag:       "https://github.com/giantswarm/coredns-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/coredns-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/coredns-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/coredns-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"coredns-extensions": {
-		tag:       "https://github.com/giantswarm/coredns-extensions-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/coredns-extensions-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/coredns-extensions-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/coredns-extensions-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"etcd-defrag": {
-		tag:       "https://github.com/giantswarm/etcd-defrag-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/etcd-defrag-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/etcd-defrag-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/etcd-defrag-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"etcd-k8s-res-count-exporter": {
-		tag:       "https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/etcd-kubernetes-resources-count-exporter/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/etcd-kubernetes-resources-count-exporter/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"external-dns": {
-		tag:       "https://github.com/giantswarm/external-dns-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/external-dns-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/external-dns-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/external-dns-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"k8s-audit-metrics": {
-		tag:       "https://github.com/giantswarm/k8s-audit-metrics/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/k8s-audit-metrics/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/k8s-audit-metrics/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/k8s-audit-metrics/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"k8s-dns-node-cache": {
-		tag:       "https://github.com/giantswarm/k8s-dns-node-cache-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/k8s-dns-node-cache-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/k8s-dns-node-cache-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/k8s-dns-node-cache-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"metrics-server": {
-		tag:       "https://github.com/giantswarm/metrics-server-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/metrics-server-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/metrics-server-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/metrics-server-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"net-exporter": {
-		tag:       "https://github.com/giantswarm/net-exporter/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/net-exporter/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/net-exporter/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/net-exporter/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"network-policies": {
-		tag:       "https://github.com/giantswarm/network-policies-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/network-policies-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/network-policies-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/network-policies-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"node-exporter": {
-		tag:       "https://github.com/giantswarm/node-exporter-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/node-exporter-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/node-exporter-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/node-exporter-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"observability-bundle": {
-		tag:       "https://github.com/giantswarm/observability-bundle/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/observability-bundle/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/observability-bundle/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/observability-bundle/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"observability-policies": {
-		tag:       "https://github.com/giantswarm/observability-policies-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/observability-policies-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/observability-policies-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/observability-policies-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"prometheus-blackbox-exporter": {
-		tag:       "https://github.com/giantswarm/prometheus-blackbox-exporter-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/prometheus-blackbox-exporter-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/prometheus-blackbox-exporter-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/prometheus-blackbox-exporter-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"security-bundle": {
-		tag:       "https://github.com/giantswarm/security-bundle/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/security-bundle/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/security-bundle/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/security-bundle/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"teleport-kube-agent": {
-		tag:       "https://github.com/giantswarm/teleport-kube-agent-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/teleport-kube-agent-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/teleport-kube-agent-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/teleport-kube-agent-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"vertical-pod-autoscaler": {
-		tag:       "https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/vertical-pod-autoscaler-app/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/vertical-pod-autoscaler-app/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 	"vertical-pod-autoscaler-crd": {
-		tag:       "https://github.com/giantswarm/vertical-pod-autoscaler-crd/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/vertical-pod-autoscaler-crd/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/vertical-pod-autoscaler-crd/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/vertical-pod-autoscaler-crd/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
 
 	// Core Components
 	"flatcar": {
-		tag:       "https://www.flatcar-linux.org/releases/#release-{{.Version}}",
-		changelog: "https://www.flatcar.org/releases-json/releases-stable.json",
+		Tag:       "https://www.flatcar-linux.org/releases/#release-{{.Version}}",
+		Changelog: "https://www.flatcar.org/releases-json/releases-stable.json",
 	},
 	"kubernetes": {
-		tag:          "https://github.com/kubernetes/kubernetes/releases/tag/v{{.Version}}",
-		changelog:    "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{.Major}}.{{.Minor}}.md#v{{.Version}}",
-		start:        "(?m)^# v?(?P<Version>\\d+\\.\\d+\\.\\d+)$",
-		intermediate: "(?m)^## Changes by Kind$",
-		end:          "(?m)^# .*$",
+		Tag:          "https://github.com/kubernetes/kubernetes/releases/tag/v{{.Version}}",
+		Changelog:    "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-{{.Major}}.{{.Minor}}.md#v{{.Version}}",
+		Start:        "(?m)^# v?(?P<Version>\\d+\\.\\d+\\.\\d+)$",
+		Intermediate: "(?m)^## Changes by Kind$",
+		End:          "(?m)^# .*$",
+		AutoDetect:   true,
 	},
 	"os-tooling": {
-		tag:       "https://github.com/giantswarm/capi-image-builder/releases/tag/v{{.Version}}",
-		changelog: "https://raw.githubusercontent.com/giantswarm/capi-image-builder/v{{.Version}}/CHANGELOG.md",
-		start:     commonStartPattern,
-		end:       commonEndPattern,
+		Tag:       "https://github.com/giantswarm/capi-image-builder/releases/tag/v{{.Version}}",
+		Changelog: "https://raw.githubusercontent.com/giantswarm/capi-image-builder/v{{.Version}}/CHANGELOG.md",
+		Start:     commonStartPattern,
+		End:       commonEndPattern,
 	},
+}
+
+// GetRepoName extracts the repository name for a given component from its tag URL.
+func GetRepoName(componentName string) (string, string) {
+	if params, ok := KnownComponents[componentName]; ok {
+		// e.g. "https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v{{.Version}}"
+		re := regexp.MustCompile(`github\.com/([^/]+)/([^/]+)`)
+		matches := re.FindStringSubmatch(params.Tag)
+		if len(matches) > 2 {
+			return matches[1], matches[2]
+		}
+	}
+	return "", ""
 }
 
 // Data about a component passed into templates that depend on versions
@@ -371,7 +394,7 @@ type CategorizedChanges struct {
 var categoryRegex = regexp.MustCompile(`^### (\w+)`)
 
 func ParseChangelog(componentName, currentVersion, endVersion string) (*Version, error) {
-	params, ok := knownComponentParseParams[componentName]
+	params, ok := KnownComponents[componentName]
 	if !ok {
 		return nil, microerror.Mask(fmt.Errorf("unknown component: %s", componentName))
 	}
@@ -389,7 +412,7 @@ func ParseChangelog(componentName, currentVersion, endVersion string) (*Version,
 	}
 
 	// Build release link using the template from the params
-	changelogURLTemplate, err := template.New("url").Parse(params.changelog)
+	changelogURLTemplate, err := template.New("url").Parse(params.Changelog)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -413,7 +436,7 @@ func ParseChangelog(componentName, currentVersion, endVersion string) (*Version,
 		// Skip parsing Flatcar
 		return &Version{
 			Name:    currentVersion,
-			Link:    strings.Replace(params.tag, "{{.Version}}", currentVersion, 1),
+			Link:    strings.Replace(params.Tag, "{{.Version}}", currentVersion, 1),
 			Content: "",
 		}, nil
 	}
@@ -447,11 +470,11 @@ func ParseChangelog(componentName, currentVersion, endVersion string) (*Version,
 	if endVersion == "" || currentVersion == endVersion {
 		// When there's no previous version or they're the same, link to single release
 		compareRange = fmt.Sprintf("v%s", currentVersion)
-		compareLink = fmt.Sprintf("https://github.com/giantswarm/%s/releases/tag/v%s", componentName, currentVersion)
+		compareLink = strings.Replace(params.Tag, "{{.Version}}", currentVersion, 1)
 	} else {
 		// When there's a version range, use comparison link
 		compareRange = fmt.Sprintf("v%s...v%s", endVersion, currentVersion)
-		compareLink = fmt.Sprintf("%s/compare/%s", splitBaseURL(params.tag), compareRange)
+		compareLink = fmt.Sprintf("%s/compare/%s", splitBaseURL(params.Tag), compareRange)
 	}
 
 	categorizedChanges := CategorizedChanges{}
@@ -460,6 +483,11 @@ func ParseChangelog(componentName, currentVersion, endVersion string) (*Version,
 
 	startHeading := fmt.Sprintf("## [%s]", currentVersion)
 	stopHeading := fmt.Sprintf("## [%s]", endVersion)
+
+	endSemVer, err := semver.NewVersion(endVersion)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 
 	for _, line := range lines {
 		// Don't trim spaces yet - we need them to detect indentation
@@ -474,6 +502,21 @@ func ParseChangelog(componentName, currentVersion, endVersion string) (*Version,
 		if inSection && strings.Contains(line, stopHeading) {
 			break
 		}
+
+		if inSection && strings.HasPrefix(line, "## [") {
+			// Extract version from heading, e.g., "## [1.2.3]"
+			versionStr := strings.TrimPrefix(line, "## [")
+			versionStr = strings.Split(versionStr, "]")[0]
+
+			ver, err := semver.NewVersion(versionStr)
+			if err == nil {
+				// Stop if we've reached a version older than or equal to the end version
+				if !ver.GreaterThan(endSemVer) {
+					break
+				}
+			}
+		}
+
 		// // Continue parsing intermediate versions - don't stop until we hit the actual endVersion.
 		// This allows collecting changes from all versions between currentVersion and endVersion.
 		// For example, when parsing from v1.2.0 to v1.0.0, this will include changes from

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -11,11 +11,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/giantswarm/devctl/v7/pkg/release/changelog"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/release-operator/v4/api/v1alpha1"
 	"github.com/mohae/deepcopy"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/devctl/v7/pkg/release/changelog"
 )
 
 type droppedAppConfig struct {

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/giantswarm/devctl/v7/pkg/release/changelog"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/release-operator/v4/api/v1alpha1"
 	"github.com/mohae/deepcopy"
@@ -31,7 +32,7 @@ var appsToBeDropped = []droppedAppConfig{
 
 // CreateRelease creates a release on the filesystem from the given parameters. This is the entry point
 // for the `devctl create release` command logic.
-func CreateRelease(name, base, releases, provider string, components, apps []string, overwrite bool, creationCommand string, bumpall bool) error {
+func CreateRelease(name, base, releases, provider string, components, apps []string, overwrite bool, creationCommand string, bumpall, yes bool) error {
 	// Paths
 	baseVersion := *semver.MustParse(base) // already validated to be a valid semver string
 	providerDirectory := ""
@@ -51,17 +52,6 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 	// Store the base release for later use because it gets modified
 	previousRelease := deepcopy.Copy(baseRelease).(v1alpha1.Release)
 
-	// Auto-detect Kubernetes version if not explicitly provided by user
-	hasUserKubernetesComponent := false
-	for _, componentVersion := range components {
-		split := strings.Split(componentVersion, "@")
-		if len(split) >= 1 && split[0] == "kubernetes" {
-			fmt.Println("Explicit Kubernetes component specified by user:", componentVersion)
-			hasUserKubernetesComponent = true
-			break
-		}
-	}
-
 	// Determine which apps to drop based on the new release version.
 	appsToDropForThisRelease := make(map[string]bool)
 	releaseVersion, err := semver.NewVersion(strings.TrimPrefix(name, "v"))
@@ -73,23 +63,83 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		}
 	}
 
-	// Only attempt auto-detection if user didn't explicitly specify Kubernetes
-	if !hasUserKubernetesComponent {
-		fmt.Printf("No explicit Kubernetes component specified by user. Attempting auto-detection based on release name pattern...\n")
-		kubernetesVersion, err := autoDetectKubernetesVersion(name)
+	// Auto-detect components that are not explicitly provided by the user.
+	// The auto-detection logic is driven by the `AutoDetect` flag in the `KnownComponents` map.
+	// For each component with this flag, we check if it was present in the base release
+	// and if the user has not already provided a version for it.
+	for componentName, params := range changelog.KnownComponents {
+		if !params.AutoDetect {
+			continue
+		}
+
+		// Check if the component is in the base release.
+		inBaseRelease := false
+		for _, component := range baseRelease.Spec.Components {
+			if component.Name == componentName {
+				inBaseRelease = true
+				break
+			}
+		}
+		for _, app := range baseRelease.Spec.Apps {
+			if app.Name == componentName {
+				inBaseRelease = true
+				break
+			}
+		}
+		if !inBaseRelease {
+			continue
+		}
+
+		// Check if the user has already provided the component.
+		isProvidedByUser := false
+		for _, componentVersion := range components {
+			split := strings.Split(componentVersion, "@")
+			if len(split) >= 1 && split[0] == componentName {
+				fmt.Printf("Explicit component specified by user: %s\n", componentVersion)
+				isProvidedByUser = true
+				break
+			}
+		}
+		if isProvidedByUser {
+			continue
+		}
+		for _, appVersion := range apps {
+			split := strings.Split(appVersion, "@")
+			if len(split) >= 1 && split[0] == componentName {
+				fmt.Printf("Explicit app specified by user: %s\n", appVersion)
+				isProvidedByUser = true
+				break
+			}
+		}
+		if isProvidedByUser {
+			continue
+		}
+
+		// Attempt to auto-detect the component version.
+		fmt.Printf("No explicit %s component specified by user. Attempting auto-detection based on release name pattern...\n", componentName)
+		var detectedVersion string
+		var err error
+		detectedVersion, err = autoDetectVersion(name, componentName)
+
 		if err != nil {
-			fmt.Printf("Warning: Could not auto-detect Kubernetes version: %v\n", err)
-			fmt.Printf("You can manually specify the Kubernetes version using --component kubernetes@<version>\n")
+			fmt.Printf("Warning: Could not auto-detect %s version: %v\n", componentName, err)
+			fmt.Printf("You can manually specify the version using --component %s@<version> or --app %s@<version>\n", componentName, componentName)
 		} else {
-			kubernetesComponent := fmt.Sprintf("kubernetes@%s", kubernetesVersion)
-			components = append(components, kubernetesComponent)
-			fmt.Printf("Auto-detected and added Kubernetes component: %s\n", kubernetesComponent)
+			if componentName == "kubernetes" {
+				component := fmt.Sprintf("%s@%s", componentName, detectedVersion)
+				components = append(components, component)
+				fmt.Printf("Auto-detected and added component: %s\n", component)
+			} else {
+				app := fmt.Sprintf("%s@%s", componentName, detectedVersion)
+				apps = append(apps, app)
+				fmt.Printf("Auto-detected and added app: %s\n", app)
+			}
 		}
 	}
 
 	if bumpall {
 		fmt.Println("Requested automated bumping of all components and apps.")
-		components, apps, err = BumpAll(baseRelease, components, apps, appsToDropForThisRelease)
+		components, apps, err = BumpAll(baseRelease, components, apps, appsToDropForThisRelease, yes)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
This pull request refactors the component auto-detection logic for release creation.

Changes:

- Generalized Auto-Detection, tries to autodetect several apps to match with the release version
- In case certain apps or components don't have a valid tag it will not add the whole changelog to the README.md.
- `devctl release create ... --bumpall --overwrite --yes` won't ask you if you really want to overwrite it.

### Checklist

- [ ] Update changelog in CHANGELOG.md.