### PR TITLE
feat(gen): bake architect orb version into circleci generator, drop --orb-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: **dropped the `--orb-version` flag**. The giantswarm/architect orb version is now baked into devctl as a constant (`OrbVersion`) next to the config template, with a Renovate custom manager keeping it current. The orb major and the template's required job/param shape are two halves of one compatibility contract; combining them at generation time via a passthrough let `architect@9.0.0` pair with a stale v8 template and emit silently-invalid config. Baking the version in means a major orb bump lands as a devctl PR → release → align-files pin bump, instead of a `giantswarm/github` literal that can skew against the template. Callers (`giantswarm/github` align-files) must stop passing `--orb-version`.
+
 ## [8.2.0] - 2026-06-01
 
 ### Changed
 
-- `gen circleci`: rework the generated `.circleci/config.yml` for architect-orb **v9.0.0** (default `--orb-version` bumped `8.3.0` → `9.0.0`). v9 removed the `multiarch:` parameter on `architect/push-to-registries` (the job always uses `docker buildx` now), so it is dropped from both the branch and the release image jobs. v9 also defaults `architect/go-build` to `linux/amd64,linux/arm64`; the previous branch-build `platforms: "linux/amd64"` optimization is dropped so branch builds validate the full multi-arch image (auto-derived from go-build's `.platforms`), matching the v9-idiomatic single-path model. The golden fixture and generator help text are updated to the v9 shape. No new fields or parameters.
+- `gen circleci`: rework the generated `.circleci/config.yml` for architect-orb **v9.0.0**. v9 removed the `multiarch:` parameter on `architect/push-to-registries` (the job always uses `docker buildx` now), so it is dropped from both the branch and the release image jobs. v9 also defaults `architect/go-build` to `linux/amd64,linux/arm64`; the previous branch-build `platforms: "linux/amd64"` optimization is dropped so branch builds validate the full multi-arch image (auto-derived from go-build's `.platforms`), matching the v9-idiomatic single-path model. The golden fixture and generator help text are updated to the v9 shape. No new fields or parameters.
 
 ## [8.1.0] - 2026-06-01
 

--- a/cmd/gen/circleci/command.go
+++ b/cmd/gen/circleci/command.go
@@ -23,9 +23,11 @@ block. Jobs are selected by:
   - app flavour        -> architect/push-to-app-catalog (app-build-suite executor)
                           and architect/run-tests-with-ats
 
-The orb is pinned to the aligned standard and tag/branch filters follow the
-giantswarm convention (branch builds validate the image, tags push multi-arch
-and publish the chart).`
+The giantswarm/architect orb is pinned to a version baked into devctl (not a
+flag): a major orb bump changes the template's required job/param shape, so it
+must ship as a new devctl release rather than being passed in at generation
+time. Tag/branch filters follow the giantswarm convention (branch builds
+validate the image, tags push multi-arch and publish the chart).`
 	example = `  devctl gen circleci --repo-name mcp-kubernetes --language go --flavour app
   devctl gen circleci --repo-name crd-docs-generator --language go`
 )

--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -8,28 +8,24 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/devctl/v8/pkg/gen"
-	"github.com/giantswarm/devctl/v8/pkg/gen/input/circleci"
 )
 
 const (
-	flagFlavour    = "flavour"
-	flagLanguage   = "language"
-	flagRepoName   = "repo-name"
-	flagOrbVersion = "orb-version"
+	flagFlavour  = "flavour"
+	flagLanguage = "language"
+	flagRepoName = "repo-name"
 )
 
 type flag struct {
-	Flavours   gen.FlavourSlice
-	Language   gen.Language
-	RepoName   string
-	OrbVersion string
+	Flavours gen.FlavourSlice
+	Language gen.Language
+	RepoName string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`List of project flavours. The "app" flavour selects the chart pipeline. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().VarP(gen.NewLanguageFlagValue(&f.Language, gen.Language("")), flagLanguage, "l", fmt.Sprintf(`The programming language. "go" selects the go-build job. Possible values: <%s>`, strings.Join(gen.AllLanguages(), "|")))
 	cmd.Flags().StringVarP(&f.RepoName, flagRepoName, "r", "", "Repository name under the giantswarm organization (used for the binary, chart, and job names).")
-	cmd.Flags().StringVar(&f.OrbVersion, flagOrbVersion, circleci.DefaultOrbVersion, "The giantswarm/architect orb version to pin.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -52,7 +52,6 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			Language:      r.flag.Language,
 			Flavours:      r.flag.Flavours,
 			HasDockerfile: hasDockerfile,
-			OrbVersion:    r.flag.OrbVersion,
 		}
 
 		circleciInput, err = circleci.New(c)

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -9,10 +9,18 @@ import (
 	"github.com/giantswarm/devctl/v8/pkg/gen/input/circleci/internal/params"
 )
 
-// DefaultOrbVersion is the aligned giantswarm/architect orb version every
-// generated CircleCI config pins. Bumping the org-wide standard is a one-line
-// change here.
-const DefaultOrbVersion = "9.0.0"
+// OrbVersion is the aligned giantswarm/architect orb version every generated
+// CircleCI config pins. It is baked in next to the template -- not a flag and
+// not passed in by callers -- so that an orb bump (which can change the
+// template's required job/param shape, i.e. a cross-major compatibility
+// contract) forces a new devctl release rather than silently combining a stale
+// template with a newer orb at generation time.
+//
+// Renovate keeps this current; a major bump lands as a devctl PR, gets released,
+// and only then reaches repos via the align-files devctl pin.
+//
+// renovate: datasource=orb depName=giantswarm/architect
+const OrbVersion = "9.0.0"
 
 type Config struct {
 	// RepoName is the repository name, used for the binary, chart, and job
@@ -26,8 +34,6 @@ type Config struct {
 	// HasDockerfile selects the image pipeline. The runner derives this from
 	// the presence of a Dockerfile in the repo.
 	HasDockerfile bool
-	// OrbVersion overrides DefaultOrbVersion when set.
-	OrbVersion string
 }
 
 type CircleCI struct {
@@ -42,18 +48,13 @@ func New(config Config) (*CircleCI, error) {
 		return nil, microerror.Maskf(invalidConfigError, "no jobs would be generated: set --language=go, add a Dockerfile, or use the app flavour")
 	}
 
-	orbVersion := config.OrbVersion
-	if orbVersion == "" {
-		orbVersion = DefaultOrbVersion
-	}
-
 	c := &CircleCI{
 		params: params.Params{
 			RepoName:      config.RepoName,
 			Language:      config.Language.String(),
 			HasDockerfile: config.HasDockerfile,
 			HasApp:        hasApp,
-			OrbVersion:    orbVersion,
+			OrbVersion:    OrbVersion,
 		},
 	}
 

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -75,7 +75,7 @@ func Test_GoldenServiceConfig(t *testing.T) {
 	}
 }
 
-func Test_DefaultOrbVersion(t *testing.T) {
+func Test_OrbVersion(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      "mcp-kubernetes",
 		Language:      gen.LanguageGo,
@@ -83,8 +83,8 @@ func Test_DefaultOrbVersion(t *testing.T) {
 		HasDockerfile: true,
 	})
 
-	if !contains(got, "giantswarm/architect@"+DefaultOrbVersion) {
-		t.Errorf("expected generated config to pin orb %s, got:\n%s", DefaultOrbVersion, got)
+	if !contains(got, "giantswarm/architect@"+OrbVersion) {
+		t.Errorf("expected generated config to pin orb %s, got:\n%s", OrbVersion, got)
 	}
 }
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,17 @@
     ],
   },
   customManagers: [
+    // The architect orb version baked into the `gen circleci` generator.
+    // Pinned as a Go constant next to the config template so a major orb bump
+    // forces a devctl release rather than silently skewing against a stale
+    // template. Renovate bumps it here, not in giantswarm/github.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pkg/gen/input/circleci/circleci\\.go$/'],
+      matchStrings: [
+        '// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*const OrbVersion = "(?<currentValue>[^"]+)"',
+      ],
+    },
     // Pre-commit hook revisions in the pre-commit config template.
     // The built-in pre-commit manager cannot parse this file because it contains
     // Go template directives ({{- if ... }}) that make the YAML invalid.


### PR DESCRIPTION
## Summary

Implements the `orb-version-guard` follow-up from the devctl-generated CircleCI rollout: the giantswarm/architect orb version is no longer passed into `devctl gen circleci` via `--orb-version`. It is now baked in as a constant next to the config template.

The orb **major** and the template's required job/param shape are two halves of one compatibility contract, previously combined at generation time with no check. That let `architect@9.0.0` pair with a stale v8-shaped template (still emitting the removed `multiarch:` param) and produce silently-invalid config in the target repo.

Baking the version in means a major orb bump lands as a devctl PR -> release -> align-files devctl-pin bump, rather than a `giantswarm/github` literal that can skew against the template shape devctl owns.

## Changes

- Removed the `--orb-version` flag and the `OrbVersion` override field from `circleci.Config`.
- Renamed the constant `DefaultOrbVersion` -> `OrbVersion` (no longer overridable) and added a `// renovate: datasource=orb depName=giantswarm/architect` annotation.
- Added a Renovate custom manager in `renovate.json5` scoped to `pkg/gen/input/circleci/circleci.go` so the orb bump lands in devctl, not in giantswarm/github.
- Updated generator help text and the test (`Test_OrbVersion`).

## Downstream follow-up (not in this PR)

`giantswarm/github` align-files currently invokes `devctl gen circleci --orb-version=...`. Once this devctl is pinned, that flag must be dropped from the action or generation fails on the now-unknown flag. Tracked separately (github-orb-v9 / align-files-devctl-pin).

## Test plan

- [x] `go build ./...`
- [x] `go vet` on the circleci packages
- [x] `golangci-lint` clean on changed packages (0 issues)
- [x] circleci package tests pass (golden fixture + `Test_OrbVersion`)

Made with [Cursor](https://cursor.com)