### PR TITLE
Fix whitespace in pre-commit workflow for Helm charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix whitespace in pre-commit workflow for Helm charts
+
 ## [7.40.4] - 2026-04-24
 
 ### Fixed

--- a/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
@@ -42,7 +42,7 @@ jobs:
           helm plugin install https://github.com/losisin/helm-values-schema-json \
             --version $HELM_VALUES_SCHEMA_JSON_VERSION
 [[- end ]]
-[[- if eq .Language "go" ]] 
+[[- if eq .Language "go" ]]
       - name: Set up Go environment
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
@@ -38,9 +38,9 @@ jobs:
           key: ${{ runner.os }}-${{ env.HELM_VALUES_SCHEMA_JSON_VERSION }}-schema
       - name: Install helm-values-schema-json
         if: steps.cache-schema.outputs.cache-hit != 'true'
-        run:
-          helm plugin install https://github.com/losisin/helm-values-schema-json --version
-          $HELM_VALUES_SCHEMA_JSON_VERSION
+        run: |
+          helm plugin install https://github.com/losisin/helm-values-schema-json \
+            --version $HELM_VALUES_SCHEMA_JSON_VERSION
 [[- end ]]
 [[- if eq .Language "go" ]] 
       - name: Set up Go environment


### PR DESCRIPTION
Otherwise the pre-commit workflow complains about itself, as seen here: https://github.com/giantswarm/mcp-capi/actions/runs/24894611881/job/72895863312?pr=100

### Checklist

- [x] Update changelog in CHANGELOG.md.
