### PR TITLE
feat(repo checks): add --remove flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `devctl repo checks --update` now accepts `--remove <names>` to drop required status checks. Combined with `--checks`, a single invocation can migrate a check from one name to another (subtract `--remove`, then union `--checks`). Existing checks not named in either flag are left untouched.
+
 ## [7.46.0] - 2026-05-28
 
 ### Added

--- a/cmd/repo/checks/command.go
+++ b/cmd/repo/checks/command.go
@@ -15,12 +15,15 @@ const (
 	shortDesc       = "Manage required status checks on the default branch"
 	longDescription = `Manage required status checks on the default branch protection rule.
 
-Use --update to add required checks. Checks already present are left as-is;
-checks not in --checks are left unchanged. The branch must already have
-protection configured.
+Use --update to add or remove required checks. --checks names are added
+(checks already present are left as-is). --remove names are dropped if
+present. Anything not listed is left unchanged. The branch must already
+have protection configured.
 
 Examples:
-  devctl repo checks --update --checks semantic-pull-request,pre-commit giantswarm/my-repo`
+  devctl repo checks --update --checks 'semantic-pull-request / Validate PR title' giantswarm/my-repo
+  devctl repo checks --update --remove semantic-pull-request giantswarm/my-repo
+  devctl repo checks --update --checks 'semantic-pull-request / Validate PR title' --remove semantic-pull-request giantswarm/my-repo`
 )
 
 type Config struct {

--- a/cmd/repo/checks/flag.go
+++ b/cmd/repo/checks/flag.go
@@ -6,12 +6,14 @@ type flag struct {
 	GithubTokenEnvVar string
 	Update            bool
 	Checks            []string
+	Remove            []string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&f.GithubTokenEnvVar, "github-token-envvar", "GITHUB_TOKEN", "Environment variable name for Github token.")
-	cmd.Flags().BoolVar(&f.Update, "update", false, "Add required status checks on the default branch.")
+	cmd.Flags().BoolVar(&f.Update, "update", false, "Update required status checks on the default branch.")
 	cmd.Flags().StringSliceVar(&f.Checks, "checks", nil, "Check names to add to required status checks. Requires --update.")
+	cmd.Flags().StringSliceVar(&f.Remove, "remove", nil, "Check names to remove from required status checks. Requires --update.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/repo/checks/runner.go
+++ b/cmd/repo/checks/runner.go
@@ -85,7 +85,7 @@ func (r *runner) update(ctx context.Context, owner, repo string) error {
 		return microerror.Mask(r.enableViaFullProtection(ctx, underlying, owner, repo, defaultBranch))
 	}
 
-	merged := mergeChecks(current.GetChecks(), r.flag.Checks)
+	merged := applyChecks(current.GetChecks(), r.flag.Checks, r.flag.Remove)
 
 	strict := current.Strict
 	_, _, err = underlying.Repositories.UpdateRequiredStatusChecks(ctx, owner, repo, defaultBranch, &github.RequiredStatusChecksRequest{
@@ -93,7 +93,7 @@ func (r *runner) update(ctx context.Context, owner, repo string) error {
 		Checks: merged,
 	})
 
-	r.logger.Infof("%s/%s: added %v to required checks on %q", owner, repo, r.flag.Checks, defaultBranch)
+	r.logger.Infof("%s/%s: required checks on %q: added %v, removed %v", owner, repo, defaultBranch, r.flag.Checks, r.flag.Remove)
 
 	return microerror.Mask(err)
 }
@@ -107,7 +107,7 @@ func (r *runner) enableViaFullProtection(ctx context.Context, underlying *github
 		return microerror.Mask(err)
 	}
 
-	merged := mergeChecks(nil, r.flag.Checks)
+	merged := applyChecks(nil, r.flag.Checks, nil)
 	False := false
 
 	req := &github.ProtectionRequest{
@@ -142,16 +142,25 @@ func (r *runner) enableViaFullProtection(ctx context.Context, underlying *github
 	return microerror.Mask(err)
 }
 
-func mergeChecks(existing []*github.RequiredStatusCheck, add []string) []*github.RequiredStatusCheck {
+func applyChecks(existing []*github.RequiredStatusCheck, add, remove []string) []*github.RequiredStatusCheck {
+	drop := make(map[string]bool, len(remove))
+	for _, name := range remove {
+		drop[name] = true
+	}
+
 	seen := make(map[string]bool, len(existing))
 	merged := make([]*github.RequiredStatusCheck, 0, len(existing)+len(add))
 	for _, c := range existing {
+		if drop[c.GetContext()] {
+			continue
+		}
 		merged = append(merged, c)
 		seen[c.GetContext()] = true
 	}
 	for _, name := range add {
 		if !seen[name] {
 			merged = append(merged, &github.RequiredStatusCheck{Context: name})
+			seen[name] = true
 		}
 	}
 	return merged

--- a/cmd/repo/checks/runner_test.go
+++ b/cmd/repo/checks/runner_test.go
@@ -1,0 +1,75 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyChecks(t *testing.T) {
+	existing := func(names ...string) []*github.RequiredStatusCheck {
+		out := make([]*github.RequiredStatusCheck, 0, len(names))
+		for _, n := range names {
+			out = append(out, &github.RequiredStatusCheck{Context: n})
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		existing []*github.RequiredStatusCheck
+		add      []string
+		remove   []string
+		want     []string
+	}{
+		{
+			name:     "add to empty",
+			existing: nil,
+			add:      []string{"a", "b"},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "add deduplicates against existing",
+			existing: existing("a"),
+			add:      []string{"a", "b"},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "remove drops named checks",
+			existing: existing("a", "b", "c"),
+			remove:   []string{"b"},
+			want:     []string{"a", "c"},
+		},
+		{
+			name:     "remove then add migrates a name",
+			existing: existing("semantic-pull-request", "other"),
+			add:      []string{"semantic-pull-request / Validate PR title"},
+			remove:   []string{"semantic-pull-request"},
+			want:     []string{"other", "semantic-pull-request / Validate PR title"},
+		},
+		{
+			name:     "remove of absent name is a no-op",
+			existing: existing("a"),
+			remove:   []string{"b"},
+			want:     []string{"a"},
+		},
+		{
+			name:     "add deduplicates within --checks itself",
+			existing: nil,
+			add:      []string{"a", "a"},
+			want:     []string{"a"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyChecks(tc.existing, tc.add, tc.remove)
+			names := make([]string, 0, len(got))
+			for _, c := range got {
+				names = append(names, c.GetContext())
+			}
+			require.Equal(t, tc.want, names)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/exp v0.0.0-20260527015227-08cc5374adb3
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
@@ -40,6 +41,7 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -64,6 +66,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect


### PR DESCRIPTION
## What

Adds `--remove <names>` to `devctl repo checks --update`. The runner now subtracts `--remove` from the current required check list before unioning in `--checks`, so a single invocation can migrate a check from one name to another. Checks not named in either flag are left untouched.

## Why

Align-files in giantswarm/github (PR #5269) pinned short workflow names as required status checks:

- `semantic-pull-request`
- `validate-changelog`
- `check-values-schema`

These three are reusable-workflow calls, so the actual check names GitHub reports include the inner job:

| Pinned | Reported |
|---|---|
| `semantic-pull-request` | `semantic-pull-request / Validate PR title` |
| `validate-changelog` | `validate-changelog / Validate changelog structure` |
| `check-values-schema` | `check-values-schema / validate` |

PRs across the org are now waiting on phantom required checks that never report. Fixing align-files to push the fully-qualified names is one half of the fix; the other half is removing the bad short names that are already pinned. A `--replace` flag that wipes the whole list would also remove unrelated per-repo required checks (vendor CI, manual additions, etc.), so `--remove` is targeted.

Used together: `devctl repo checks --update --checks 'semantic-pull-request / Validate PR title' --remove semantic-pull-request giantswarm/<repo>`.

## Behaviour

- `--remove` runs before `--checks` is unioned in, so `--checks new --remove old` migrates `old` → `new` even on repos where both were somehow pinned.
- Removing a name not present is a no-op.
- `--checks` and `--remove` can be used independently.
- Existing required checks not named in either flag are left in place.

## Verified

- `go test ./cmd/repo/checks/...` — green, including the new `applyChecks` table tests covering add, remove, migration, missing-name, and dedup.
- `go vet ./cmd/repo/checks/...` clean.