### PR TITLE
Fix github repository setup to correctly detect and configure required checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `devctl repo setup`: Use check runs API instead of commit statuses to correctly detect required checks. Change default `--checks-filter` from `aliyun` to `create-release`.
+
 ## [7.38.0] - 2026-04-14
 
 ### Changed

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -67,7 +67,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.DefaultBranch, "default-branch", "main", "Default branch name")
 	cmd.Flags().BoolVar(&f.DisableBranchProtection, "disable-branch-protection", false, "Disable default branch protection")
 	cmd.Flags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
-	cmd.Flags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
+	cmd.Flags().StringVar(&f.ChecksFilter, "checks-filter", "create-release", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
 
 	// Renovate
 	cmd.Flags().BoolVar(&f.SetupRenovate, "renovate", true, "Sets up renovate for the repo")

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -262,41 +262,41 @@ func (c *Client) getGithubChecks(ctx context.Context, repository *github.Reposit
 	}
 	c.logger.Debugf("get commit statuses for ref: %q", ref)
 
-	var allCombinedStatus []*github.CombinedStatus
+	// Fetch all check runs
+	var allCheckRuns []*github.CheckRun
 	{
-		opt := &github.ListOptions{
-			PerPage: 10,
+		opt := &github.ListCheckRunsOptions{
+			ListOptions: github.ListOptions{
+				PerPage: 10,
+			},
 		}
 
 		underlyingClient := c.GetUnderlyingClient(ctx)
 
 		for {
-			combinedStatus, resp, err := underlyingClient.Repositories.GetCombinedStatus(ctx, owner, repo, ref, opt)
+			listCheckRunsResults, resp, err := underlyingClient.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, opt)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
-			allCombinedStatus = append(allCombinedStatus, combinedStatus)
+
+			allCheckRuns = append(allCheckRuns, listCheckRunsResults.CheckRuns...)
 			if resp.NextPage == 0 {
 				break
 			}
 			opt.Page = resp.NextPage
-
 		}
 	}
 
+	// List all check names and apply filter if needed.
 	var checks []string
-	for _, combinedStatus := range allCombinedStatus {
-		for _, status := range combinedStatus.Statuses {
-			if checksFilter == nil || !checksFilter.MatchString(status.GetContext()) {
-				checks = append(checks, status.GetContext())
-			}
+	for _, checkRun := range allCheckRuns {
+		check := checkRun.GetName()
+		if check != "" && (checksFilter == nil || !checksFilter.MatchString(check)) {
+			checks = append(checks, check)
+			c.logger.Debugf(" - status check found: %q", check)
 		}
 	}
-
 	c.logger.Debugf("found %d commit statuses for ref %q:", len(checks), ref)
-	for id, check := range checks {
-		c.logger.Debugf(" - checks[%d] = %q", id, check)
-	}
 
 	return checks, nil
 }

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -117,6 +117,8 @@ func (c *Client) SetRepositorySettings(ctx context.Context, repository, reposito
 	return repository, nil
 }
 
+// SetRepositoryPermissions grants team permissions on the repository and
+// sets the default workflow permission to "write" for GitHub Actions.
 func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *github.Repository, permissions map[string]string) error {
 	org := repository.GetOrganization().GetLogin()
 	owner := repository.GetOwner().GetLogin()
@@ -156,6 +158,9 @@ func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *githu
 	return nil
 }
 
+// SetRepositoryBranchProtection configures branch protection rules on the
+// default branch. If checkNames is nil, checks are auto-detected from recent
+// CI runs and optionally filtered by checksFilter.
 func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *github.Repository, checkNames []string, checksFilter *regexp.Regexp) (err error) {
 	owner := repository.GetOwner().GetLogin()
 	repo := repository.GetName()


### PR DESCRIPTION
This PR fixes an issue where the `devctl repo setup` command was not correctly configuring required check on the default branch.

## Summary

- Switch from `GetCombinedStatus` to `ListCheckRunsForRef` API to correctly detect required status checks when configuring branch protection
- Change default `--checks-filter` from `aliyun` to `create-release` to exclude the release workflow from required checks

## Tests

I've managed to configure checks on the a repo using `devctl repo setup giantswarm/some-repo--log-level debug`

### Before

<img width="908" height="419" alt="image" src="https://github.com/user-attachments/assets/63b159e0-d73c-4d19-9a87-197270de683c" />


### After

<img width="958" height="878" alt="image" src="https://github.com/user-attachments/assets/7ad3fc60-fbfc-4955-8944-6839dee7bdf3" />

