### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.0.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   go-build:
@@ -12,6 +12,7 @@ workflows:
         binary: devctl
         clone_depth: 0
         pre_test_target: generate-go
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           # Needed to trigger job also on git tag.
         filters:
           tags:
@@ -20,6 +21,7 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        platforms: "linux/amd64,linux/arm64"
         requires:
         - go-build-devctl
         filters:
@@ -30,3 +32,15 @@ workflows:
             ignore:
             - main
             - master
+
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        binary: devctl
+        requires:
+        - go-build-devctl
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `devctl-windows-<arch>.exe`.
+
 ## [8.4.0] - 2026-06-03
 
 ### Added


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `push-to-registries`: pins `platforms: "linux/amd64,linux/arm64"` so the non-linux entries written to `.platforms` by `go-build` don't propagate to the Docker buildx build.
- `upload-release-assets`: new job; uploads binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe`.

Same pattern as giantswarm/muster#796.