### PR TITLE
### Motivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `devctl release create --bumpall`:
+  - The release type (`major`, `minor`, `patch`) is now inferred from the `--base` and `--name` versions instead of requiring a separate flag.
+  - The release type is used to enforce version bumping rules for `kubernetes`, `flatcar`, and other components.
+  - Includes version constraints defined in provider-specific `requests.yaml` files.
+
+### Fixed
+
+- Fix a table rendering issue in the `devctl release create --bumpall` output.
+
 ## [7.11.1] - 2025-09-11
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/briandowns/spinner v1.23.2
-	github.com/buger/goterm v1.0.4
 	github.com/fatih/color v1.18.0
 	github.com/giantswarm/microerror v0.4.1
 	github.com/giantswarm/micrologger v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
-github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
-github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -212,7 +210,6 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/release-operator/v4/api/v1alpha1"
 	"github.com/mohae/deepcopy"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/devctl/v7/pkg/release/changelog"
 )
@@ -46,6 +47,11 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		providerDirectory = filepath.Join(releases, "capa")
 	} else {
 		providerDirectory = filepath.Join(releases, provider)
+	}
+
+	requests, err := readRequests(providerDirectory, name)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	baseRelease, baseReleasePath, err := findRelease(providerDirectory, baseVersion)
@@ -151,6 +157,28 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		if verbose {
 			fmt.Println("Requested automated bumping of all components and apps.")
 		}
+
+		// Determine release type from base and new versions.
+		releaseType := ""
+		{
+			baseV, err := semver.Parse(strings.TrimPrefix(base, "v"))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			newV, err := semver.Parse(strings.TrimPrefix(name, "v"))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			if newV.Major > baseV.Major {
+				releaseType = "major"
+			} else if newV.Minor > baseV.Minor {
+				releaseType = "minor"
+			} else {
+				releaseType = "patch"
+			}
+		}
+
 		// Pin k8s version to the release major version.
 		releaseVersionForK8s, err := semver.Parse(strings.TrimPrefix(name, "v"))
 		if err != nil {
@@ -158,7 +186,7 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		}
 		major := releaseVersionForK8s.Major
 
-		components, apps, err = BumpAll(baseRelease, components, apps, appsToDropForThisRelease, yes, output, changesOnly, requestedOnly, major)
+		components, apps, err = BumpAll(baseRelease, components, apps, releaseType, appsToDropForThisRelease, requests, yes, output, changesOnly, requestedOnly, major)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -360,4 +388,23 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 	}
 
 	return nil
+}
+
+func readRequests(providerDirectory, version string) ([]Request, error) {
+	requestsYAMLPath := filepath.Join(providerDirectory, "requests.yaml")
+	data, err := os.ReadFile(requestsYAMLPath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var requests Requests
+	err = yaml.Unmarshal(data, &requests)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	version = strings.TrimPrefix(version, "v")
+	return requests.ForVersion(version)
 }

--- a/pkg/release/requests.go
+++ b/pkg/release/requests.go
@@ -1,0 +1,40 @@
+package release
+
+import "github.com/blang/semver"
+
+type Requests struct {
+	Releases []ReleaseRequest `yaml:"releases"`
+}
+
+type ReleaseRequest struct {
+	Name     string    `yaml:"name"`
+	Requests []Request `yaml:"requests"`
+}
+
+type Request struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+func (r Requests) ForVersion(version string) ([]Request, error) {
+	var requests []Request
+
+	v, err := semver.Parse(version)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, releaseRequest := range r.Releases {
+		constraint, err := semver.ParseRange(releaseRequest.Name)
+		if err != nil {
+			// Silently ignore failing constraints for now.
+			continue
+		}
+
+		if constraint(v) {
+			requests = append(requests, releaseRequest.Requests...)
+		}
+	}
+
+	return requests, nil
+}


### PR DESCRIPTION
The `devctl release create --bumpall` command was previously a bit too aggressive, always attempting to update every component to its latest version. This was not ideal for `minor` and `patch` releases, which have stricter rules about what can be changed (e.g., no minor version bumps for Flatcar in a minor release).

This PR makes the command "release-aware" by automatically inferring the release type and applying specific bumping rules, reducing the need for manual intervention and preventing accidental version bumps.

### Changes

-   **Automatic Release Type Inference**: The command now determines if a release is `major`, `minor`, or `patch` by comparing the `--base` and `--name` versions.
-   **Release-Aware Bumping Logic**:
    -   **Major**: Bumps all components and apps to their latest versions.
    -   **Minor**: Restricts `flatcar` to only patch version bumps.
    -   **Patch**: Prevents any version changes for `kubernetes` and `flatcar`, and only allows patch-level bumps for other components and apps.
-   **Provider-Specific Constraints**: The command now reads and enforces version constraints from the `requests.yaml` file located in each provider's directory. This ensures provider-specific requirements are met.
-   **Fixed**: Corrected a table rendering issue that was causing broken lines in the output.

### How to Test

You can test the new logic by running the command with different version increments:

```bash
# Patch Release
./devctl release create --base v31.1.1 --name v31.1.2 --provider aws --bumpall

# Minor Release
./devctl release create --base v31.1.2 --name v31.2.0 --provider aws --bumpall

# Major Release
./devctl release create --base v31.2.0 --name v32.0.0 --provider aws --bumpall
```

Observe the output table and verify that the "DESIRED VERSION" for each component aligns with the new bumping rules.


### Checklist

- [x] Update changelog in CHANGELOG.md.