### PR TITLE
fix(gen): remove [Unreleased] from CHANGELOG.md in release-please mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - `gen workflows` (`--release-workflow=release-please`): also delete the legacy release workflow files (`.github/workflows/zz_generated.create_release.yaml`, `zz_generated.create_release_pr.yaml`, `zz_generated.validate_changelog.yaml`) on every run. A repo uses either the legacy `create-release` flow or release-please — never both. Previously devctl stopped generating the legacy files in release-please mode but left whatever was already on disk, so a migrating repo carried orphaned workflows that still triggered on the legacy branch/tag patterns. Uses the existing `input.Input{Delete: true}` primitive, so the change is a no-op for green-field release-please repos.
+- `gen workflows` (`--release-workflow=release-please`): also remove the `## [Unreleased]` section from `CHANGELOG.md` (heading line plus content up to the next `## ` heading). release-please is commit-driven and inserts the next version above the most recent `## ` heading; with `[Unreleased]` present it landed below the new version, stranding the header mid-file. Linked-form (`## [Unreleased](https://…)`) is recognised. No-op when `CHANGELOG.md` doesn't exist or no `[Unreleased]` section is present, so this is safe for green-field release-please repos. Legacy-mode runs are untouched — those still curate from `[Unreleased]`.
 
 ### Fixed
 

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -138,5 +138,15 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		return microerror.Mask(err)
 	}
 
+	// release-please is commit-driven, so the curated "## [Unreleased]"
+	// section is no longer the source of upcoming release notes. Drop it on
+	// every gen run; otherwise release-please's next-version insert lands
+	// above it and the "[Unreleased]" header gets stranded mid-file.
+	if r.flag.ReleaseWorkflow == "release-please" {
+		if err := workflows.RemoveChangelogUnreleasedSection("CHANGELOG.md"); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	return nil
 }

--- a/docs/gen.md
+++ b/docs/gen.md
@@ -47,6 +47,8 @@ In `release-please` mode, three files are written:
 - `.github/workflows/zz_generated.create_release_pr.yaml`
 - `.github/workflows/zz_generated.validate_changelog.yaml`
 
+The `## [Unreleased]` section is also removed from `CHANGELOG.md` if present (heading line up to the next `## ` heading). release-please builds release notes from conventional commits, not from a curated section, and would otherwise strand the `[Unreleased]` heading mid-file on its next-version insert. No-op for repos that don't have a `[Unreleased]` section.
+
 ## Generating Makefiles
 
 Creates common `Makefile` and includes in the root directory.

--- a/pkg/gen/input/workflows/changelog_cleanup.go
+++ b/pkg/gen/input/workflows/changelog_cleanup.go
@@ -1,0 +1,74 @@
+package workflows
+
+import (
+	"os"
+	"strings"
+)
+
+// RemoveChangelogUnreleasedSection rewrites the file at path in place, dropping
+// the "## [Unreleased]" section (heading line plus content) up to but not
+// including the next "## " heading. No-op when the file does not exist or does
+// not contain an "## [Unreleased]" heading.
+//
+// Used after a repo opts into release-please: that flow is commit-driven, so
+// the "[Unreleased]" section is no longer the curation point and would
+// otherwise be stranded mid-file by release-please's next-version inserts
+// (which land directly above the most recent "## " heading).
+func RemoveChangelogUnreleasedSection(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Detect a trailing newline so we can preserve the file's terminator after
+	// rewriting. strings.Split on "\n" turns "a\nb\n" into ["a","b",""] — the
+	// trailing empty slot lets strings.Join produce the same terminator.
+	hadTrailingNewline := strings.HasSuffix(string(data), "\n")
+	lines := strings.Split(string(data), "\n")
+
+	out := make([]string, 0, len(lines))
+	inUnreleased := false
+	changed := false
+
+	for _, line := range lines {
+		if !inUnreleased && isUnreleasedHeading(line) {
+			inUnreleased = true
+			changed = true
+			continue
+		}
+		if inUnreleased {
+			if strings.HasPrefix(line, "## ") {
+				// Reached the next H2 heading — end of the Unreleased section.
+				inUnreleased = false
+				out = append(out, line)
+			}
+			// Otherwise we're inside the section — drop the line.
+			continue
+		}
+		out = append(out, line)
+	}
+
+	if !changed {
+		return nil
+	}
+
+	rewritten := strings.Join(out, "\n")
+	if !hadTrailingNewline && strings.HasSuffix(rewritten, "\n") {
+		rewritten = strings.TrimSuffix(rewritten, "\n")
+	}
+
+	return os.WriteFile(path, []byte(rewritten), 0644)
+}
+
+// isUnreleasedHeading reports whether line is a Keep-a-Changelog "Unreleased"
+// H2 heading. Accepts both the bare "## [Unreleased]" form and the linked
+// "## [Unreleased](https://…)" form.
+func isUnreleasedHeading(line string) bool {
+	if !strings.HasPrefix(line, "## ") {
+		return false
+	}
+	return strings.Contains(line, "[Unreleased]") || strings.Contains(line, "[unreleased]")
+}

