### PR TITLE
fix: seed release-please manifest via GitHub API when local git has no tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `gen workflows` (`--release-workflow=release-please`): fall back to the GitHub REST API when local git has no `v*.*.*` tags, so manifest seeding still finds the latest released version under shallow clones. The previous code only consulted `git tag --list` in the cwd. The `giantswarm/github` `align-files` action (which is how most repos get devctl re-run) does `git clone --depth=1` without fetching tags, so `git tag --list` returns nothing and the manifest was seeded with `{}` — silently dropping the release baseline. Repos hit by this would then get a "1.0.0" release PR aggregating commits from inception, because release-please had no per-path baseline to compute "since last release" against. The fallback queries `api.github.com/repos/<owner>/<repo>/tags` using `GS_GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN` when available (or unauthenticated for public repos), parses `v<major>.<minor>.<patch>` tags only (matching the existing local-git filter), and picks the highest. Empty result on any error preserves the pre-fallback behavior (write `{}`).
+
 ## [8.1.0] - 2026-06-01
 
 ### Changed

--- a/pkg/gen/input/workflows/internal/file/release_please_manifest.go
+++ b/pkg/gen/input/workflows/internal/file/release_please_manifest.go
@@ -2,11 +2,17 @@ package file
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/devctl/v8/pkg/gen/input"
 )
@@ -19,10 +25,28 @@ var releasePleaseManifestTemplate string
 // excluded on purpose: they should not become the manifest baseline.
 var semverTagRegexp = regexp.MustCompile(`^v(\d+\.\d+\.\d+)$`)
 
-// latestReleasedVersion returns the highest "v<major>.<minor>.<patch>" tag in
-// the working directory (with the leading "v" stripped), or "" if there are no
-// such tags or git is not available. The cwd at gen time is the consumer repo.
+// originURLRegexp extracts owner/repo from common GitHub remote URL shapes
+// (ssh, https, with or without the trailing .git suffix).
+var originURLRegexp = regexp.MustCompile(`github\.com[:/]([^/]+)/([^/.]+?)(?:\.git)?/?$`)
+
+// githubAPIBaseURL is the GitHub REST API root. Overridden by tests to point
+// at a local httptest server.
+var githubAPIBaseURL = "https://api.github.com"
+
+// latestReleasedVersion returns the highest "v<major>.<minor>.<patch>" tag
+// (with the leading "v" stripped) reachable from the working directory, or ""
+// if no such tag exists. Local git tags are checked first; if none are found,
+// falls back to the GitHub API so shallow clones (e.g. `git clone --depth=1`
+// in CI like giantswarm/github's align-files action, which doesn't fetch tags)
+// still seed the manifest correctly.
 func latestReleasedVersion() string {
+	if v := latestReleasedVersionFromGit(); v != "" {
+		return v
+	}
+	return latestReleasedVersionFromAPI()
+}
+
+func latestReleasedVersionFromGit() string {
 	// --sort=-v:refname orders tags by version descending, so the first match
 	// is the highest.
 	cmd := exec.Command("git", "tag", "--list", "v*.*.*", "--sort=-v:refname")
@@ -36,6 +60,94 @@ func latestReleasedVersion() string {
 		}
 	}
 	return ""
+}
+
+// latestReleasedVersionFromAPI queries the GitHub REST API for the highest
+// v<major>.<minor>.<patch> tag on the repo whose `origin` remote points to
+// github.com. Returns "" on any error — the caller treats that as "no
+// baseline" and writes an empty manifest, matching the pre-fallback behavior.
+func latestReleasedVersionFromAPI() string {
+	owner, repo := repoFromOriginRemote()
+	if owner == "" || repo == "" {
+		return ""
+	}
+
+	req, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("%s/repos/%s/%s/tags?per_page=100", githubAPIBaseURL, owner, repo), nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// Both env vars are common: GS_GITHUB_TOKEN is set by the align-files
+	// action; GH_TOKEN is what `gh` and most local setups export. Either
+	// works; unauthenticated requests also work for public repos but are
+	// rate-limited to 60/hour.
+	for _, env := range []string{"GS_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if tok := os.Getenv(env); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+			break
+		}
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var tags []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return ""
+	}
+
+	type parsed struct {
+		raw        string
+		mj, mn, pa int
+	}
+	var versions []parsed
+	for _, t := range tags {
+		m := semverTagRegexp.FindStringSubmatch(t.Name)
+		if m == nil {
+			continue
+		}
+		parts := strings.Split(m[1], ".")
+		mj, _ := strconv.Atoi(parts[0])
+		mn, _ := strconv.Atoi(parts[1])
+		pa, _ := strconv.Atoi(parts[2])
+		versions = append(versions, parsed{raw: m[1], mj: mj, mn: mn, pa: pa})
+	}
+	if len(versions) == 0 {
+		return ""
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].mj != versions[j].mj {
+			return versions[i].mj > versions[j].mj
+		}
+		if versions[i].mn != versions[j].mn {
+			return versions[i].mn > versions[j].mn
+		}
+		return versions[i].pa > versions[j].pa
+	})
+	return versions[0].raw
+}
+
+func repoFromOriginRemote() (string, string) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", ""
+	}
+	m := originURLRegexp.FindStringSubmatch(strings.TrimSpace(string(out)))
+	if m == nil {
+		return "", ""
+	}
+	return m[1], m[2]
 }
 
 // NewReleasePleaseManifestInput returns a scaffolding Input (generate-once) for
