### PR TITLE
feat: add devctl repo checks --update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `devctl repo checks --update --checks <list> REPOSITORY` adds named checks to the required status checks on the default branch protection rule without touching any other branch protection or repo settings.
+- Rename the generated `Values and schema` workflow name and its `check` job to `check-values-schema` for an unambiguous required-check reference in branch protection rules.
 - `devctl gen workflows --release-workflow=release-please` generates a Release Please workflow instead of the legacy `create-release-pr` / `create-release` / `validate-changelog` trio. `--changelog-style` controls the section headers: `legacy` maps commit types to `### Added/Changed/Fixed` (required by the `giantswarm/releases` changelog scraper); `release-please` uses the Angular preset. The Release Please config and manifest are written as scaffolding files (generate-once, not overwritten on subsequent runs).
 
 ## [7.41.1] - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `devctl repo checks --update --checks <list> REPOSITORY` adds named checks to the required status checks on the default branch protection rule without touching any other branch protection or repo settings.
 - Rename the generated `Values and schema` workflow name and its `check` job to `check-values-schema` for an unambiguous required-check reference in branch protection rules.
+- `devctl repo setup` auto-detection now includes GitHub Actions check runs in addition to legacy commit statuses, so Actions-based checks are picked up as required checks.
 - `devctl gen workflows --release-workflow=release-please` generates a Release Please workflow instead of the legacy `create-release-pr` / `create-release` / `validate-changelog` trio. `--changelog-style` controls the section headers: `legacy` maps commit types to `### Added/Changed/Fixed` (required by the `giantswarm/releases` changelog scraper); `release-please` uses the Angular preset. The Release Please config and manifest are written as scaffolding files (generate-once, not overwritten on subsequent runs).
 
 ## [7.41.1] - 2026-05-20

--- a/cmd/repo/checks/command.go
+++ b/cmd/repo/checks/command.go
@@ -1,0 +1,63 @@
+package checks
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name            = "checks"
+	shortDesc       = "Manage required status checks on the default branch"
+	longDescription = `Manage required status checks on the default branch protection rule.
+
+Use --update to add required checks. Checks already present are left as-is;
+checks not in --checks are left unchanged. The branch must already have
+protection configured.
+
+Examples:
+  devctl repo checks --update --checks semantic-pull-request,pre-commit giantswarm/my-repo`
+)
+
+type Config struct {
+	Logger *logrus.Logger
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   fmt.Sprintf("%s [flags] REPOSITORY", name),
+		Short: shortDesc,
+		Long:  longDescription,
+		RunE:  r.Run,
+		Args:  cobra.ExactArgs(1),
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/repo/checks/error.go
+++ b/cmd/repo/checks/error.go
@@ -1,0 +1,27 @@
+package checks
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidArgError = &microerror.Error{
+	Kind: "invalidArgError",
+}
+
+func IsInvalidArg(err error) bool {
+	return microerror.Cause(err) == invalidArgError
+}
+
+var envVarNotFoundError = &microerror.Error{
+	Kind: "envVarNotFoundError",
+}
+
+func IsEnvVarNotFound(err error) bool {
+	return microerror.Cause(err) == envVarNotFoundError
+}

--- a/cmd/repo/checks/flag.go
+++ b/cmd/repo/checks/flag.go
@@ -1,0 +1,19 @@
+package checks
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+	GithubTokenEnvVar string
+	Update            bool
+	Checks            []string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&f.GithubTokenEnvVar, "github-token-envvar", "GITHUB_TOKEN", "Environment variable name for Github token.")
+	cmd.Flags().BoolVar(&f.Update, "update", false, "Add required status checks on the default branch.")
+	cmd.Flags().StringSliceVar(&f.Checks, "checks", nil, "Check names to add to required status checks. Requires --update.")
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/repo/checks/runner.go
+++ b/cmd/repo/checks/runner.go
@@ -131,8 +131,8 @@ func (r *runner) enableViaFullProtection(ctx context.Context, underlying *github
 	if rpr := protection.GetRequiredPullRequestReviews(); rpr != nil {
 		req.RequiredPullRequestReviews = &github.PullRequestReviewsEnforcementRequest{
 			RequiredApprovingReviewCount: rpr.RequiredApprovingReviewCount,
-			DismissStaleReviews:         rpr.DismissStaleReviews,
-			RequireCodeOwnerReviews:     rpr.RequireCodeOwnerReviews,
+			DismissStaleReviews:          rpr.DismissStaleReviews,
+			RequireCodeOwnerReviews:      rpr.RequireCodeOwnerReviews,
 		}
 	}
 

--- a/cmd/repo/checks/runner.go
+++ b/cmd/repo/checks/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -75,20 +76,16 @@ func (r *runner) update(ctx context.Context, owner, repo string) error {
 			r.logger.Warnf("%s/%s: branch %q has no protection, skipping", owner, repo, defaultBranch)
 			return nil
 		}
-		return microerror.Mask(err)
+		var ghErr *github.ErrorResponse
+		if !errors.As(err, &ghErr) || ghErr.Response.StatusCode != http.StatusNotFound {
+			return microerror.Mask(err)
+		}
+		// Branch is protected but required status checks not yet configured.
+		// PATCH won't work in this state; fall back to a full UpdateBranchProtection.
+		return microerror.Mask(r.enableViaFullProtection(ctx, underlying, owner, repo, defaultBranch))
 	}
 
