### PR TITLE
Releases: always use UTC to format `releaseTimestamp` field for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Releases: always use UTC to format `releaseTimestamp` field for consistency
+
 ## [7.18.0] - 2025-10-02
 
 ### Added

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -420,7 +420,7 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 	newReleaseInfo := ReleaseJsonInfo{
 		Version:          newVersion.String(),
 		IsDeprecated:     false,
-		ReleaseTimestamp: now.Format(time.RFC3339),
+		ReleaseTimestamp: now.UTC().Format(time.RFC3339),
 		ChangelogUrl:     fmt.Sprintf("https://github.com/giantswarm/releases/blob/master/%s/%s/README.md", provider, releaseDirectory),
 		IsStable:         true,
 	}


### PR DESCRIPTION
Simply:

```diff
-      "releaseTimestamp": "2025-10-07T09:53:29+02:00",
+      "releaseTimestamp": "2025-10-07T07:53:29Z",
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
