### PR TITLE
feat(gen): release-please workflow passes GitHub App secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Generated `release-please.yaml` workflow now passes `RELEASE_PLEASE_APP_ID` and `RELEASE_PLEASE_PRIVATE_KEY` secrets to the `giantswarm/github-workflows` `release.yaml` reusable workflow instead of `TAYLORBOT_GITHUB_ACTION`. This matches the App-based authentication introduced in the reusable workflow (replaces the taylorbot PAT). Requires those two org secrets to be available to the consuming repo.
+
 ## [7.43.0] - 2026-05-21
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/release_please.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/release_please.yaml.template
@@ -16,4 +16,5 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      TAYLORBOT_GITHUB_ACTION: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+      RELEASE_PLEASE_APP_ID: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+      RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Update the `release_please.yaml.template` so the generated `release-please.yaml` workflow in consumer repos passes the new GitHub App secrets (`RELEASE_PLEASE_CLIENT_ID`, `RELEASE_PLEASE_PRIVATE_KEY`) to the `giantswarm/github-workflows` `release.yaml` reusable workflow, instead of the old `TAYLORBOT_GITHUB_ACTION` PAT.

This is the consumer-side follow-up to https://github.com/giantswarm/github-workflows/pull/181, which switched the reusable workflow's authentication to a GitHub App token minted via `actions/create-github-app-token` (`client-id:` input).

## Why

- The reusable workflow now mints a short-lived installation token from a GitHub App, so consumers must pass App credentials, not a PAT.
- Both `RELEASE_PLEASE_CLIENT_ID` and `RELEASE_PLEASE_PRIVATE_KEY` are organization-level secrets accessible to all repositories.
- The convention of explicitly passing each secret matches sibling templates like `fix_vulnerabilities.yaml.template`.

## Scope

Only `release_please.yaml.template` is updated. Other templates (`create_release`, `create_release_pr`, `update_chart`) still pass `TAYLORBOT_GITHUB_ACTION` because the reusable workflows they call have not migrated yet.

## Sequencing

1. Merge https://github.com/giantswarm/github-workflows/pull/181 first.
2. Then merge this PR.
3. Then cut a devctl release and regenerate `release-please.yaml` in each consumer repo (`devctl gen workflows --release-workflow=release-please`).

If this PR is merged before #181, repos regenerated in the window will fail their release workflow until #181 lands.

## Test plan

- [ ] Run `devctl gen workflows --release-workflow=release-please` against a scratch repo and confirm the generated `.github/workflows/release-please.yaml` passes `RELEASE_PLEASE_CLIENT_ID` and `RELEASE_PLEASE_PRIVATE_KEY` and no longer references `TAYLORBOT_GITHUB_ACTION`.
- [ ] After both this PR and #181 are merged, regenerate against one low-risk consumer repo and confirm a conventional commit on `main` produces a release PR opened by the GitHub App.