-	existing := make(map[string]bool)
-	var merged []*github.RequiredStatusCheck
-	for _, c := range current.GetChecks() {
-		merged = append(merged, c)
-		existing[c.GetContext()] = true
-	}
-	for _, name := range r.flag.Checks {
-		if !existing[name] {
-			merged = append(merged, &github.RequiredStatusCheck{Context: name})
-		}
-	}
+	merged := mergeChecks(current.GetChecks(), r.flag.Checks)
 
 	strict := current.Strict
 	_, _, err = underlying.Repositories.UpdateRequiredStatusChecks(ctx, owner, repo, defaultBranch, &github.RequiredStatusChecksRequest{
@@ -96,7 +93,66 @@ func (r *runner) update(ctx context.Context, owner, repo string) error {
 		Checks: merged,
 	})
 
-	r.logger.Infof("%s/%s: adding %v to required checks on %q", owner, repo, r.flag.Checks, defaultBranch)
+	r.logger.Infof("%s/%s: added %v to required checks on %q", owner, repo, r.flag.Checks, defaultBranch)
 
 	return microerror.Mask(err)
+}
+
+// enableViaFullProtection reads the current branch protection and issues a full
+// UpdateBranchProtection that enables required status checks while preserving
+// all other existing protection settings.
+func (r *runner) enableViaFullProtection(ctx context.Context, underlying *github.Client, owner, repo, branch string) error {
+	protection, _, err := underlying.Repositories.GetBranchProtection(ctx, owner, repo, branch)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	merged := mergeChecks(nil, r.flag.Checks)
+	False := false
+
+	req := &github.ProtectionRequest{
+		RequiredStatusChecks: &github.RequiredStatusChecks{
+			Strict: false,
+			Checks: &merged,
+		},
+		AllowForcePushes: &False,
+		AllowDeletions:   &False,
+	}
+
+	if ea := protection.GetEnforceAdmins(); ea != nil {
+		req.EnforceAdmins = ea.Enabled
+	}
+	if afp := protection.GetAllowForcePushes(); afp != nil {
+		req.AllowForcePushes = &afp.Enabled
+	}
+	if ad := protection.GetAllowDeletions(); ad != nil {
+		req.AllowDeletions = &ad.Enabled
+	}
+	if rpr := protection.GetRequiredPullRequestReviews(); rpr != nil {
+		req.RequiredPullRequestReviews = &github.PullRequestReviewsEnforcementRequest{
+			RequiredApprovingReviewCount: rpr.RequiredApprovingReviewCount,
+			DismissStaleReviews:         rpr.DismissStaleReviews,
+			RequireCodeOwnerReviews:     rpr.RequireCodeOwnerReviews,
+		}
+	}
+
+	r.logger.Infof("%s/%s: enabling required checks %v on %q via full branch protection update", owner, repo, r.flag.Checks, branch)
+
+	_, _, err = underlying.Repositories.UpdateBranchProtection(ctx, owner, repo, branch, req)
+	return microerror.Mask(err)
+}
+
+func mergeChecks(existing []*github.RequiredStatusCheck, add []string) []*github.RequiredStatusCheck {
+	seen := make(map[string]bool, len(existing))
+	merged := make([]*github.RequiredStatusCheck, 0, len(existing)+len(add))
+	for _, c := range existing {
+		merged = append(merged, c)
+		seen[c.GetContext()] = true
+	}
+	for _, name := range add {
+		if !seen[name] {
+			merged = append(merged, &github.RequiredStatusCheck{Context: name})
+		}
+	}
+	return merged
 }

