### PR TITLE
feat(gen): add --auto-release-level flag, fix release-please App secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `gen workflows`: Add `--auto-release-level` flag (`none`, `patch`, `minor`, `major`; default `none`), only used with `--release-workflow=release-please`. It sets the `auto-merge-level` input of the `giantswarm/github-workflows` `release.yaml` reusable workflow, which auto-merges the Release Please PR once CI passes, up to the given bump level (`none` disables auto-merge). The consuming repo must have "Allow auto-merge" enabled and the `release-please` GitHub App on its branch-protection bypass list.
+
+### Changed
+
+- Generated `release-please.yaml` workflow now passes `RELEASE_PLEASE_CLIENT_ID` and `RELEASE_PLEASE_PRIVATE_KEY` secrets to the `giantswarm/github-workflows` `release.yaml` reusable workflow instead of `TAYLORBOT_GITHUB_ACTION`. This matches the App-based authentication in the reusable workflow (the reusable workflow feeds `RELEASE_PLEASE_CLIENT_ID` to `create-github-app-token`'s `client-id`). Requires those two org secrets to be available to the consuming repo.
+
 ## [7.43.0] - 2026-05-21
 
 ### Added

--- a/cmd/gen/workflows/flag.go
+++ b/cmd/gen/workflows/flag.go
@@ -22,6 +22,7 @@ const (
 	flagDispatchUpdateChartEventsRepo = "dispatch-update-chart-events-repo"
 	flagReleaseWorkflow               = "release-workflow"
 	flagChangelogStyle                = "changelog-style"
+	flagAutoReleaseLevel              = "auto-release-level"
 )
 
 type flag struct {
@@ -36,6 +37,7 @@ type flag struct {
 	DispatchUpdateChartEventsRepo string
 	ReleaseWorkflow               string
 	ChangelogStyle                string
+	AutoReleaseLevel              string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -50,11 +52,19 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.DispatchUpdateChartEventsRepo, flagDispatchUpdateChartEventsRepo, "", "The repository to dispatch update chart events to. Only valid if --upstream-sync-automation is true.")
 	cmd.Flags().StringVar(&f.ReleaseWorkflow, flagReleaseWorkflow, "legacy", "Release workflow to generate. Possible values: legacy (default), release-please.")
 	cmd.Flags().StringVar(&f.ChangelogStyle, flagChangelogStyle, "legacy", "Changelog section style for release-please. 'legacy' maps conventional commit types to ### Added/Changed/Fixed. 'release-please' uses the Release Please Angular preset. Possible values: legacy (default), release-please.")
+	cmd.Flags().StringVar(&f.AutoReleaseLevel, flagAutoReleaseLevel, "none", "Automatically merge the release-please Release PR when CI passes, up to this bump level. Sets the reusable workflow's 'auto-merge-level' input. Only used with --release-workflow=release-please. Possible values: none (default), patch, minor, major.")
 }
 
 func (f *flag) Validate() error {
 	if len(f.Flavours) == 0 {
 		return microerror.Maskf(invalidFlagError, "--%s must be one of: %s", flagFlavour, strings.Join(gen.AllFlavours(), ", "))
+	}
+
+	switch f.AutoReleaseLevel {
+	case "none", "patch", "minor", "major":
+		// valid
+	default:
+		return microerror.Maskf(invalidFlagError, "--%s must be one of: none, patch, minor, major", flagAutoReleaseLevel)
 	}
 
 	return nil

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -60,7 +60,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		_, statErr := os.Stat("pkg/project/project.go")
 		hasProjectGo := r.flag.Language == "go" && statErr == nil
 		inputs = append(inputs,
-			workflowsInput.ReleasePlease(),
+			workflowsInput.ReleasePlease(r.flag.AutoReleaseLevel),
 			workflowsInput.ReleasePleaseConfig(r.flag.ChangelogStyle, hasProjectGo),
 			workflowsInput.ReleasePleaseManifest(),
 		)

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -25,13 +25,15 @@ To opt a repository into [Release Please](https://github.com/googleapis/release-
 ```nohighlight
 devctl gen workflows --flavour app --language go \
   --release-workflow release-please \
-  --changelog-style legacy
+  --changelog-style legacy \
+  --auto-release-level minor
 ```
 
 | Flag | Values | Default | Notes |
 |------|--------|---------|-------|
 | `--release-workflow` | `legacy`, `release-please` | `legacy` | Switches between the legacy `create-release-pr` flow and Release Please |
 | `--changelog-style` | `legacy`, `release-please` | `legacy` | `legacy` maps commit types to `### Added/Changed/Fixed` (required by the `giantswarm/releases` changelog scraper). `release-please` uses the Angular preset (`### Features`, `### Bug Fixes`, etc.) |
+| `--auto-release-level` | `none`, `patch`, `minor`, `major` | `none` | Auto-merges the Release Please PR when CI passes, up to this bump level (sets the reusable workflow's `auto-merge-level` input). `none` disables auto-merge. Requires "Allow auto-merge" enabled on the repo and the `release-please` GitHub App on its branch-protection bypass list. |
 
 In `release-please` mode, three files are written:
 

--- a/pkg/gen/input/workflows/internal/file/release_please.go
+++ b/pkg/gen/input/workflows/internal/file/release_please.go
@@ -14,7 +14,7 @@ var releasePleaseTemplate string
 //go:embed release_please.yaml.template.sha
 var releasePleaseTemplateSha string
 
-func NewReleasePleaseInput(p params.Params) input.Input {
+func NewReleasePleaseInput(p params.Params, autoMergeLevel string) input.Input {
 	return input.Input{
 		Path:         params.RegenerableFileName(p, "release-please.yaml"),
 		TemplateBody: releasePleaseTemplate,
@@ -23,7 +23,8 @@ func NewReleasePleaseInput(p params.Params) input.Input {
 			Right: "}}}}",
 		},
 		TemplateData: map[string]interface{}{
-			"Header": params.Header("#", releasePleaseTemplateSha),
+			"Header":         params.Header("#", releasePleaseTemplateSha),
+			"AutoMergeLevel": autoMergeLevel,
 		},
 	}
 }

--- a/pkg/gen/input/workflows/internal/file/release_please.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/release_please.yaml.template
@@ -15,5 +15,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    with:
+      auto-merge-level: {{{{ .AutoMergeLevel }}}}
     secrets:
-      TAYLORBOT_GITHUB_ACTION: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+      RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+      RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -105,8 +105,8 @@ func (w *Workflows) ZizmorBaseYml() input.Input {
 	return file.NewZizmorBaseInput(w.params)
 }
 
-func (w *Workflows) ReleasePlease() input.Input {
-	return file.NewReleasePleaseInput(w.params)
+func (w *Workflows) ReleasePlease(autoMergeLevel string) input.Input {
+	return file.NewReleasePleaseInput(w.params, autoMergeLevel)
 }
 
 func (w *Workflows) ReleasePleaseConfig(changelogStyle string, hasProjectGo bool) input.Input {


### PR DESCRIPTION
## What

Lets repositories opt the **release-please** workflow into auto-merging its Release PR, by wiring devctl to the `auto-merge-level` input added to the `giantswarm/github-workflows` `release.yaml` reusable workflow (giantswarm/github-workflows#185, merged).

- New `gen workflows` flag **`--auto-release-level`** (`none` | `patch` | `minor` | `major`; default `none`), only meaningful with `--release-workflow=release-please`. It sets the reusable workflow's `auto-merge-level` input. Invalid values are rejected at gen time.
- **Fixes the generated secrets.** The template still passed `TAYLORBOT_GITHUB_ACTION`, but the reusable workflow switched to GitHub App auth and now requires `RELEASE_PLEASE_CLIENT_ID` + `RELEASE_PLEASE_PRIVATE_KEY` (the former feeds `create-github-app-token`'s `client-id`). The generated `release-please.yaml` was therefore non-functional against `release.yaml@main`; this corrects it.

## Generated output

`--auto-release-level minor`:
```yaml
  release_please:
    uses: giantswarm/github-workflows/.github/workflows/release.yaml@main
    permissions:
      contents: write
      pull-requests: write
    with:
      auto-merge-level: minor
    secrets:
      RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
      RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
```
Default (no flag) renders `auto-merge-level: none`.

## Relationship to other PRs

- Supersedes draft **#1843** (which fixed the secrets but used `RELEASE_PLEASE_APP_ID`; the reusable workflow requires `RELEASE_PLEASE_CLIENT_ID`, not `APP_ID`). Suggest closing #1843 in favor of this. The auth wiring originates in #1831.

## Consuming-repo prerequisites for auto-merge

- `RELEASE_PLEASE_CLIENT_ID` and `RELEASE_PLEASE_PRIVATE_KEY` available as org/repo secrets.
- "Allow auto-merge" enabled in repo settings.
- `release-please` GitHub App on the default branch's protection/ruleset bypass list.

## Verification

- `go generate ./... && go build ./...` and `go test ./pkg/gen/input/workflows/... ./cmd/gen/workflows/...` pass; `gofmt`/`go vet` clean.
- Rendered end-to-end in a scratch repo for `minor`, default (`none`), and an invalid value (rejected by validation).