### PR TITLE
fix(gen): use `gitsemver get` for go Makefile version (gitsemver v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen makefile` (`--language go`): the generated `Makefile.gen.go.mk` now resolves the build version with `gitsemver get` instead of `gitsemver version`. gitsemver [v2.0.0](https://github.com/giantswarm/gitsemver/releases/tag/v2.0.0) renamed the `version` subcommand to `get` (to avoid confusion with the `--version` flag), a breaking change: with gitsemver v2 the old `gitsemver version` invocation fails, leaving `VERSION` empty and breaking the build/package targets. Repos must have gitsemver v2.0.0+ on `PATH` after re-running `devctl gen makefile`.
+
 ### Fixed
 
 - `gen circleci`: the chart-test job (`architect/run-tests-with-ats`, "execute chart tests") now waits for the image push before deploying. It previously required only `build-<repo>-chart`, so on image-bearing chart repos it deployed the chart and tried to pull the freshly built dev image from gsoci before `push-to-registries` had finished, racing the push and flaking on `ImagePullBackOff` (the kubelet's pull backoff outlasts the test deadline once an early pull attempt fails). The job is now split into a branch variant requiring `push-to-registries` and a release variant (`execute chart tests on release`) requiring `push-to-registries-release`, each gated on `HasDockerfile` so chart-only repos are unaffected.

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -15,7 +15,7 @@ MODULE         := $(shell go list -m)
 MAIN_SOURCE    := $(shell if test -e cmd/main.go; then echo cmd/main.go; else echo main.go; fi)
 OS             := $(shell go env GOOS)
 SOURCES        := $(shell find . -name '*.go')
-VERSION        := $(shell gitsemver version)
+VERSION        := $(shell gitsemver get)
 ifeq ($(OS), linux)
 EXTLDFLAGS := -static
 endif

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -14,7 +14,7 @@ MODULE         := $(shell go list -m)
 MAIN_SOURCE    := $(shell if test -e cmd/main.go; then echo cmd/main.go; else echo main.go; fi)
 OS             := $(shell go env GOOS)
 SOURCES        := $(shell find . -name '*.go')
-VERSION        := $(shell gitsemver version)
+VERSION        := $(shell gitsemver get)
 ifeq ($(OS), linux)
 EXTLDFLAGS := -static
 endif


### PR DESCRIPTION
## What

gitsemver [v2.0.0](https://github.com/giantswarm/gitsemver/releases/tag/v2.0.0) is a **breaking release** that renamed the `version` subcommand to `get` (to avoid confusion with the `--version` flag).

The generated `Makefile.gen.go.mk` (for `--language go` projects) resolves the build version with:

```make
VERSION        := $(shell gitsemver version)
```

Under gitsemver v2 this invocation fails, leaving `VERSION` empty and breaking the `build`/`package`/`build-docker` targets that interpolate it.

## Changes

- `pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template`: `gitsemver version` → `gitsemver get`
- `Makefile.gen.go.mk` (devctl's own generated Makefile): same one-line change, so devctl itself builds with gitsemver v2
- `CHANGELOG.md`: entry under `[Unreleased]`

The diff is deliberately scoped to the single command rename. (A full `devctl gen makefile` regen would also pull in pre-existing, unrelated LDFLAGS drift; that's left out of this PR.)

## Impact

Repos consuming this template must have **gitsemver v2.0.0+** on `PATH` after re-running `devctl gen makefile`. The `get` subcommand otherwise takes the same default behavior (`--ref HEAD`, `--dir .`).

## Testing

- `go build ./...` — clean
- `go test ./...` — all pass
- Verified `devctl gen makefile --flavour cli --language go` now emits `VERSION := $(shell gitsemver get)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)