### PR TITLE
Environment: Unify GitHub token retrieval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Environment: Unify GitHub token retrieval.
+
 ## [7.10.5] - 2025-09-10
 
 ### Changed

--- a/cmd/deploy/runner.go
+++ b/cmd/deploy/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/devctl/v7/internal/env"
 	"github.com/giantswarm/devctl/v7/pkg/appstatus"
 	"github.com/giantswarm/devctl/v7/pkg/githubclient"
 )
@@ -34,7 +35,7 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get GitHub token from environment variables
-	token := getGitHubToken()
+	token := env.GitHubToken.Val()
 	if token == "" {
 		return microerror.Maskf(envVarNotFoundError, "GitHub token not found in environment variables. Please set GITHUB_TOKEN or OPSCTL_GITHUB_TOKEN")
 	}
@@ -141,18 +142,4 @@ func parseGitOpsRepo(repo string) (string, string, error) {
 		return "", "", microerror.Maskf(invalidArgError, "invalid GitOps repository format: %q", repo)
 	}
 	return s[0], s[1], nil
-}
-
-func getGitHubToken() string {
-	// Try GITHUB_TOKEN first
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		return token
-	}
-
-	// Try OPSCTL_GITHUB_TOKEN as fallback
-	if token := os.Getenv("OPSCTL_GITHUB_TOKEN"); token != "" {
-		return token
-	}
-
-	return ""
 }

--- a/cmd/pr/approvealign/runner.go
+++ b/cmd/pr/approvealign/runner.go
@@ -4,18 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-github/v74/github"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/devctl/v7/internal/env"
 	"github.com/giantswarm/devctl/v7/pkg/githubclient"
-)
-
-const (
-	githubTokenEnvVar = "GITHUB_TOKEN" // Standard environment variable for GitHub token
 )
 
 type runner struct {
@@ -38,9 +34,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	fmt.Fprintln(r.stdout, "Auto-approving all 'Align files' PRs that have passing status checks...")
 
-	githubToken, found := os.LookupEnv(githubTokenEnvVar)
-	if !found {
-		return microerror.Maskf(executionFailedError, "environment variable %#q not found, please set it to your GitHub personal access token", githubTokenEnvVar)
+	githubToken := env.GitHubToken.Val()
+	if githubToken == "" {
+		return microerror.Maskf(executionFailedError, "environment variable GITHUB_TOKEN not found, please set it to your GitHub personal access token")
 	}
 
 	ghClientService, err := githubclient.New(githubclient.Config{

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -10,6 +10,7 @@ import (
 var (
 	ConfigDir                = configDir{}
 	DevctlUnsafeForceVersion = devctlUnsafeForceVersion{}
+	GitHubToken              = gitHubToken{}
 )
 
 type configDir struct{}
@@ -32,3 +33,25 @@ type devctlUnsafeForceVersion struct{}
 
 func (devctlUnsafeForceVersion) Key() string { return "DEVCTL_UNSAFE_FORCE_VERSION" } // nolint:gosec
 func (devctlUnsafeForceVersion) Val() string { return os.Getenv(devctlUnsafeForceVersion{}.Key()) }
+
+type gitHubToken struct{}
+
+// Tries to get the GitHub token from environment variables.
+func (gitHubToken) Val() string {
+	// Try DEVCTL_GITHUB_TOKEN first.
+	if token := os.Getenv("DEVCTL_GITHUB_TOKEN"); token != "" {
+		return token
+	}
+
+	// Try GITHUB_TOKEN.
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token
+	}
+
+	// Fallback to OPSCTL_GITHUB_TOKEN.
+	if token := os.Getenv("OPSCTL_GITHUB_TOKEN"); token != "" {
+		return token
+	}
+
+	return ""
+}

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	"github.com/giantswarm/devctl/v7/internal/env"
 	"github.com/giantswarm/devctl/v7/pkg/githubclient"
 	"github.com/giantswarm/devctl/v7/pkg/release/changelog"
 )
@@ -540,7 +541,7 @@ func findNewestComponent(name string) (componentVersion, error) {
 }
 
 func getLatestGithubRelease(owner string, name string) (string, error) {
-	token := os.Getenv("OPSCTL_GITHUB_TOKEN")
+	token := env.GitHubToken.Val()
 
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
@@ -580,7 +581,7 @@ func getLatestGithubRelease(owner string, name string) (string, error) {
 
 // getLatestK8sVersion returns the latest patch version for a given k8s major.minor version.
 func getLatestK8sVersion(major uint64) (string, error) {
-	token := os.Getenv("OPSCTL_GITHUB_TOKEN")
+	token := env.GitHubToken.Val()
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
@@ -633,7 +634,7 @@ func getLatestK8sVersion(major uint64) (string, error) {
 // getLatestReleaseForMinor fetches the latest patch version for a given minor version of a component.
 // e.g., for minorVersion "1.31", it might return "1.31.9"
 func getLatestReleaseForMinor(owner, repo, minorVersion string) (string, error) {
-	token := os.Getenv("OPSCTL_GITHUB_TOKEN")
+	token := env.GitHubToken.Val()
 
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
@@ -837,7 +838,7 @@ func getLatestFlatcarRelease() (string, error) {
 func getAppVersionFromHelmChart(name string, ref string) (string, error) {
 	c := githubclient.Config{
 		Logger:      logrus.StandardLogger(),
-		AccessToken: os.Getenv("OPSCTL_GITHUB_TOKEN"),
+		AccessToken: env.GitHubToken.Val(),
 	}
 
 	client, err := githubclient.New(c)


### PR DESCRIPTION
I left out places where we retrieve the GitHub token by using a given environment variable name and only replaced those statically relying on `GITHUB_TOKEN` or `OPSCTL_GITHUB_TOKEN` on purpose.