### PR TITLE
`gen precommit`: Remove version badges from helm-docs template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen precommit`: Removed badges from helm-docs template, to avoid workflow failures due to version changes outside the PR.
+
 ## [7.40.1] - 2026-04-24
 
 ### Changed

--- a/pkg/gen/input/precommit/internal/file/helm-readme.gotmpl.template
+++ b/pkg/gen/input/precommit/internal/file/helm-readme.gotmpl.template
@@ -1,8 +1,6 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}


### PR DESCRIPTION
The version badges could cause changes that were not based on anything within the PR that was currently checked.

Example: https://github.com/giantswarm/backstage/actions/runs/24884590555/job/72861309651 -- Here the helm-docs output changed because since creating the PR a new release has been published.

Lacking a better solution, I'd rather remove the version from the template to avoid these side effects.

### Checklist

- [x] Update changelog in CHANGELOG.md.
