### PR TITLE
Enable full git commit history in builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.15.0
+  architect: giantswarm/architect@7.0.0
 
 workflows:
   go-build:
@@ -9,6 +9,7 @@ workflows:
     - architect/go-build:
         name: go-build-devctl
         binary: devctl
+        clone_depth: 0
         pre_test_target: generate-go
           # Needed to trigger job also on git tag.
         filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped architect-orb to v7.0.0 and applied `clone_depth: 0` to the go-build job, to fix the problem that all generated files' headers pointed to the HEAD commit for the last change.
+
 ## [7.40.2] - 2026-04-24
 
 ### Changed


### PR DESCRIPTION
This PR makes the full git commit history available when building the Go binary.

This should solve the problem that all generated files always point to the HEAD commit for the latest change.

### Checklist

- [x] Update changelog in CHANGELOG.md.
