### PR TITLE
feat: enforce Conventional Commits in generated repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Generate a `semantic_pull_request.yaml` GitHub Actions workflow in every repo. It calls the new `giantswarm/github-workflows/.github/workflows/semantic-pull-request.yaml` reusable workflow, which validates that the PR title follows Conventional Commits. The check runs on `pull_request` (`opened`, `edited`, `synchronize`) and uses the action's default type set (`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`).
+- Add `compilerla/conventional-pre-commit` hook to the generated `.pre-commit-config.yaml`, gated to the `commit-msg` stage. Contributors enable it locally with `pre-commit install --hook-type commit-msg`.
+
 ### Changed
 
 - Upgrade `github.com/google/go-github` from v85 to v86.

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -54,6 +54,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	inputs := []input.Input{
 		workflowsInput.CreateRelease(),
 		workflowsInput.CreateReleasePR(),
+		workflowsInput.SemanticPullRequest(),
 		workflowsInput.ValidateChangelog(),
 	}
 

--- a/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
@@ -13,6 +13,13 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
         exclude: ".*testdata/.*"
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [--strict]
 {{- if eq .Language "python" }}
 
   # Python hooks

--- a/pkg/gen/input/workflows/internal/file/semantic_pull_request.go
+++ b/pkg/gen/input/workflows/internal/file/semantic_pull_request.go
@@ -1,0 +1,31 @@
+package file
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/devctl/v7/pkg/gen/input"
+	"github.com/giantswarm/devctl/v7/pkg/gen/input/workflows/internal/params"
+)
+
+//go:embed semantic_pull_request.yaml.template
+var semanticPullRequestTemplate string
+
+//go:generate go run ../../../update-template-sha.go semantic_pull_request.yaml.template
+//go:embed semantic_pull_request.yaml.template.sha
+var semanticPullRequestTemplateSha string
+
+func NewSemanticPullRequestInput(p params.Params) input.Input {
+	i := input.Input{
+		Path:         params.RegenerableFileName(p, "semantic_pull_request.yaml"),
+		TemplateBody: semanticPullRequestTemplate,
+		TemplateDelims: input.InputTemplateDelims{
+			Left:  "{{{{",
+			Right: "}}}}",
+		},
+		TemplateData: map[string]interface{}{
+			"Header": params.Header("#", semanticPullRequestTemplateSha),
+		},
+	}
+
+	return i
+}

--- a/pkg/gen/input/workflows/internal/file/semantic_pull_request.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/semantic_pull_request.yaml.template
@@ -1,0 +1,17 @@
+{{{{ .Header }}}}
+name: semantic-pull-request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions: {}
+
+jobs:
+  semantic-pull-request:
+    uses: giantswarm/github-workflows/.github/workflows/semantic-pull-request.yaml@main
+    permissions:
+      pull-requests: read

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -77,6 +77,10 @@ func (w *Workflows) RunOSSFScorecard() input.Input {
 	return file.NewRunOSSFScorecardInput(w.params)
 }
 
+func (w *Workflows) SemanticPullRequest() input.Input {
+	return file.NewSemanticPullRequestInput(w.params)
+}
+
 func (w *Workflows) SyncFromUpstream() input.Input {
 	return file.NewSyncFromUpstreamInput(w.params)
 }


### PR DESCRIPTION
## Summary

Adds two layers of Conventional Commits enforcement, wired into devctl's generators so every regenerated repo picks them up automatically.

### Authoritative gate — PR-title workflow

A new always-on workflow `semantic_pull_request.yaml` is added to `.github/workflows/` for every repo. It calls the new reusable workflow giantswarm/github-workflows#175 (must merge first), which validates the PR title against [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) using the action's default type set (`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` — same as [commitizen/conventional-commit-types](https://github.com/commitizen/conventional-commit-types)).

Triggered on `pull_request` with `types: [opened, edited, synchronize]`. Non-bypassable, becomes a required check on the PR — and the squash-merge commit message comes from the PR title so `main`'s history stays Conventional Commits-compliant regardless of in-PR commit hygiene.

### Local advisory — commit-msg hook

Adds [`compilerla/conventional-pre-commit`](https://github.com/compilerla/conventional-pre-commit) to the generated `.pre-commit-config.yaml`, gated to `stages: [commit-msg]`. The CI pre-commit action runs `pre-commit run --all-files` which only executes the `pre-commit` stage, so this hook is **local-only**.

Contributors activate it once per checkout with:

```sh
pre-commit install --hook-type commit-msg
```

## Rollout impact

Every consumer repo that runs `devctl gen workflows` and `devctl gen precommit` after this lands will pick up both files on next regeneration. Existing in-flight PRs whose titles don't follow Conventional Commits will start failing the new check immediately. Worth a heads-up in #team-engineering before the next devctl release cuts.

## Renovate

All three version pins are covered by existing Renovate config — no `renovate.json5` changes:

| Pin | Manager |
|---|---|
| `compilerla/conventional-pre-commit@v4.4.0` in precommit template | custom regex manager (`renovate.json5:16-23`) |
| `amannn/action-semantic-pull-request@<sha>` in github-workflows | github-actions manager + `helpers:pinGitHubActionDigests` |
| `giantswarm/github-workflows/...@main` in wrapper template | intentionally excluded (`renovate.json5:69-74`) |

## Verified

- `go test ./...` — all green
- Smoke-tested `devctl gen workflows --flavour generic` — `zz_generated.semantic_pull_request.yaml` lands with correct content
- Smoke-tested `devctl gen precommit --language generic --repo-name test` — `conventional-pre-commit` block appears with `stages: [commit-msg]`