### PR TITLE
Fix go vulnerabilities: Set default branch to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Change workflow "Fix go vulnerabilities": Set default branch to `main` for manual workflow execution
+
 ## [7.37.2] - 2026-04-09
 
 ### Fixed

--- a/pkg/gen/input/workflows/internal/file/fix_vulnerabilities.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/fix_vulnerabilities.yaml.template
@@ -9,11 +9,12 @@ on:
     inputs:
       branch:
         description: Branch on which to fix vulnerabilities
+        default: main
         required: true
         type: string
       log_level:
         description: Log Level (info / error / debug)
-        default: "info"
+        default: info
         type: string
 
 permissions: {}


### PR DESCRIPTION
This sets a default branch for the manual execution of the "Fix Go vulnerabilities" workflow. `main` should be correct in most cases.

### Checklist

- [x] Update changelog in CHANGELOG.md.
