### PR TITLE
feat(gen): release-please project.go extra-files, ldflags version, app mk path fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `devctl gen workflows --release-workflow=release-please` now adds `pkg/project/project.go` to `extra-files` in `release-please-config.json` when the language is Go and the file exists, so release-please updates the version constant in the release PR. No post-release dev-bump PR is needed.
+- `Makefile.gen.go.mk` now injects the version into the binary via `-X .../pkg/project.version=$(VERSION)` in `LDFLAGS`, alongside the existing `buildTimestamp` and `gitSHA` flags. `VERSION` is derived from `architect project version` (git tag), so local and CI builds self-report correctly without modifying `project.go` at build time.
+
+### Fixed
+
+- The generated `Release Please` workflow referenced a non-existent reusable workflow (`release-please.yaml`); corrected to `release.yaml`.
+- `Makefile.gen.app.mk` used `$(APPLICATION)/charts` for Helm dependency paths; all repos place charts under `helm/$(APPLICATION)/`, so the `DEPS`, `update-deps`, `$(DEPS)`, and `helm-docs` targets now use `helm/$(APPLICATION)/` as the base path.
+
 ## [7.42.0] - 2026-05-21
 
 ### Added

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -3,6 +3,7 @@ package workflows
 import (
 	"context"
 	"io"
+	"os"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -36,7 +37,7 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	var err error
 
 	var workflowsInput *workflows.Workflows
@@ -56,9 +57,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	if r.flag.ReleaseWorkflow == "release-please" {
+		_, statErr := os.Stat("pkg/project/project.go")
+		hasProjectGo := r.flag.Language == "go" && statErr == nil
 		inputs = append(inputs,
 			workflowsInput.ReleasePlease(),
-			workflowsInput.ReleasePleaseConfig(r.flag.ChangelogStyle),
+			workflowsInput.ReleasePleaseConfig(r.flag.ChangelogStyle, hasProjectGo),
 			workflowsInput.ReleasePleaseManifest(),
 		)
 	} else {

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.app.mk.template
@@ -6,7 +6,7 @@ YQ=docker run --rm -u $$(id -u) -v $${PWD}:/workdir mikefarah/yq:4.29.2
 HELM_DOCS=docker run --rm -u $$(id -u) -v $${PWD}:/helm-docs jnorwood/helm-docs:v1.11.0
 
 ifdef APPLICATION
-DEPS := $(shell find $(APPLICATION)/charts -maxdepth 2 -name "Chart.yaml" -printf "%h\n")
+DEPS := $(shell find helm/$(APPLICATION)/charts -maxdepth 2 -name "Chart.yaml" -printf "%h\n" 2>/dev/null)
 endif
 
 .PHONY: lint-chart check-env update-chart helm-docs update-deps $(DEPS)
@@ -27,15 +27,15 @@ update-chart: check-env ## Sync chart with upstream repo.
 	$(MAKE) update-deps
 
 update-deps: check-env $(DEPS) ## Update Helm dependencies.
-	cd $(APPLICATION) && helm dependency update
+	cd helm/$(APPLICATION) && helm dependency update
 
 $(DEPS): check-env ## Update main Chart.yaml with new local dep versions.
 	dep_name=$(shell basename $@) && \
-	new_version=`$(YQ) .version $(APPLICATION)/charts/$$dep_name/Chart.yaml` && \
-	$(YQ) -i e "with(.dependencies[]; select(.name == \"$$dep_name\") | .version = \"$$new_version\")" $(APPLICATION)/Chart.yaml
+	new_version=`$(YQ) .version helm/$(APPLICATION)/charts/$$dep_name/Chart.yaml` && \
+	$(YQ) -i e "with(.dependencies[]; select(.name == \"$$dep_name\") | .version = \"$$new_version\")" helm/$(APPLICATION)/Chart.yaml
 
 helm-docs: check-env ## Update $(APPLICATION) README.
-	$(HELM_DOCS) -c $(APPLICATION) -g $(APPLICATION)
+	$(HELM_DOCS) -c helm/$(APPLICATION) -g helm/$(APPLICATION)
 
 check-env:
 ifndef APPLICATION

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -19,8 +19,9 @@ ifeq ($(OS), linux)
 EXTLDFLAGS := -static
 endif
 LDFLAGS        ?= -w -linkmode 'auto' -extldflags '$(EXTLDFLAGS)' \
-  -X '$(shell go list -m)/pkg/project.buildTimestamp=${BUILDTIMESTAMP}' \
-  -X '$(shell go list -m)/pkg/project.gitSHA=${GITSHA1}'
+  -X '$(MODULE)/pkg/project.version=$(VERSION)' \
+  -X '$(MODULE)/pkg/project.buildTimestamp=$(BUILDTIMESTAMP)' \
+  -X '$(MODULE)/pkg/project.gitSHA=$(GITSHA1)'
 
 .DEFAULT_GOAL := build
 

--- a/pkg/gen/input/workflows/internal/file/release_please.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/release_please.yaml.template
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   release_please:
-    uses: giantswarm/github-workflows/.github/workflows/release-please.yaml@main
+    uses: giantswarm/github-workflows/.github/workflows/release.yaml@main
     permissions:
       contents: write
       pull-requests: write

--- a/pkg/gen/input/workflows/internal/file/release_please.yaml.template.sha
+++ b/pkg/gen/input/workflows/internal/file/release_please.yaml.template.sha
@@ -1,1 +1,1 @@
-https://github.com/giantswarm/devctl/blob/c14c46bd0d9b7e0083a9933749a7f0fb0991bb0d/pkg/gen/input/workflows/internal/file/release_please.yaml.template
+https://github.com/giantswarm/devctl/blob/cd16e904bbe96fc5a776b8e57aca0a7fc8d033ac/pkg/gen/input/workflows/internal/file/release_please.yaml.template

--- a/pkg/gen/input/workflows/internal/file/release_please_config.go
+++ b/pkg/gen/input/workflows/internal/file/release_please_config.go
@@ -13,7 +13,7 @@ var releasePleaseConfigTemplate string
 // NewReleasePleaseConfigInput returns a scaffolding Input (generate-once) for
 // release-please-config.json in the repository root. Existing files are never
 // overwritten so users can extend the config (e.g. add version-files).
-func NewReleasePleaseConfigInput(changelogStyle string) input.Input {
+func NewReleasePleaseConfigInput(changelogStyle string, hasProjectGo bool) input.Input {
 	return input.Input{
 		Path:         filepath.Join(".", "release-please-config.json"),
 		TemplateBody: releasePleaseConfigTemplate,
@@ -23,6 +23,7 @@ func NewReleasePleaseConfigInput(changelogStyle string) input.Input {
 		},
 		TemplateData: map[string]interface{}{
 			"LegacyChangelog": changelogStyle != "release-please",
+			"HasProjectGo":    hasProjectGo,
 		},
 	}
 }

--- a/pkg/gen/input/workflows/internal/file/release_please_config.json.template
+++ b/pkg/gen/input/workflows/internal/file/release_please_config.json.template
@@ -1,5 +1,10 @@
 {{{{- if .LegacyChangelog }}}}{
   "release-type": "simple",
+  {{{{- if .HasProjectGo }}}}
+  "extra-files": [
+    {"type": "generic", "path": "pkg/project/project.go"}
+  ],
+  {{{{- end }}}}
   "changelog-sections": [
     {"type": "feat",     "section": "### Added"},
     {"type": "fix",      "section": "### Fixed"},
@@ -15,6 +20,11 @@
 }
 {{{{- else }}}}{
   "release-type": "simple",
+  {{{{- if .HasProjectGo }}}}
+  "extra-files": [
+    {"type": "generic", "path": "pkg/project/project.go"}
+  ],
+  {{{{- end }}}}
   "changelog-sections": [
     {"type": "feat",     "section": "### Added"},
     {"type": "fix",      "section": "### Fixed"},

--- a/pkg/gen/input/workflows/internal/file/release_please_config_test.go
+++ b/pkg/gen/input/workflows/internal/file/release_please_config_test.go
@@ -8,6 +8,11 @@ import (
 	"text/template"
 )
 
+type releasePleaseExtraFile struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
 type releasePleaseSection struct {
 	Type    string `json:"type"`
 	Section string `json:"section"`
@@ -15,19 +20,23 @@ type releasePleaseSection struct {
 }
 
 type releasePleaseConfig struct {
-	ReleaseType       string                 `json:"release-type"`
-	ChangelogSections []releasePleaseSection `json:"changelog-sections"`
+	ReleaseType       string                   `json:"release-type"`
+	ExtraFiles        []releasePleaseExtraFile `json:"extra-files"`
+	ChangelogSections []releasePleaseSection   `json:"changelog-sections"`
 }
 
 func Test_NewReleasePleaseConfigInput(t *testing.T) {
 	testCases := []struct {
 		name             string
 		changelogStyle   string
+		hasProjectGo     bool
 		expectedSections map[string]string
+		expectExtraFiles []releasePleaseExtraFile
 	}{
 		{
-			name:           "release-please style writes full Angular-to-KaC mapping plus security",
+			name:           "release-please style without project.go",
 			changelogStyle: "release-please",
+			hasProjectGo:   false,
 			expectedSections: map[string]string{
 				"feat":     "### Added",
 				"fix":      "### Fixed",
@@ -44,8 +53,31 @@ func Test_NewReleasePleaseConfigInput(t *testing.T) {
 			},
 		},
 		{
-			name:           "legacy style keeps existing types and adds security",
+			name:           "release-please style with project.go",
+			changelogStyle: "release-please",
+			hasProjectGo:   true,
+			expectedSections: map[string]string{
+				"feat":     "### Added",
+				"fix":      "### Fixed",
+				"perf":     "### Changed",
+				"revert":   "### Changed",
+				"refactor": "### Changed",
+				"docs":     "### Changed",
+				"style":    "### Changed",
+				"test":     "### Changed",
+				"build":    "### Changed",
+				"ci":       "### Changed",
+				"chore":    "### Changed",
+				"security": "### Security",
+			},
+			expectExtraFiles: []releasePleaseExtraFile{
+				{Type: "generic", Path: "pkg/project/project.go"},
+			},
+		},
+		{
+			name:           "legacy style without project.go",
 			changelogStyle: "legacy",
+			hasProjectGo:   false,
 			expectedSections: map[string]string{
 				"feat":     "### Added",
 				"fix":      "### Fixed",
@@ -59,11 +91,31 @@ func Test_NewReleasePleaseConfigInput(t *testing.T) {
 				"security": "### Security",
 			},
 		},
+		{
+			name:           "legacy style with project.go",
+			changelogStyle: "legacy",
+			hasProjectGo:   true,
+			expectedSections: map[string]string{
+				"feat":     "### Added",
+				"fix":      "### Fixed",
+				"refactor": "### Changed",
+				"perf":     "### Changed",
+				"docs":     "### Changed",
+				"chore":    "### Changed",
+				"test":     "### Changed",
+				"build":    "### Changed",
+				"ci":       "### Changed",
+				"security": "### Security",
+			},
+			expectExtraFiles: []releasePleaseExtraFile{
+				{Type: "generic", Path: "pkg/project/project.go"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			in := NewReleasePleaseConfigInput(tc.changelogStyle)
+			in := NewReleasePleaseConfigInput(tc.changelogStyle, tc.hasProjectGo)
 
 			tpl, err := template.New("release-please-config").
 				Delims(in.TemplateDelims.Left, in.TemplateDelims.Right).
@@ -95,6 +147,10 @@ func Test_NewReleasePleaseConfigInput(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotSections, tc.expectedSections) {
 				t.Errorf("changelog-sections mismatch\ngot:  %#v\nwant: %#v", gotSections, tc.expectedSections)
+			}
+
+			if !reflect.DeepEqual(got.ExtraFiles, tc.expectExtraFiles) {
+				t.Errorf("extra-files mismatch\ngot:  %#v\nwant: %#v", got.ExtraFiles, tc.expectExtraFiles)
 			}
 		})
 	}

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -109,8 +109,8 @@ func (w *Workflows) ReleasePlease() input.Input {
 	return file.NewReleasePleaseInput(w.params)
 }
 
-func (w *Workflows) ReleasePleaseConfig(changelogStyle string) input.Input {
-	return file.NewReleasePleaseConfigInput(changelogStyle)
+func (w *Workflows) ReleasePleaseConfig(changelogStyle string, hasProjectGo bool) input.Input {
+	return file.NewReleasePleaseConfigInput(changelogStyle, hasProjectGo)
 }
 
 func (w *Workflows) ReleasePleaseManifest() input.Input {


### PR DESCRIPTION
## Summary

- Fix generated `Release Please` workflow: the reusable workflow was referenced as `release-please.yaml` but the actual file in `giantswarm/github-workflows` is `release.yaml`.
- When `--release-workflow=release-please` and `--language=go`, add `pkg/project/project.go` to `extra-files` in `release-please-config.json` (scaffolded) if the file exists. Release-please updates the version constant inside the release PR, removing the need for a separate post-release dev-bump PR.
- Add `-X .../pkg/project.version=$(VERSION)` to `LDFLAGS` in `Makefile.gen.go.mk`. `VERSION` comes from `architect project version` (git tag), so local and CI builds self-report the correct version at build time without requiring `project.go` to be modified out-of-band.
- Fix `Makefile.gen.app.mk` Helm dependency paths: `$(APPLICATION)/charts` → `helm/$(APPLICATION)/charts` in `DEPS`, `update-deps`, the per-dep update targets, and `helm-docs`. All GS repos place charts under `helm/<name>/`, not at the repo root.