### PR TITLE
fix(gen): delete legacy release workflow files in release-please mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen workflows` (`--release-workflow=release-please`): also delete the legacy release workflow files (`.github/workflows/zz_generated.create_release.yaml`, `zz_generated.create_release_pr.yaml`, `zz_generated.validate_changelog.yaml`) on every run. A repo uses either the legacy `create-release` flow or release-please — never both. Previously devctl stopped generating the legacy files in release-please mode but left whatever was already on disk, so a migrating repo carried orphaned workflows that still triggered on the legacy branch/tag patterns. Uses the existing `input.Input{Delete: true}` primitive, so the change is a no-op for green-field release-please repos.
+
 ### Fixed
 
 - `gen workflows` (`--release-workflow=release-please`): declare the root package in the generated `release-please-config.json`. The template now renders `"packages": {".": {}}` at the top level. `packages` is `required` per release-please's official `schemas/config.json`; without it release-please loads the config but has no package to release, logs `Found release tag with component '', but not configured in manifest` for every existing tag, and exits without opening a Release PR even when conventional commits exist. The top-level `release-type: "simple"` continues to apply as the per-package default. Pairs with the manifest seeding fix below — both are needed for a legacy → release-please migration to produce a Release PR on first run.

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -63,6 +63,13 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			workflowsInput.ReleasePlease(r.flag.AutoReleaseLevel),
 			workflowsInput.ReleasePleaseConfig(r.flag.ChangelogStyle, hasProjectGo),
 			workflowsInput.ReleasePleaseManifest(),
+			// A repo uses either the legacy create-release flow or release-please,
+			// never both — the two would race over CHANGELOG.md and tags. When a
+			// repo opts into release-please, remove the legacy workflow files that
+			// a previous gen run may have left behind.
+			workflowsInput.CreateReleaseDeletion(),
+			workflowsInput.CreateReleasePRDeletion(),
+			workflowsInput.ValidateChangelogDeletion(),
 		)
 	} else {
 		inputs = append(inputs,

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -41,6 +41,12 @@ In `release-please` mode, three files are written:
 - `release-please-config.json` — written once; edit freely to add `version-files` or other Release Please settings
 - `.release-please-manifest.json` — written once; updated by Release Please on every run to track the current version
 
+…and the legacy release workflow files, if present, are removed on every run (a repo uses one flow or the other, never both):
+
+- `.github/workflows/zz_generated.create_release.yaml`
+- `.github/workflows/zz_generated.create_release_pr.yaml`
+- `.github/workflows/zz_generated.validate_changelog.yaml`
+
 ## Generating Makefiles
 
 Creates common `Makefile` and includes in the root directory.

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -32,3 +32,13 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 
 	return i
 }
+
+// NewCreateReleaseDeletionInput returns an Input that deletes the file
+// NewCreateReleaseInput would generate. Used when switching a repo to the
+// release-please flow so the legacy workflow is removed in the same gen run.
+func NewCreateReleaseDeletionInput(p params.Params) input.Input {
+	return input.Input{
+		Delete: true,
+		Path:   params.RegenerableFileName(p, "create_release.yaml"),
+	}
+}

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -30,3 +30,13 @@ func NewCreateReleasePRInput(p params.Params) input.Input {
 
 	return i
 }
+
+// NewCreateReleasePRDeletionInput returns an Input that deletes the file
+// NewCreateReleasePRInput would generate. Used when switching a repo to the
+// release-please flow so the legacy workflow is removed in the same gen run.
+func NewCreateReleasePRDeletionInput(p params.Params) input.Input {
+	return input.Input{
+		Delete: true,
+		Path:   params.RegenerableFileName(p, "create_release_pr.yaml"),
+	}
+}

--- a/pkg/gen/input/workflows/internal/file/validate_changelog.go
+++ b/pkg/gen/input/workflows/internal/file/validate_changelog.go
@@ -29,3 +29,13 @@ func NewValidateChangelogInput(p params.Params) input.Input {
 
 	return i
 }
+
+// NewValidateChangelogDeletionInput returns an Input that deletes the file
+// NewValidateChangelogInput would generate. Used when switching a repo to the
+// release-please flow so the legacy workflow is removed in the same gen run.
+func NewValidateChangelogDeletionInput(p params.Params) input.Input {
+	return input.Input{
+		Delete: true,
+		Path:   params.RegenerableFileName(p, "validate_changelog.yaml"),
+	}
+}

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -49,8 +49,16 @@ func (w *Workflows) CreateRelease() input.Input {
 	return file.NewCreateReleaseInput(w.params)
 }
 
+func (w *Workflows) CreateReleaseDeletion() input.Input {
+	return file.NewCreateReleaseDeletionInput(w.params)
+}
+
 func (w *Workflows) CreateReleasePR() input.Input {
 	return file.NewCreateReleasePRInput(w.params)
+}
+
+func (w *Workflows) CreateReleasePRDeletion() input.Input {
+	return file.NewCreateReleasePRDeletionInput(w.params)
 }
 
 func (w *Workflows) DispatchUpdateChartEvents(targetRepo string) input.Input {
@@ -95,6 +103,10 @@ func (w *Workflows) UpdateChart() input.Input {
 
 func (w *Workflows) ValidateChangelog() input.Input {
 	return file.NewValidateChangelogInput(w.params)
+}
+
+func (w *Workflows) ValidateChangelogDeletion() input.Input {
+	return file.NewValidateChangelogDeletionInput(w.params)
 }
 
 func (w *Workflows) AnalyzeGithubActions() input.Input {


### PR DESCRIPTION
## What

When `gen workflows` is invoked with `--release-workflow=release-please`, also delete the three legacy release workflow files in the same gen run:

```
.github/workflows/zz_generated.create_release.yaml
.github/workflows/zz_generated.create_release_pr.yaml
.github/workflows/zz_generated.validate_changelog.yaml
```

## Why

A repo uses either the legacy `create-release` flow or release-please — never both; the two would race over `CHANGELOG.md` and tags. Today devctl stops generating the legacy files in release-please mode but leaves whatever is already on disk, so a migrating repo carries orphaned workflows that still trigger on their branch/tag patterns while release-please is also running.

## How

`input.Input` already has a `Delete bool` field and the gen engine at `pkg/gen/gen.go:30` calls `os.Remove(file.Path)` for it (and ignores absent files), so this is a no-op for green-field release-please repos.

Each existing generator (`NewCreateReleaseInput` / `NewCreateReleasePRInput` / `NewValidateChangelogInput`) now has a sibling `…DeletionInput` co-located in the same `.go`, returning the same `Path` (via `params.RegenerableFileName`) so the deletion path is always exactly what the generator would write. They're exposed on `Workflows` and wired into the `release-please` branch of `cmd/gen/workflows/runner.go`. The `else` (legacy) branch is unchanged.

## End-to-end verification

Built the binary and ran in scratch repos:

| Mode | Setup | Outcome |
|---|---|---|
| `release-please` | `.github/workflows/` pre-populated with all 3 legacy files | All 3 legacy files **removed**; release-please workflow + config + manifest written |
| `release-please` | Green-field repo (no legacy files) | Same outcome; `os.Remove` no-ops on missing files |
| _legacy (default)_ | `.github/workflows/zz_generated.create_release.yaml` pre-populated | File **re-generated** (759 bytes); not removed |

Plus `gofmt`, `go vet`, `go test ./pkg/gen/input/workflows/... ./cmd/gen/workflows/...` — all clean. The existing `Test_NewReleasePleaseConfigInput` golden test (extended in #1857 to assert `packages`) continues to pass.

## Related

- giantswarm/devctl#1857 (merged) — manifest seeding + `packages` block
- giantswarm/mcp-oauth#414, giantswarm/agentic-platform-ui#38 / #40 — manual bootstraps; with this PR landed they may still need a separate one-off `git rm` of the legacy files in those specific repos (devctl will remove them on the next sync run).