### PR TITLE
Prevent major version bumps of components in minor releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Change workflow "Fix go vulnerabilities": Set default branch to `main` for manual workflow execution
+- Prevent major version bumps of components (e.g. cluster provider charts) when using `--bump-all` in minor releases.
 
 ## [7.37.2] - 2026-04-09
 

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -107,15 +107,7 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 					// For minor releases, add an implicit constraint to prevent major version jumps.
 					// Users can still force a major bump via --component flag.
 					if releaseType == "minor" && constraint == nil {
-						currentVersion, parseErr := semver.ParseTolerant(comp.Version)
-						if parseErr == nil {
-							nextMajor := currentVersion.Major + 1
-							rangeStr := fmt.Sprintf(">=%d.0.0 <%d.0.0", currentVersion.Major, nextMajor)
-							c, rangeErr := semver.ParseRange(rangeStr)
-							if rangeErr == nil {
-								constraint = &c
-							}
-						}
+						constraint = sameMajorConstraint(comp.Version)
 					}
 
 					var latestVersionString string
@@ -582,6 +574,23 @@ func FindNewestApp(name string, getUpstreamVersion bool, constraint *semver.Rang
 	}
 
 	return ret, nil
+}
+
+// sameMajorConstraint returns a semver range that constrains versions to the
+// same major version as the given version string. Returns nil if the version
+// cannot be parsed.
+func sameMajorConstraint(version string) *semver.Range {
+	v, err := semver.ParseTolerant(version)
+	if err != nil {
+		return nil
+	}
+	nextMajor := v.Major + 1
+	rangeStr := fmt.Sprintf(">=%d.0.0 <%d.0.0", v.Major, nextMajor)
+	c, err := semver.ParseRange(rangeStr)
+	if err != nil {
+		return nil
+	}
+	return &c
 }
 
 func findNewestComponentVersion(name string, constraint *semver.Range) (string, error) {

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -104,6 +104,20 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 						version.Version, err = getLatestFlatcarRelease()
 					}
 				} else {
+					// For minor releases, add an implicit constraint to prevent major version jumps.
+					// Users can still force a major bump via --component flag.
+					if releaseType == "minor" && constraint == nil {
+						currentVersion, parseErr := semver.ParseTolerant(comp.Version)
+						if parseErr == nil {
+							nextMajor := currentVersion.Major + 1
+							rangeStr := fmt.Sprintf(">=%d.0.0 <%d.0.0", currentVersion.Major, nextMajor)
+							c, rangeErr := semver.ParseRange(rangeStr)
+							if rangeErr == nil {
+								constraint = &c
+							}
+						}
+					}
+
 					var latestVersionString string
 					latestVersionString, err = findNewestComponentVersion(comp.Name, constraint)
 					if err == nil {
@@ -111,7 +125,7 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 							// For a patch release, we don't want to automatically bump anything.
 							// The user must manually request a bump for a component.
 							version.Version = comp.Version
-						} else { // major or minor, no restrictions for other components
+						} else { // major or minor
 							version.Version = latestVersionString
 						}
 					}

--- a/pkg/release/bumpall_test.go
+++ b/pkg/release/bumpall_test.go
@@ -1,0 +1,89 @@
+package release
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+)
+
+func TestSameMajorConstraint(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		allowed        []string
+		blocked        []string
+	}{
+		{
+			name:           "cluster-aws style: major 7",
+			currentVersion: "7.4.0",
+			allowed:        []string{"7.4.0", "7.4.1", "7.5.0", "7.99.99"},
+			blocked:        []string{"8.0.0", "8.1.0", "6.9.9", "0.1.0"},
+		},
+		{
+			name:           "cluster-azure style: major 6",
+			currentVersion: "6.1.0",
+			allowed:        []string{"6.0.0", "6.1.0", "6.2.0", "6.99.0"},
+			blocked:        []string{"7.0.0", "5.9.9"},
+		},
+		{
+			name:           "component at major 1",
+			currentVersion: "1.26.4",
+			allowed:        []string{"1.26.4", "1.26.5", "1.27.0", "1.99.0"},
+			blocked:        []string{"2.0.0", "0.9.0"},
+		},
+		{
+			name:           "component at major 0",
+			currentVersion: "0.5.0",
+			allowed:        []string{"0.5.0", "0.5.1", "0.6.0", "0.99.0"},
+			blocked:        []string{"1.0.0", "2.0.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			constraint := sameMajorConstraint(tc.currentVersion)
+			if constraint == nil {
+				t.Fatalf("sameMajorConstraint(%q) returned nil", tc.currentVersion)
+			}
+
+			for _, v := range tc.allowed {
+				sv := semver.MustParse(v)
+				if !(*constraint)(sv) {
+					t.Errorf("expected version %s to be allowed (current: %s)", v, tc.currentVersion)
+				}
+			}
+
+			for _, v := range tc.blocked {
+				sv := semver.MustParse(v)
+				if (*constraint)(sv) {
+					t.Errorf("expected version %s to be blocked (current: %s)", v, tc.currentVersion)
+				}
+			}
+		})
+	}
+}
+
+func TestSameMajorConstraint_InvalidVersion(t *testing.T) {
+	constraint := sameMajorConstraint("not-a-version")
+	if constraint != nil {
+		t.Error("expected nil constraint for invalid version string")
+	}
+}
+
+func TestSameMajorConstraint_NotAppliedForMajorRelease(t *testing.T) {
+	// Verify that the constraint logic in BumpAll only applies for minor releases.
+	// For major releases, constraint should remain nil (no restriction).
+	// This test documents the expected behavior by checking that sameMajorConstraint
+	// would block a major bump that should be allowed in major releases.
+	constraint := sameMajorConstraint("7.4.0")
+	if constraint == nil {
+		t.Fatal("expected non-nil constraint")
+	}
+
+	// A major release would allow 8.1.0, but the constraint blocks it.
+	// This confirms the constraint is doing its job and should NOT be applied for major releases.
+	sv := semver.MustParse("8.1.0")
+	if (*constraint)(sv) {
+		t.Error("constraint should block version 8.1.0 for current 7.4.0")
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/releases/pull/2240

When using --bump-all for minor releases, components (like cluster provider charts) are now
constrained to stay within their current major version. This prevents unintended breaking
changes (e.g. cluster-aws 7.4.0 → 8.1.0) from being pulled into minor releases.

- Major releases: unchanged, picks up the absolute latest
- Minor releases: components stay within current major (e.g. 7.x.y)
- Patch releases: unchanged, nothing gets bumped automatically
- Explicit --component flag: always respected, bypasses the constraint