### PR TITLE
Fix unauthenticated GitHub API rate limit in update checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Pass GitHub token to the update checker to avoid unauthenticated API rate limits.
-- Make update check non-fatal so network/rate-limit errors don't block commands.
 
 ## [7.37.1] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass GitHub token to the update checker to avoid unauthenticated API rate limits.
+- Make update check non-fatal so network/rate-limit errors don't block commands.
+
 ## [7.37.1] - 2026-04-08
 
 ### Added

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -82,6 +82,7 @@ func (r *runner) persistentPreRun(ctx context.Context, cmd *cobra.Command, args 
 		}
 
 		config := updater.Config{
+			GithubToken:    env.GitHubToken.Val(),
 			CurrentVersion: project.Version(),
 			RepositoryURL:  project.Source(),
 			CacheDir:       cacheDir,
@@ -102,7 +103,7 @@ func (r *runner) persistentPreRun(ctx context.Context, cmd *cobra.Command, args 
 
 		return microerror.Mask(err)
 	} else if err != nil {
-		return microerror.Mask(err)
+		_, _ = fmt.Fprintf(r.stderr, "WARNING: Update check failed: %s\n", err)
 	}
 
 	return nil

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -103,7 +103,7 @@ func (r *runner) persistentPreRun(ctx context.Context, cmd *cobra.Command, args 
 
 		return microerror.Mask(err)
 	} else if err != nil {
-		_, _ = fmt.Fprintf(r.stderr, "WARNING: Update check failed: %s\n", err)
+		return microerror.Mask(err)
 	}
 
 	return nil


### PR DESCRIPTION
The update checker in `cmd/runner.go` was not passing the GitHub token to the
updater, causing all version checks to hit the unauthenticated rate limit
(60 req/hour per IP). On shared GitHub Actions runners this gets exhausted
quickly, failing CI runs.

- Pass `env.GitHubToken.Val()` to the updater config for authenticated requests (5,000 req/hour)
- Make update check errors non-fatal (warn instead of abort) so transient failures don't block commands