### PR TITLE
Create branch from parent version tag create-release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Create branch from parent version tag create-release workflow
+
 ## [7.7.2] - 2025-09-05
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -261,7 +261,7 @@ jobs:
             exit 0
           fi
 
-          git branch $release_branch HEAD^
+          git branch $release_branch "refs/tags/v${parent_version}"
           git push origin $release_branch
 
 {{{{- if .IsFlavourCLI }}}}


### PR DESCRIPTION
Prior to this change, the branch is created including all the commits
that are meant for the following version.
This change sets the "Release" commit as a base for the new release
branch.

Signed-off-by: Matias Charriere <matias@giantswarm.io>

### Checklist

- [ ] Update changelog in CHANGELOG.md.
