### PR TITLE
Releases: Remove Karpenter Bundle from CAPI v33.0.0 and higher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Releases: Remove Karpenter Bundle from CAPI v33.0.0 and higher.
+
 ## [7.16.0] - 2025-10-01
 
 ### Removed

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -31,6 +31,10 @@ var appsToBeDropped = []droppedAppConfig{
 		MajorVersion: 33,
 	},
 	{
+		Name:         "karpenter-bundle",
+		MajorVersion: 33,
+	},
+	{
 		Name:         "karpenter-nodepools",
 		MajorVersion: 32,
 	},


### PR DESCRIPTION
Going to be restructured into single HelmReleases.