--- a/pkg/gen/input/workflows/changelog_cleanup_test.go
+++ b/pkg/gen/input/workflows/changelog_cleanup_test.go
@@ -1,0 +1,97 @@
+package workflows
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_RemoveChangelogUnreleasedSection(t *testing.T) {
+	const preamble = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+`
+	const v018 = `## [0.1.8] - 2026-05-28
+
+### Added
+
+- Something.
+`
+	const v017 = `## [0.1.7] - 2026-05-27
+
+### Fixed
+
+- Bug.
+`
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "unreleased with content is removed",
+			input:    preamble + "## [Unreleased]\n\n### Added\n\n- New thing.\n\n" + v018 + "\n" + v017,
+			expected: preamble + v018 + "\n" + v017,
+		},
+		{
+			name:     "empty unreleased is removed",
+			input:    preamble + "## [Unreleased]\n\n" + v018 + "\n" + v017,
+			expected: preamble + v018 + "\n" + v017,
+		},
+		{
+			name:     "no unreleased section is a no-op",
+			input:    preamble + v018 + "\n" + v017,
+			expected: preamble + v018 + "\n" + v017,
+		},
+		{
+			name:     "linked unreleased form is recognised",
+			input:    preamble + "## [Unreleased](https://example.com/compare/v0.1.8...HEAD)\n\n### Added\n\n- New.\n\n" + v018,
+			expected: preamble + v018,
+		},
+		{
+			// Degenerate: removing Unreleased leaves a trailing blank line in
+			// the preamble that no longer separates anything. We trim it so
+			// the file ends with a single POSIX-style terminating newline.
+			name:     "unreleased as the only versioned section trims to preamble (no trailing blank)",
+			input:    preamble + "## [Unreleased]\n\n### Added\n\n- Stub.\n",
+			expected: "# Changelog\n\nAll notable changes to this project will be documented in this file.\n",
+		},
+		{
+			name:     "preserves file with no trailing newline",
+			input:    preamble + "## [Unreleased]\n\n- x\n\n## [0.1.0] - 2026-05-28\n\n- y",
+			expected: preamble + "## [0.1.0] - 2026-05-28\n\n- y",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "CHANGELOG.md")
+			if err := os.WriteFile(path, []byte(tc.input), 0644); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			if err := RemoveChangelogUnreleasedSection(path); err != nil {
+				t.Fatalf("RemoveChangelogUnreleasedSection: %v", err)
+			}
+
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if string(got) != tc.expected {
+				t.Errorf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", string(got), tc.expected)
+			}
+		})
+	}
+}
+
+func Test_RemoveChangelogUnreleasedSection_MissingFile(t *testing.T) {
+	// Calling on a non-existent path must be a clean no-op (no error), so that
+	// repos without a CHANGELOG.md don't break a release-please gen run.
+	if err := RemoveChangelogUnreleasedSection(filepath.Join(t.TempDir(), "does-not-exist.md")); err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

When `gen workflows --release-workflow=release-please` runs, also remove the `## [Unreleased]` section from `CHANGELOG.md` (heading line up to the next `## ` heading). Pairs with #1860 (legacy workflow file deletion) — both clean up vestigial pieces of the legacy curation flow when a repo opts into release-please.

## Why

release-please is commit-driven; it builds the next release section from conventional commits, not from a hand-curated `[Unreleased]` block. Worse, release-please's next-version insert lands directly above the most recent `## ` heading, so a `[Unreleased]` heading left in place ends up *stranded mid-file* once a new release is cut — see the result on `giantswarm/agentic-platform-ui` after its first release-please run, where `## [Unreleased]` ended up below `## [0.1.0]`.

Removing the section on every gen makes release-please's first-version insert land cleanly between the preamble and the previous version.

## How

New `workflows.RemoveChangelogUnreleasedSection(path)` helper (package `pkg/gen/input/workflows`):

- Reads the file. No-op + no error if it doesn't exist.
- Drops everything from the first `## [Unreleased]` line up to (but not including) the next `## ` H2 heading. Recognises bare `## [Unreleased]` and linked `## [Unreleased](https://…)` forms.
- Writes the file only if it changed; preserves the file's trailing-newline convention.

Wired into `cmd/gen/workflows/runner.go` immediately after `gen.Execute`, gated on `--release-workflow=release-please`. Doing it post-execute (rather than as a new `input.Input` mode) keeps the existing `Input` contract unchanged — in-place editing isn't a great fit for that model.

Out of scope: pre-existing curated content in `[Unreleased]` is dropped, not migrated forward. Anything the team has been writing there is presumed to already be captured as conventional commits (which is the premise of switching to release-please). Mentioned in the docs update so this isn't a surprise.

## End-to-end verification

Built the binary and ran in scratch repos:

| Mode | Setup | Outcome |
|---|---|---|
| `release-please` | `CHANGELOG.md` with `[Unreleased]` + content + a prior version | `[Unreleased]` block **removed**; preamble and prior version intact, clean spacing |
| `release-please` | `CHANGELOG.md` with no `[Unreleased]` | File **untouched** (no-op) |
| `release-please` | No `CHANGELOG.md` | No-op, no error |
| Legacy (default) | `CHANGELOG.md` with `[Unreleased]` | `[Unreleased]` **preserved** at line 3 (legacy flow still curates from it) |

Unit tests cover: with-content, empty, no-section, linked form, only-versioned-section, no-trailing-newline file, and the missing-file no-op. All 7 sub-tests pass alongside the existing `Test_NewReleasePleaseConfigInput` and the rest of the workflows test suite. `gofmt`, `go vet` clean.

## Follow-up

Two small repo-level cleanup PRs to remove the already-stranded `[Unreleased]` section from the consumer repos that migrated before this fix:

- `giantswarm/mcp-oauth` — cleanup PR
- `giantswarm/agentic-platform-ui` — cleanup PR

(devctl handles only the *gen-time* path; existing committed `[Unreleased]` blocks won't be auto-removed on the next sync run because the section can be present in a repo that *never* ran release-please yet — leaving the trim purely the responsibility of the release-please code path is the right call. The two manual cleanup PRs are one-time work.)