### PR TITLE
fix(approve-align-files): adapt title for align-files PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Change the PR name looked for in `devctl pr approve-align-files` from `Align files` to `chore: align files according to platform standards`
+
 ## [7.41.0] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ devctl gen license
 # where you or your team is requested for review
 devctl pr approve-merge-renovate "architect-orb v7.8.9"
 
-# Approve "Align files" PRs
+# Approve align-files PRs
 # where you are requested for review
+# (full PR title: "chore: align files according to platform standards")
 devctl pr approve-align-files
 ```
 

--- a/cmd/pr/approvealign/runner.go
+++ b/cmd/pr/approvealign/runner.go
@@ -58,10 +58,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	githubClient := ghClientService.GetUnderlyingClient(ctx)
 
-	// Search for "Align files" PRs
+	// Search for align-files PRs
 	// Note: We don't filter by status:success here because we want to find all PRs
 	// and then check/wait for their status in processPR (similar to approve-merge-renovate)
-	searchQuery := `is:pr is:open archived:false org:giantswarm review-requested:@me "Align files"`
+	searchQuery := `is:pr is:open archived:false org:giantswarm review-requested:@me "chore: align files according to platform standards"`
 
 	searchOpts := &github.SearchOptions{
 		ListOptions: github.ListOptions{PerPage: 100},


### PR DESCRIPTION
Adapting the `devctl pr approve-align-files` command for mass-approving PRs to find the PRs with their new PR title.

The command name `approve-align-files` IMO still fits, as "align-files" works as a shorthand for the longer PR title. People can make the connection.

### Checklist

- [x] Update changelog in CHANGELOG.md.
