### PR TITLE
feat(gen): branch=build+test circleci shape with coupled branch-publish opt-in

### DIFF
--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -11,18 +11,21 @@ import (
 )
 
 const (
-	flagFlavour  = "flavour"
-	flagLanguage = "language"
-	flagRepoName = "repo-name"
+	flagBranchPublish = "branch-publish"
+	flagFlavour       = "flavour"
+	flagLanguage      = "language"
+	flagRepoName      = "repo-name"
 )
 
 type flag struct {
-	Flavours gen.FlavourSlice
-	Language gen.Language
-	RepoName string
+	BranchPublish bool
+	Flavours      gen.FlavourSlice
+	Language      gen.Language
+	RepoName      string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.BranchPublish, flagBranchPublish, false, "Publish a dev image and chart on branch builds. By default branches build + test only (no push); when set, the branch path additionally pushes an amd64 dev image and the dev chart (coupled).")
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`List of project flavours. The "app" flavour selects the chart pipeline. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().VarP(gen.NewLanguageFlagValue(&f.Language, gen.Language("")), flagLanguage, "l", fmt.Sprintf(`The programming language. "go" selects the go-build job. Possible values: <%s>`, strings.Join(gen.AllLanguages(), "|")))
 	cmd.Flags().StringVarP(&f.RepoName, flagRepoName, "r", "", "Repository name under the giantswarm organization (used for the binary, chart, and job names).")

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -52,6 +52,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			Language:      r.flag.Language,
 			Flavours:      r.flag.Flavours,
 			HasDockerfile: hasDockerfile,
+			BranchPublish: r.flag.BranchPublish,
 		}
 
 		circleciInput, err = circleci.New(c)

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -34,6 +34,11 @@ type Config struct {
 	// HasDockerfile selects the image pipeline. The runner derives this from
 	// the presence of a Dockerfile in the repo.
 	HasDockerfile bool
+	// BranchPublish opts the repo into publishing a dev image and chart on
+	// branch builds. By default branches build + test only (no push). When
+	// set, the branch path additionally pushes an amd64 dev image and the
+	// dev chart, coupled (both or neither).
+	BranchPublish bool
 }
 
 type CircleCI struct {
@@ -54,6 +59,7 @@ func New(config Config) (*CircleCI, error) {
 			Language:      config.Language.String(),
 			HasDockerfile: config.HasDockerfile,
 			HasApp:        hasApp,
+			BranchPublish: config.BranchPublish,
 			OrbVersion:    OrbVersion,
 		},
 	}

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -17,6 +17,8 @@ const (
 	jobRunTests       = "architect/run-tests-with-ats"
 
 	goldenPath = "testdata/mcp-kubernetes.config.yml"
+
+	repoMCPKubernetes = "mcp-kubernetes"
 )
 
 // render executes an input.Input the same way pkg/gen/internal.Execute does,
@@ -53,13 +55,13 @@ func contains(got, substr string) bool {
 }
 
 // Test_GoldenServiceConfig is the golden test: generating with mcp-kubernetes's
-// signals (language go, app flavour, a Dockerfile) must reproduce the aligned
-// standard byte-for-byte. The golden file is mcp-kubernetes's checked-in
-// .circleci/config.yml with the only allowed drift -- the orb bump to the
-// aligned OrbVersion and the v9 buildx/multi-arch shape -- applied.
+// signals (language go, app flavour, a Dockerfile, branch-publish off) must
+// reproduce the aligned standard byte-for-byte. The golden reflects the
+// build+test-only branch default: branches run go-build, build-chart, and
+// execute-chart-tests, while the image and chart pushes are tag-only.
 func Test_GoldenServiceConfig(t *testing.T) {
 	got := render(t, Config{
-		RepoName:      "mcp-kubernetes",
+		RepoName:      repoMCPKubernetes,
 		Language:      gen.LanguageGo,
 		Flavours:      gen.FlavourSlice{gen.FlavourApp},
 		HasDockerfile: true,
@@ -77,7 +79,7 @@ func Test_GoldenServiceConfig(t *testing.T) {
 
 func Test_OrbVersion(t *testing.T) {
 	got := render(t, Config{
-		RepoName:      "mcp-kubernetes",
+		RepoName:      repoMCPKubernetes,
 		Language:      gen.LanguageGo,
 		Flavours:      gen.FlavourSlice{gen.FlavourApp},
 		HasDockerfile: true,
@@ -163,6 +165,68 @@ func Test_ChartOnlyOmitsImage(t *testing.T) {
 	for _, unwanted := range []string{jobGoBuild, jobPushRegistries, jobSyncChina, "- push-to-registries"} {
 		if contains(got, unwanted) {
 			t.Errorf("chart config should not contain %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+// Test_BranchPublishOffOmitsBranchPushes verifies the default branch shape:
+// branches build + test only. The branch image push (name: push-to-registries)
+// and the branch chart push (name: push-chart) must be absent, while the
+// tag-only release jobs and the shared build-chart job remain.
+func Test_BranchPublishOffOmitsBranchPushes(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+		BranchPublish: false,
+	})
+
+	for _, want := range []string{
+		"name: go-build",
+		"name: build-chart",
+		"name: execute-chart-tests",
+		"name: push-to-registries-release",
+		"name: sync-china-registry",
+		"name: push-chart-release",
+	} {
+		if !contains(got, want) {
+			t.Errorf("default config missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"name: push-to-registries\n",
+		"name: push-chart\n",
+		"platforms: linux/amd64",
+	} {
+		if contains(got, unwanted) {
+			t.Errorf("default config should not contain branch-publish %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+// Test_BranchPublishOnAddsCoupledBranchPushes verifies the opt-in branch shape:
+// the branch path additionally emits an amd64 image push (name:
+// push-to-registries with platforms: linux/amd64) and the coupled branch chart
+// push (name: push-chart), without disturbing the tag-only release jobs.
+func Test_BranchPublishOnAddsCoupledBranchPushes(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+		BranchPublish: true,
+	})
+
+	for _, want := range []string{
+		"name: push-to-registries\n",
+		"platforms: linux/amd64",
+		"name: push-chart\n",
+		"name: push-to-registries-release",
+		"name: push-chart-release",
+	} {
+		if !contains(got, want) {
+			t.Errorf("branch-publish config missing %q:\n%s", want, got)
 		}
 	}
 }

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -19,6 +19,7 @@ func NewConfigInput(p params.Params) input.Input {
 			"Language":      p.Language,
 			"HasDockerfile": p.HasDockerfile,
 			"HasApp":        p.HasApp,
+			"BranchPublish": p.BranchPublish,
 			"OrbVersion":    p.OrbVersion,
 		},
 	}

--- a/pkg/gen/input/circleci/internal/file/config.yml.template
+++ b/pkg/gen/input/circleci/internal/file/config.yml.template
@@ -7,7 +7,7 @@ workflows:
     jobs:
 {{- if eq .Language "go" }}
     - architect/go-build:
-        name: go-build-{{ .RepoName }}
+        name: go-build
         binary: {{ .RepoName }}
         context: architect
         filters:
@@ -15,21 +15,24 @@ workflows:
             only: /^v.*/
 {{- end }}
 {{- if .HasDockerfile }}
+{{- if .BranchPublish }}
 
-    # Branch builds: multi-arch image to gsoci for PR validation. v9's
-    # push-to-registries always uses buildx and derives the platforms from
-    # go-build's .platforms file (linux/amd64,linux/arm64 by default).
+    # Branch builds (opt-in): amd64 dev image to gsoci for PR validation,
+    # coupled with the branch chart push below. v9's push-to-registries always
+    # uses buildx; platforms is pinned to amd64 to keep branch builds fast.
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        platforms: linux/amd64
 {{- if eq .Language "go" }}
         requires:
-        - go-build-{{ .RepoName }}
+        - go-build
 {{- end }}
         filters:
           branches:
             ignore:
             - main
+{{- end }}
 
     # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is
     # handled by the sync-china-registry job below (orb's split-china-push
@@ -40,7 +43,7 @@ workflows:
         split-china-push: true
 {{- if eq .Language "go" }}
         requires:
-        - go-build-{{ .RepoName }}
+        - go-build
 {{- end }}
         filters:
           tags:
@@ -64,10 +67,13 @@ workflows:
 {{- end }}
 {{- if .HasApp }}
 
+    # build-chart: package + lint via app-build-suite and persist the archive
+    # (no push). Shared by the branch and tag paths -- branches get build + test
+    # only by default.
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
-        name: build-{{ .RepoName }}-chart
+        name: build-chart
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
         chart: {{ .RepoName }}
@@ -76,7 +82,7 @@ workflows:
         persist_chart_archive: true
 {{- if eq .Language "go" }}
         requires:
-        - go-build-{{ .RepoName }}
+        - go-build
 {{- end }}
         filters:
           tags:
@@ -85,16 +91,15 @@ workflows:
             ignore:
             - main
 
-    # Branch: run chart tests after the image is pushed. run-tests-with-ats
-    # deploys the chart, which pulls the freshly built dev image from gsoci.
-    # Without depending on push-to-registries the test races the image push and
-    # flakes on ImagePullBackOff (the kubelet's pull backoff outlasts the test
-    # deadline once an early pull attempt fails).
+    # Branch: run chart tests after build-chart. When branchPublish pushes a dev
+    # image, the test also waits on push-to-registries -- run-tests-with-ats
+    # deploys the chart, which pulls that image from gsoci, and gating on the
+    # push avoids an ImagePullBackOff race.
     - architect/run-tests-with-ats:
-        name: execute chart tests
+        name: execute-chart-tests
         requires:
-        - build-{{ .RepoName }}-chart
-{{- if .HasDockerfile }}
+        - build-chart
+{{- if and .HasDockerfile .BranchPublish }}
         - push-to-registries
 {{- end }}
         filters:
@@ -105,9 +110,9 @@ workflows:
     # Tag: run chart tests after the release image is pushed, for the same
     # image-availability reason as the branch job above.
     - architect/run-tests-with-ats:
-        name: execute chart tests on release
+        name: execute-chart-tests-release
         requires:
-        - build-{{ .RepoName }}-chart
+        - build-chart
 {{- if .HasDockerfile }}
         - push-to-registries-release
 {{- end }}
@@ -116,17 +121,19 @@ workflows:
             only: /^v.*/
           branches:
             ignore: /.*/
+{{- if .BranchPublish }}
 
-    # Branch: push chart (git catalog + OCI per architect default) after tests + image
+    # Branch chart push (opt-in): publish the dev chart after tests + the amd64
+    # branch image, coupled with push-to-registries above.
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
-        name: push-{{ .RepoName }}-to-giantswarm-app-catalog
+        name: push-chart
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
         chart: {{ .RepoName }}
         requires:
-        - execute chart tests
+        - execute-chart-tests
 {{- if .HasDockerfile }}
         - push-to-registries
 {{- end }}
@@ -134,6 +141,7 @@ workflows:
           branches:
             ignore:
             - main
+{{- end }}
 
     # Tag: push chart after tests + the gsoci image. Intentionally does NOT
     # depend on sync-china-registry so the chart catalog can publish even if
@@ -141,12 +149,12 @@ workflows:
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
-        name: push-{{ .RepoName }}-to-giantswarm-app-catalog-release
+        name: push-chart-release
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
         chart: {{ .RepoName }}
         requires:
-        - execute chart tests on release
+        - execute-chart-tests-release
 {{- if .HasDockerfile }}
         - push-to-registries-release
 {{- end }}

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -19,6 +19,11 @@ type Params struct {
 	// Helm chart). It selects the chart pipeline (push-to-app-catalog with the
 	// app-build-suite executor and run-tests-with-ats).
 	HasApp bool
+	// BranchPublish is true when the repo opts into publishing a dev image and
+	// chart on branch builds. By default branches build + test only; when set,
+	// the branch path additionally pushes an amd64 dev image and the dev chart
+	// (coupled).
+	BranchPublish bool
 	// OrbVersion is the giantswarm/architect orb version to pin.
 	OrbVersion string
 }

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.config.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.config.yml
@@ -6,25 +6,12 @@ workflows:
   build:
     jobs:
     - architect/go-build:
-        name: go-build-mcp-kubernetes
+        name: go-build
         binary: mcp-kubernetes
         context: architect
         filters:
           tags:
             only: /^v.*/
-
-    # Branch builds: multi-arch image to gsoci for PR validation. v9's
-    # push-to-registries always uses buildx and derives the platforms from
-    # go-build's .platforms file (linux/amd64,linux/arm64 by default).
-    - architect/push-to-registries:
-        context: architect
-        name: push-to-registries
-        requires:
-        - go-build-mcp-kubernetes
-        filters:
-          branches:
-            ignore:
-            - main
 
     # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is
     # handled by the sync-china-registry job below (orb's split-china-push
@@ -34,7 +21,7 @@ workflows:
         name: push-to-registries-release
         split-china-push: true
         requires:
-        - go-build-mcp-kubernetes
+        - go-build
         filters:
           tags:
             only: /^v.*/
@@ -55,10 +42,13 @@ workflows:
           branches:
             ignore: /.*/
 
+    # build-chart: package + lint via app-build-suite and persist the archive
+    # (no push). Shared by the branch and tag paths -- branches get build + test
+    # only by default.
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
-        name: build-mcp-kubernetes-chart
+        name: build-chart
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
         chart: mcp-kubernetes
@@ -66,7 +56,7 @@ workflows:
         push_to_oci_registry: false
         persist_chart_archive: true
         requires:
-        - go-build-mcp-kubernetes
+        - go-build
         filters:
           tags:
             only: /^v.*/
@@ -74,16 +64,14 @@ workflows:
             ignore:
             - main
 
-    # Branch: run chart tests after the image is pushed. run-tests-with-ats
-    # deploys the chart, which pulls the freshly built dev image from gsoci.
-    # Without depending on push-to-registries the test races the image push and
-    # flakes on ImagePullBackOff (the kubelet's pull backoff outlasts the test
-    # deadline once an early pull attempt fails).
+    # Branch: run chart tests after build-chart. When branchPublish pushes a dev
+    # image, the test also waits on push-to-registries -- run-tests-with-ats
+    # deploys the chart, which pulls that image from gsoci, and gating on the
+    # push avoids an ImagePullBackOff race.
     - architect/run-tests-with-ats:
-        name: execute chart tests
+        name: execute-chart-tests
         requires:
-        - build-mcp-kubernetes-chart
-        - push-to-registries
+        - build-chart
         filters:
           branches:
             ignore:
@@ -92,9 +80,9 @@ workflows:
     # Tag: run chart tests after the release image is pushed, for the same
     # image-availability reason as the branch job above.
     - architect/run-tests-with-ats:
-        name: execute chart tests on release
+        name: execute-chart-tests-release
         requires:
-        - build-mcp-kubernetes-chart
+        - build-chart
         - push-to-registries-release
         filters:
           tags:
@@ -102,34 +90,18 @@ workflows:
           branches:
             ignore: /.*/
 
-    # Branch: push chart (git catalog + OCI per architect default) after tests + image
-    - architect/push-to-app-catalog:
-        executor: app-build-suite
-        context: architect
-        name: push-mcp-kubernetes-to-giantswarm-app-catalog
-        app_catalog: giantswarm-catalog
-        app_catalog_test: giantswarm-test-catalog
-        chart: mcp-kubernetes
-        requires:
-        - execute chart tests
-        - push-to-registries
-        filters:
-          branches:
-            ignore:
-            - main
-
     # Tag: push chart after tests + the gsoci image. Intentionally does NOT
     # depend on sync-china-registry so the chart catalog can publish even if
     # the in-China Aliyun mirror is slow or fails.
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
-        name: push-mcp-kubernetes-to-giantswarm-app-catalog-release
+        name: push-chart-release
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
         chart: mcp-kubernetes
         requires:
-        - execute chart tests on release
+        - execute-chart-tests-release
         - push-to-registries-release
         filters:
           tags:


### PR DESCRIPTION
## Summary

Reworks the `devctl gen circleci` generator toward the golden-config shape, rebased on top of the recent ImagePullBackOff fix (#1883):

- **Branch = build + test only (default).** Branch builds run `go-build`, `build-chart` (package + persist via app-build-suite, no push), and `execute-chart-tests`. The image and chart **pushes** move to the tag path only.
- **Coupled `--branch-publish` opt-in.** When set, the branch path additionally emits a pushing `push-to-registries` pinned to `platforms: linux/amd64` and a coupled `push-chart` (dev chart). Both or neither. When branch-publish pushes the dev image, `execute-chart-tests` gates on `push-to-registries` to keep #1883's ImagePullBackOff fix intact.
- **Consistent job naming.** Dropped the repo-name suffix and spaces from every `name:` label -> `go-build`, `push-to-registries`, `push-to-registries-release`, `sync-china-registry`, `build-chart`, `execute-chart-tests`, `execute-chart-tests-release`, `push-chart`, `push-chart-release`. `binary:`/`chart:` keep the repo name; all `requires:` references updated.
- **Tag path keeps #1883's split.** `execute-chart-tests-release` gates on `push-to-registries-release`; `push-chart-release` gates on the release test + image.
- **Orb bump.** Pinned `const OrbVersion` -> `9.0.2` (patch release, no consumer-facing job/param shape change).

Plumbing: `BranchPublish` added to `Config`, `params.Params`, and the template data map; a `--branch-publish` flag wired through `cmd/gen/circleci`.

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` passes
- [x] `go build ./...` passes
- [x] Regenerated golden `testdata/mcp-kubernetes.config.yml` reflects the build+test-only branch default
- [x] Added `Test_BranchPublishOffOmitsBranchPushes` and `Test_BranchPublishOnAddsCoupledBranchPushes`
- [ ] CI green