### PR TITLE
fix(ci): untrack release_please.yaml.template.sha

### DIFF
--- a/pkg/gen/input/workflows/internal/file/release_please.yaml.template.sha
+++ b/pkg/gen/input/workflows/internal/file/release_please.yaml.template.sha
@@ -1,1 +1,0 @@
-https://github.com/giantswarm/devctl/blob/cd16e904bbe96fc5a776b8e57aca0a7fc8d033ac/pkg/gen/input/workflows/internal/file/release_please.yaml.template


### PR DESCRIPTION
\`*.template.sha\` files are in \`.gitignore\` and generated fresh by \`go generate ./...\`. \`release_please.yaml.template.sha\` was accidentally committed and tracked, so when CI ran \`generate-go\` it updated the file to the current HEAD SHA, then \`git diff --exit-code\` caught the modification and failed every PR.

Removing it from tracking makes it behave identically to every other \`*.template.sha\` file: generated locally/in CI by \`go generate\`, never tracked.