### PR TITLE
fix(gen): gate chart tests on the image push to stop ImagePullBackOff races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `gen circleci`: the chart-test job (`architect/run-tests-with-ats`, "execute chart tests") now waits for the image push before deploying. It previously required only `build-<repo>-chart`, so on image-bearing chart repos it deployed the chart and tried to pull the freshly built dev image from gsoci before `push-to-registries` had finished, racing the push and flaking on `ImagePullBackOff` (the kubelet's pull backoff outlasts the test deadline once an early pull attempt fails). The job is now split into a branch variant requiring `push-to-registries` and a release variant (`execute chart tests on release`) requiring `push-to-registries-release`, each gated on `HasDockerfile` so chart-only repos are unaffected.
+
 ## [8.3.0] - 2026-06-01
 
 ### Changed

--- a/pkg/gen/input/circleci/internal/file/config.yml.template
+++ b/pkg/gen/input/circleci/internal/file/config.yml.template
@@ -85,16 +85,37 @@ workflows:
             ignore:
             - main
 
+    # Branch: run chart tests after the image is pushed. run-tests-with-ats
+    # deploys the chart, which pulls the freshly built dev image from gsoci.
+    # Without depending on push-to-registries the test races the image push and
+    # flakes on ImagePullBackOff (the kubelet's pull backoff outlasts the test
+    # deadline once an early pull attempt fails).
     - architect/run-tests-with-ats:
         name: execute chart tests
         requires:
         - build-{{ .RepoName }}-chart
+{{- if .HasDockerfile }}
+        - push-to-registries
+{{- end }}
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag: run chart tests after the release image is pushed, for the same
+    # image-availability reason as the branch job above.
+    - architect/run-tests-with-ats:
+        name: execute chart tests on release
+        requires:
+        - build-{{ .RepoName }}-chart
+{{- if .HasDockerfile }}
+        - push-to-registries-release
+{{- end }}
         filters:
           tags:
             only: /^v.*/
           branches:
-            ignore:
-            - main
+            ignore: /.*/
 
     # Branch: push chart (git catalog + OCI per architect default) after tests + image
     - architect/push-to-app-catalog:
@@ -125,7 +146,7 @@ workflows:
         app_catalog_test: giantswarm-test-catalog
         chart: {{ .RepoName }}
         requires:
-        - execute chart tests
+        - execute chart tests on release
 {{- if .HasDockerfile }}
         - push-to-registries-release
 {{- end }}

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.config.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.config.yml
@@ -74,16 +74,33 @@ workflows:
             ignore:
             - main
 
+    # Branch: run chart tests after the image is pushed. run-tests-with-ats
+    # deploys the chart, which pulls the freshly built dev image from gsoci.
+    # Without depending on push-to-registries the test races the image push and
+    # flakes on ImagePullBackOff (the kubelet's pull backoff outlasts the test
+    # deadline once an early pull attempt fails).
     - architect/run-tests-with-ats:
         name: execute chart tests
         requires:
         - build-mcp-kubernetes-chart
+        - push-to-registries
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag: run chart tests after the release image is pushed, for the same
+    # image-availability reason as the branch job above.
+    - architect/run-tests-with-ats:
+        name: execute chart tests on release
+        requires:
+        - build-mcp-kubernetes-chart
+        - push-to-registries-release
         filters:
           tags:
             only: /^v.*/
           branches:
-            ignore:
-            - main
+            ignore: /.*/
 
     # Branch: push chart (git catalog + OCI per architect default) after tests + image
     - architect/push-to-app-catalog:
@@ -112,7 +129,7 @@ workflows:
         app_catalog_test: giantswarm-test-catalog
         chart: mcp-kubernetes
         requires:
-        - execute chart tests
+        - execute chart tests on release
         - push-to-registries-release
         filters:
           tags:


### PR DESCRIPTION
## Problem

The CI rollout (opting Bumblebee chart repos into `gen.ci`) surfaced an intermittent failure: `architect/run-tests-with-ats` ("execute chart tests") flaked on `ImagePullBackOff`.

`run-tests-with-ats` deploys the chart under test, which pulls the freshly built **dev image** from gsoci. The job required only `build-<repo>-chart`, **not** the image push. On image-bearing chart repos the chart-test job therefore started right after the (fast) chart build and raced the (slow, multi-arch buildx) `push-to-registries` job:

- `build-<repo>-chart` finishes in ~1 min → chart test starts
- `push-to-registries` is still running (multi-arch buildx, several minutes)
- the chart deploys, the kubelet tries to pull the not-yet-pushed dev image → `ErrImagePull` → `ImagePullBackOff`
- the kubelet's pull backoff timer outlasts the ATS deadline even after the push finishes, so the test never recovers

Observed on `search-mcp`, `mcp-kubernetes`, and `mcp-capi`; `mcp-prometheus` passed only because its push happened to win the race.

## Fix

Split `run-tests-with-ats` into two filter-scoped jobs so each waits for the matching image push before deploying:

- **branch**: `execute chart tests` → `requires: [build-<repo>-chart, push-to-registries]`
- **tag**: `execute chart tests on release` → `requires: [build-<repo>-chart, push-to-registries-release]`

Both `push-to-registries` references are gated on `HasDockerfile`, so chart-only repos (no image) are unaffected and keep a single dependency on the chart build. The release chart push now requires `execute chart tests on release`.

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` (golden + derivation tests) green
- [x] Golden fixture (`testdata/mcp-kubernetes.config.yml`) regenerated and matches
- [ ] After release + align-files pin bump, the affected repos' chart-test jobs no longer race the image push

Made with [Cursor](https://cursor.com)