### PR TITLE
feat(repo): add --allow-release-please-bypass to repo setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `devctl repo setup`: new `--allow-release-please-bypass` flag (default `false`). When set, the configured default-branch protection lists the `release-please-workflow` GitHub App in `bypass_pull_request_allowances`, so release-please's Release PR can auto-merge without a human review. Pairs with `gen workflows --auto-release-level`, which previously required this bypass to be configured manually.
+
 ## [7.48.0] - 2026-05-31
 
 ### Added

--- a/cmd/repo/setup/flag.go
+++ b/cmd/repo/setup/flag.go
@@ -28,10 +28,11 @@ type flag struct {
 	Permissions map[string]string
 
 	// Branch
-	DefaultBranch           string
-	DisableBranchProtection bool
-	Checks                  []string
-	ChecksFilter            string
+	DefaultBranch            string
+	DisableBranchProtection  bool
+	Checks                   []string
+	ChecksFilter             string
+	AllowReleasePleaseBypass bool
 
 	// Renovate
 	SetupRenovate bool
@@ -68,6 +69,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.DisableBranchProtection, "disable-branch-protection", false, "Disable default branch protection")
 	cmd.Flags().StringSliceVar(&f.Checks, "checks", nil, "Check context names for branch protection. Default will add all auto-detected checks, this can be disabled by passing an empty string. Overrides \"--checks-filter\"")
 	cmd.Flags().StringVar(&f.ChecksFilter, "checks-filter", "aliyun", "Provide a regex to filter checks. Checks matching the regex will be ignored. Empty string disables filter (all checks are accepted).")
+	cmd.Flags().BoolVar(&f.AllowReleasePleaseBypass, "allow-release-please-bypass", false, "Allow the \"release-please-workflow\" GitHub App to bypass the default branch's required pull request reviews. Use this on repos where release-please's Release PR should auto-merge.")
 
 	// Renovate
 	cmd.Flags().BoolVar(&f.SetupRenovate, "renovate", true, "Sets up renovate for the repo")

--- a/cmd/repo/setup/runner.go
+++ b/cmd/repo/setup/runner.go
@@ -111,7 +111,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 	} else {
-		err = client.SetRepositoryBranchProtection(ctx, repository, r.flag.Checks, ChecksFilterRegexp)
+		var bypassApps []string
+		if r.flag.AllowReleasePleaseBypass {
+			bypassApps = []string{"release-please-workflow"}
+		}
+		err = client.SetRepositoryBranchProtection(ctx, repository, r.flag.Checks, ChecksFilterRegexp, bypassApps)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pkg/githubclient/client_repository.go
+++ b/pkg/githubclient/client_repository.go
@@ -156,7 +156,7 @@ func (c *Client) SetRepositoryPermissions(ctx context.Context, repository *githu
 	return nil
 }
 
-func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *github.Repository, checkNames []string, checksFilter *regexp.Regexp) (err error) {
+func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *github.Repository, checkNames []string, checksFilter *regexp.Regexp, bypassApps []string) (err error) {
 	owner := repository.GetOwner().GetLogin()
 	repo := repository.GetName()
 	default_branch := repository.GetDefaultBranch()
@@ -165,13 +165,22 @@ func (c *Client) SetRepositoryBranchProtection(ctx context.Context, repository *
 
 	c.logger.Infof("configure protection for %q branch", default_branch)
 
+	reviews := &github.PullRequestReviewsEnforcementRequest{
+		RequiredApprovingReviewCount: 1,
+	}
+	if len(bypassApps) > 0 {
+		reviews.BypassPullRequestAllowancesRequest = &github.BypassPullRequestAllowancesRequest{
+			Users: []string{},
+			Teams: []string{},
+			Apps:  bypassApps,
+		}
+	}
+
 	opts := &github.ProtectionRequest{
-		RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
-			RequiredApprovingReviewCount: 1,
-		},
-		AllowForcePushes: &False,
-		AllowDeletions:   &False,
-		EnforceAdmins:    true,
+		RequiredPullRequestReviews: reviews,
+		AllowForcePushes:           &False,
+		AllowDeletions:             &False,
+		EnforceAdmins:              true,
 	}
 
 	if checkNames == nil {


### PR DESCRIPTION
## Summary

- Adds a `--allow-release-please-bypass` flag to `devctl repo setup` (default `false`). When set, the default-branch protection registers the `release-please-workflow` GitHub App in `bypass_pull_request_allowances`, so the Release PR can auto-merge without a human review.
- Pairs with `gen workflows --auto-release-level` (CHANGELOG line 47, v7.44.0), which previously required this bypass to be configured manually on every consuming repo.
- Generalizes `pkg/githubclient.SetRepositoryBranchProtection` with a `bypassApps []string` parameter; the runner is the only layer that knows about the `release-please-workflow` slug.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean.
- [x] `go test ./cmd/repo/... ./pkg/githubclient/...` passes.
- [ ] Smoke-test against a sandbox repo: run `devctl repo setup giantswarm/<sandbox> --allow-release-please-bypass --dry-run`, confirm logged payload contains the bypass entry.
- [ ] Smoke-test live: run without `--dry-run` against a sandbox repo, confirm the GitHub UI shows `release-please-workflow` under "Allow specified actors to bypass required pull requests".
- [ ] Confirm the existing default invocation (no flag) is unchanged — the bypass block is omitted entirely when the flag is `false`.

## Notes

- Bypass allowances only take effect on GitHub Pro / Team / Enterprise repos. All giantswarm org repos qualify.
- Slug `release-please-workflow` is hard-coded in `cmd/repo/setup/runner.go`. If we ever rename or reinstall the App under a different slug, that constant needs updating.