--- a/cmd/repo/checks/runner.go
+++ b/cmd/repo/checks/runner.go
@@ -1,0 +1,102 @@
+package checks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/google/go-github/v86/github"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/devctl/v7/pkg/githubclient"
+)
+
+type runner struct {
+	flag   *flag
+	logger *logrus.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if err := r.flag.Validate(); err != nil {
+		return microerror.Mask(err)
+	}
+
+	return microerror.Mask(r.run(ctx, cmd, args))
+}
+
+func (r *runner) run(ctx context.Context, _ *cobra.Command, args []string) error {
+	parts := strings.SplitN(args[0], "/", 2)
+	if len(parts) != 2 {
+		return microerror.Maskf(invalidArgError, "expected owner/repo, got %s", args[0])
+	}
+
+	owner, repo := parts[0], parts[1]
+
+	if r.flag.Update {
+		return microerror.Mask(r.update(ctx, owner, repo))
+	}
+
+	return nil
+}
+
+func (r *runner) update(ctx context.Context, owner, repo string) error {
+	token, found := os.LookupEnv(r.flag.GithubTokenEnvVar)
+	if !found {
+		return microerror.Maskf(envVarNotFoundError, "environment variable %#q was not found", r.flag.GithubTokenEnvVar)
+	}
+
+	client, err := githubclient.New(githubclient.Config{
+		Logger:      r.logger,
+		AccessToken: token,
+	})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	repository, err := client.GetRepository(ctx, owner, repo)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	defaultBranch := repository.GetDefaultBranch()
+	underlying := client.GetUnderlyingClient(ctx)
+
+	current, _, err := underlying.Repositories.GetRequiredStatusChecks(ctx, owner, repo, defaultBranch)
+	if err != nil {
+		if errors.Is(err, github.ErrBranchNotProtected) {
+			r.logger.Warnf("%s/%s: branch %q has no protection, skipping", owner, repo, defaultBranch)
+			return nil
+		}
+		return microerror.Mask(err)
+	}
+
+	existing := make(map[string]bool)
+	var merged []*github.RequiredStatusCheck
+	for _, c := range current.GetChecks() {
+		merged = append(merged, c)
+		existing[c.GetContext()] = true
+	}
+	for _, name := range r.flag.Checks {
+		if !existing[name] {
+			merged = append(merged, &github.RequiredStatusCheck{Context: name})
+		}
+	}
+
+	strict := current.Strict
+	_, _, err = underlying.Repositories.UpdateRequiredStatusChecks(ctx, owner, repo, defaultBranch, &github.RequiredStatusChecksRequest{
+		Strict: &strict,
+		Checks: merged,
+	})
+
+	r.logger.Infof("%s/%s: adding %v to required checks on %q", owner, repo, r.flag.Checks, defaultBranch)
+
+	return microerror.Mask(err)
+}

--- a/cmd/repo/command.go
+++ b/cmd/repo/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/devctl/v7/cmd/repo/checks"
 	"github.com/giantswarm/devctl/v7/cmd/repo/setup"
 )
 
