### PR TITLE
feat(gen): rework circleci generator for architect-orb v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: rework the generated `.circleci/config.yml` for architect-orb **v9.0.0** (default `--orb-version` bumped `8.3.0` → `9.0.0`). v9 removed the `multiarch:` parameter on `architect/push-to-registries` (the job always uses `docker buildx` now), so it is dropped from both the branch and the release image jobs. v9 also defaults `architect/go-build` to `linux/amd64,linux/arm64`; the previous branch-build `platforms: "linux/amd64"` optimization is dropped so branch builds validate the full multi-arch image (auto-derived from go-build's `.platforms`), matching the v9-idiomatic single-path model. The golden fixture and generator help text are updated to the v9 shape. No new fields or parameters.
+
 ## [8.1.0] - 2026-06-01
 
 ### Changed

--- a/cmd/gen/circleci/command.go
+++ b/cmd/gen/circleci/command.go
@@ -18,14 +18,14 @@ The pipeline is fully derived from existing signals -- there is no CI parameter
 block. Jobs are selected by:
 
   - language go        -> architect/go-build
-  - Dockerfile present -> architect/push-to-registries (multiarch + split-china-push)
+  - Dockerfile present -> architect/push-to-registries (buildx + split-china-push)
                           and architect/sync-china-registry
   - app flavour        -> architect/push-to-app-catalog (app-build-suite executor)
                           and architect/run-tests-with-ats
 
 The orb is pinned to the aligned standard and tag/branch filters follow the
-giantswarm convention (branch builds amd64-only, tags build multi-arch and
-publish the chart).`
+giantswarm convention (branch builds validate the image, tags push multi-arch
+and publish the chart).`
 	example = `  devctl gen circleci --repo-name mcp-kubernetes --language go --flavour app
   devctl gen circleci --repo-name crd-docs-generator --language go`
 )

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -12,7 +12,7 @@ import (
 // DefaultOrbVersion is the aligned giantswarm/architect orb version every
 // generated CircleCI config pins. Bumping the org-wide standard is a one-line
 // change here.
-const DefaultOrbVersion = "8.3.0"
+const DefaultOrbVersion = "9.0.0"
 
 type Config struct {
 	// RepoName is the repository name, used for the binary, chart, and job

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -56,7 +56,7 @@ func contains(got, substr string) bool {
 // signals (language go, app flavour, a Dockerfile) must reproduce the aligned
 // standard byte-for-byte. The golden file is mcp-kubernetes's checked-in
 // .circleci/config.yml with the only allowed drift -- the orb bump to the
-// aligned 8.3.0 -- applied.
+// aligned 9.0.0 and the v9 buildx/multi-arch shape -- applied.
 func Test_GoldenServiceConfig(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      "mcp-kubernetes",

--- a/pkg/gen/input/circleci/internal/file/config.yml.template
+++ b/pkg/gen/input/circleci/internal/file/config.yml.template
@@ -16,12 +16,12 @@ workflows:
 {{- end }}
 {{- if .HasDockerfile }}
 
-    # Branch builds: amd64 only for faster PR feedback
+    # Branch builds: multi-arch image to gsoci for PR validation. v9's
+    # push-to-registries always uses buildx and derives the platforms from
+    # go-build's .platforms file (linux/amd64,linux/arm64 by default).
     - architect/push-to-registries:
         context: architect
-        multiarch: true
         name: push-to-registries
-        platforms: "linux/amd64"
 {{- if eq .Language "go" }}
         requires:
         - go-build-{{ .RepoName }}
@@ -36,7 +36,6 @@ workflows:
     # mechanism), so the buildx push no longer crosses the Pacific.
     - architect/push-to-registries:
         context: architect
-        multiarch: true
         name: push-to-registries-release
         split-china-push: true
 {{- if eq .Language "go" }}
@@ -97,7 +96,7 @@ workflows:
             ignore:
             - main
 
-    # Branch: push chart (git catalog + OCI per architect default) after tests + amd64 image
+    # Branch: push chart (git catalog + OCI per architect default) after tests + image
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -12,7 +12,7 @@ type Params struct {
 	// job.
 	Language string
 	// HasDockerfile is true when the repo ships a Dockerfile. It selects the
-	// image pipeline (push-to-registries multiarch + split-china-push and the
+	// image pipeline (push-to-registries with split-china-push and the
 	// paired sync-china-registry job).
 	HasDockerfile bool
 	// HasApp is true when the repo carries the "app" flavour (at least one

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.config.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.3.0
+  architect: giantswarm/architect@9.0.0
 
 workflows:
   build:
@@ -13,12 +13,12 @@ workflows:
           tags:
             only: /^v.*/
 
-    # Branch builds: amd64 only for faster PR feedback
+    # Branch builds: multi-arch image to gsoci for PR validation. v9's
+    # push-to-registries always uses buildx and derives the platforms from
+    # go-build's .platforms file (linux/amd64,linux/arm64 by default).
     - architect/push-to-registries:
         context: architect
-        multiarch: true
         name: push-to-registries
-        platforms: "linux/amd64"
         requires:
         - go-build-mcp-kubernetes
         filters:
@@ -31,7 +31,6 @@ workflows:
     # mechanism), so the buildx push no longer crosses the Pacific.
     - architect/push-to-registries:
         context: architect
-        multiarch: true
         name: push-to-registries-release
         split-china-push: true
         requires:
@@ -86,7 +85,7 @@ workflows:
             ignore:
             - main
 
-    # Branch: push chart (git catalog + OCI per architect default) after tests + amd64 image
+    # Branch: push chart (git catalog + OCI per architect default) after tests + image
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect


### PR DESCRIPTION
## Summary

Follow-up to #1867. [architect-orb v9.0.0](https://github.com/giantswarm/architect-orb/blob/main/CHANGELOG.md#900---2026-06-01) (2026-06-01) shipped a hard-breaking release that changes the shape of the standard `service` pipeline the `gen circleci` generator emits. This reworks the generator template, golden fixture, and help text to the v9 shape so generated configs are valid on `architect@9.0.0`.

- **Bump `DefaultOrbVersion` `8.3.0` -> `9.0.0`** (the single-sourced org standard the generator pins).
- **Drop `multiarch: true` from both `push-to-registries` jobs** -- v9 removed the `multiarch:` parameter; the job always uses `docker buildx` now ([migration §2](https://github.com/giantswarm/architect-orb/blob/main/docs/migration-v8-to-v9.md)). Leaving it would render an invalid config on v9.
- **Drop the branch-build `platforms: "linux/amd64"` optimization** -- v9 defaults `go-build` to `linux/amd64,linux/arm64` ([migration §5](https://github.com/giantswarm/architect-orb/blob/main/docs/migration-v8-to-v9.md)). Per the plan's preferred option (a), branch builds now validate the full multi-arch image (auto-derived from `go-build`'s `.platforms`), the v9-idiomatic single-path model.

No new fields or parameters -- the pipeline stays fully derived from existing signals.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/gen/...` passes (golden test updated to the 9.0.0 shape)
- [x] v9 sanity-check grep finds no v8-only params (`multiarch:`, `platforms:`, etc.) in template or golden fixture
- [x] changed packages lint clean

Tracks giantswarm/giantswarm#36730 (CI & build-system alignment, Workstream 1).

Made with [Cursor](https://cursor.com)