@@ -52,6 +164,11 @@ func latestReleasedVersion() string {
 //
 // and exits without opening a Release PR because it has no per-path baseline
 // to compute "what changed since the last release" against.
+//
+// The latest tag is discovered from local git first, then via the GitHub API
+// as a fallback — needed because the align-files action shallow-clones
+// (--depth=1) without tags, so a purely-local lookup returns nothing and the
+// repo ends up seeded with {} despite having released tags.
 func NewReleasePleaseManifestInput() input.Input {
 	body := releasePleaseManifestTemplate
 	if v := latestReleasedVersion(); v != "" {

--- a/pkg/gen/input/workflows/internal/file/release_please_manifest_test.go
+++ b/pkg/gen/input/workflows/internal/file/release_please_manifest_test.go
@@ -1,0 +1,119 @@
+package file
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+)
+
+func Test_repoFromOriginRemote(t *testing.T) {
+	testCases := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+	}{
+		{"ssh with .git", "git@github.com:giantswarm/mcp-toolkit.git", "giantswarm", "mcp-toolkit"},
+		{"ssh without .git", "git@github.com:giantswarm/mcp-toolkit", "giantswarm", "mcp-toolkit"},
+		{"https with .git", "https://github.com/giantswarm/mcp-toolkit.git", "giantswarm", "mcp-toolkit"},
+		{"https without .git", "https://github.com/giantswarm/mcp-toolkit", "giantswarm", "mcp-toolkit"},
+		{"https with token (align-files action shape)", "https://x-access-token:abc@github.com/giantswarm/mcp-toolkit.git", "giantswarm", "mcp-toolkit"},
+		{"non-github remote", "git@gitlab.com:foo/bar.git", "", ""},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := initRepoWithRemote(t, tc.url)
+			t.Chdir(dir)
+			owner, repo := repoFromOriginRemote()
+			if owner != tc.wantOwner || repo != tc.wantRepo {
+				t.Fatalf("got (%q, %q), want (%q, %q)", owner, repo, tc.wantOwner, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func Test_latestReleasedVersionFromAPI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/giantswarm/mcp-toolkit/tags" {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Unsorted, with non-semver and pre-release entries the picker must skip.
+		_, _ = w.Write([]byte(`[
+			{"name":"v0.1.0"},
+			{"name":"v0.2.1"},
+			{"name":"v0.2.0"},
+			{"name":"v0.2.1-rc1"},
+			{"name":"not-a-version"}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("GS_GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	origBaseURL := githubAPIBaseURL
+	githubAPIBaseURL = server.URL
+	t.Cleanup(func() { githubAPIBaseURL = origBaseURL })
+
+	dir := initRepoWithRemote(t, "git@github.com:giantswarm/mcp-toolkit.git")
+	t.Chdir(dir)
+
+	got := latestReleasedVersionFromAPI()
+	if got != "0.2.1" {
+		t.Fatalf("got %q, want %q", got, "0.2.1")
+	}
+}
+
+func Test_latestReleasedVersionFromAPI_noTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	origBaseURL := githubAPIBaseURL
+	githubAPIBaseURL = server.URL
+	t.Cleanup(func() { githubAPIBaseURL = origBaseURL })
+
+	dir := initRepoWithRemote(t, "git@github.com:giantswarm/new-repo.git")
+	t.Chdir(dir)
+
+	if got := latestReleasedVersionFromAPI(); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func Test_latestReleasedVersionFromAPI_apiError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	origBaseURL := githubAPIBaseURL
+	githubAPIBaseURL = server.URL
+	t.Cleanup(func() { githubAPIBaseURL = origBaseURL })
+
+	dir := initRepoWithRemote(t, "git@github.com:giantswarm/mcp-toolkit.git")
+	t.Chdir(dir)
+
+	if got := latestReleasedVersionFromAPI(); got != "" {
+		t.Fatalf("got %q on API 500, want empty (callers treat empty as 'no baseline')", got)
+	}
+}
+
+func initRepoWithRemote(t *testing.T, url string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"remote", "add", "origin", url},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}


### PR DESCRIPTION
## Summary

The release-please manifest seeder silently dropped the release baseline whenever devctl ran under a shallow clone — specifically the \`giantswarm/github\` \`align-files\` action, which does \`git clone --depth=1\` without fetching tags. \`git tag --list 'v*.*.*'\` returns nothing, the function falls through to the empty template, and the repo gets a \`{}\` manifest **despite having v*.*.* tags**.

Once \`{}\` is committed, release-please has no per-path baseline to compute \"since last release\" against, so its next run produces an inception-spanning release PR (typically titled \`chore(main): release 1.0.0\` regardless of the repo's actual history).

## Reproducer

\`\`\`bash
git clone --depth=1 https://github.com/giantswarm/mcp-toolkit.git
cd mcp-toolkit
git tag --list 'v*.*.*'      # empty, even though mcp-toolkit has v0.1.0, v0.2.0, v0.2.1
\`\`\`

Devctl running in that cwd writes \`{}\` to \`.release-please-manifest.json\`.

## Repos hit in production

Discovered via a sweep across the org: 3 repos currently have \`{}\` manifests despite having \`v*.*.*\` tags — \`giantswarm/mcp-oauth\`, \`giantswarm/mcp-toolkit\`, \`giantswarm/telemetrydeck-go\`. Separate one-shot repair PRs to fix each will follow this PR; the fix here is structural (prevents new victims).

## Fix

Add a GitHub REST API fallback: when \`git tag\` returns nothing, query \`api.github.com/repos/<owner>/<repo>/tags\`, parse \`v<major>.<minor>.<patch>\` entries (matching the existing local-git filter), and pick the highest. The owner/repo is derived from \`git remote get-url origin\`, which works in shallow clones (it doesn't need fetched tags).

Auth precedence: \`GS_GITHUB_TOKEN\` → \`GH_TOKEN\` → \`GITHUB_TOKEN\` → unauthenticated. The align-files action exports \`GS_GITHUB_TOKEN\`; local \`gh\` sessions and most CI export \`GH_TOKEN\`/\`GITHUB_TOKEN\`. Unauthenticated also works for public repos (rate-limited to 60/h, well under devctl's invocation rate).

Empty result on any error (network, 4xx/5xx, parse failure) preserves the pre-fallback behavior of writing an empty manifest — so a transient API outage during a greenfield repo's first \`gen workflows\` run can't corrupt anything.

## Tests

- Origin URL parsing across the four shapes giantswarm uses in practice (ssh ± \`.git\`, https ± \`.git\`, https with token from align-files), plus a negative case for non-github remotes.
- API fallback against an httptest server returning unsorted + pre-release + non-semver entries — verifies the picker picks \`v0.2.1\` and ignores pre-releases.
- No-tags case (greenfield repo) → returns empty so the empty template is written.
- API-error case (500) → returns empty so legitimate greenfield manifests aren't corrupted by transient failures.

## Test plan

- [x] \`go build ./...\` clean.
- [x] All new and existing tests in the package pass.
- [x] Bug reproduced empirically: \`git clone --depth=1\` of \`mcp-toolkit\` returns no tags from \`git tag --list 'v*.*.*'\`.
- [ ] After merge: bump devctl pin in \`giantswarm/github\`'s align-files workflow to the new version, then trigger align-files for one of the 3 affected repos to confirm the fallback fires in real CI (manifest would be re-written correctly on a fresh \`gen workflows\` if the seeder weren't generate-once — separate followup).

## Followups (not in this PR)

- 3 manual repair PRs for the already-affected repos (the manifest is generate-once, so re-running devctl won't fix them — they need explicit one-line manifest commits).
- Consider making the seeder re-runnable when the existing manifest is empty (\`{}\`), so repos hit by this bug self-heal on next align-files run instead of needing manual repair. Held out of this PR because the affected set is currently just 3 repos; the added complexity isn't worth it yet.