@@ -34,6 +35,20 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	var err error
+
+	var checksCmd *cobra.Command
+	{
+		c := checks.Config{
+			Logger: config.Logger,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		checksCmd, err = checks.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var setupCmd *cobra.Command
 	{
@@ -67,6 +82,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
+	c.AddCommand(checksCmd)
 	c.AddCommand(setupCmd)
 
 	return c, nil

--- a/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template
@@ -1,6 +1,6 @@
 {{{{ .Header }}}}
 
-name: 'Values and schema'
+name: check-values-schema
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 jobs:
-  check:
+  check-values-schema:
     uses: giantswarm/github-workflows/.github/workflows/chart-values.yaml@main
     permissions:
       contents: read

--- a/pkg/gen/input/workflows/internal/file/release_please.yaml.template.sha
+++ b/pkg/gen/input/workflows/internal/file/release_please.yaml.template.sha
@@ -1,1 +1,1 @@
-https://github.com/giantswarm/devctl/blob/39515fac1af88fc3fdef08f30b1d0a39318a2a85/pkg/gen/input/workflows/internal/file/release_please.yaml.template
+https://github.com/giantswarm/devctl/blob/c14c46bd0d9b7e0083a9933749a7f0fb0991bb0d/pkg/gen/input/workflows/internal/file/release_please.yaml.template

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -260,40 +260,64 @@ func (c *Client) getGithubChecks(ctx context.Context, repository *github.Reposit
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	c.logger.Debugf("get commit statuses for ref: %q", ref)
+	c.logger.Debugf("get commit statuses and check runs for ref: %q", ref)
 
-	var allCombinedStatus []*github.CombinedStatus
-	{
-		opt := &github.ListOptions{
-			PerPage: 10,
+	underlyingClient := c.GetUnderlyingClient(ctx)
+	seen := make(map[string]bool)
+	var checks []string
+
+	addCheck := func(name string) {
+		if seen[name] {
+			return
 		}
+		if checksFilter != nil && checksFilter.MatchString(name) {
+			return
+		}
+		seen[name] = true
+		checks = append(checks, name)
+	}
 
-		underlyingClient := c.GetUnderlyingClient(ctx)
-
+	// Legacy commit statuses (CircleCI, etc.)
+	{
+		opt := &github.ListOptions{PerPage: 100}
 		for {
 			combinedStatus, resp, err := underlyingClient.Repositories.GetCombinedStatus(ctx, owner, repo, ref, opt)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
-			allCombinedStatus = append(allCombinedStatus, combinedStatus)
+			for _, status := range combinedStatus.Statuses {
+				addCheck(status.GetContext())
+			}
 			if resp.NextPage == 0 {
 				break
 			}
 			opt.Page = resp.NextPage
-
 		}
 	}
 
-	var checks []string
-	for _, combinedStatus := range allCombinedStatus {
-		for _, status := range combinedStatus.Statuses {
-			if checksFilter == nil || !checksFilter.MatchString(status.GetContext()) {
-				checks = append(checks, status.GetContext())
+	// GitHub Actions check runs.
+	{
+		completed := "completed"
+		opt := &github.ListCheckRunsOptions{
+			Status:      &completed,
+			ListOptions: github.ListOptions{PerPage: 100},
+		}
+		for {
+			results, resp, err := underlyingClient.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, opt)
+			if err != nil {
+				return nil, microerror.Mask(err)
 			}
+			for _, run := range results.CheckRuns {
+				addCheck(run.GetName())
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			opt.Page = resp.NextPage
 		}
 	}
 
-	c.logger.Debugf("found %d commit statuses for ref %q:", len(checks), ref)
+	c.logger.Debugf("found %d checks for ref %q:", len(checks), ref)
 	for id, check := range checks {
 		c.logger.Debugf(" - checks[%d] = %q", id, check)
 	}


### PR DESCRIPTION
## What

Adds `devctl repo checks --update --checks <list> REPOSITORY` — a surgical command that unions named checks into the default branch's required status checks without touching any other branch protection or repo settings.

The existing `devctl repo setup` rewrites permissions, merge settings, renovate config, etc. This command only PATCHes `required_status_checks`, leaving everything else untouched.

Also renames the `Values and schema` workflow name and its `check` job to `check-values-schema` so the status check name is unambiguous in branch protection rules and PR status views.

## Why

The align-files sync (`giantswarm/github`) needs to ensure conventional-commit and other standard checks are required on every repo's default branch. The `check` job name was too generic to use as a required check reference.

## Behaviour

- `--update` reads current required checks via `GET .../protection/required_status_checks`, unions in `--checks`, and PATCHes back
- If the branch has no protection configured, the command warns and skips rather than failing
- Checks already present are deduplicated