### PR TITLE
feat(gen): drop build-release-artifacts from CLI release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: remove `build-release-artifacts: true` from the generated `create_release` workflow for CLI-flavored repos. Binaries are now produced and signed by the architect-orb `upload-release-assets` path instead.
+
 ## [8.4.0] - 2026-06-03
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/create_release.yaml.template
+++ b/pkg/gen/input/workflows/internal/file/create_release.yaml.template
@@ -17,7 +17,6 @@ jobs:
   create-release:
     uses: giantswarm/github-workflows/.github/workflows/create-release.yaml@main
     with:
-      build-release-artifacts: {{{{ .IsFlavourCLI }}}}
       fetch-deep-gitlog-for-build: {{{{ .IsDevctl }}}}
     secrets:
       TAYLORBOT_GITHUB_ACTION: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}


### PR DESCRIPTION
## What

Removes `build-release-artifacts: true` from the generated `zz_generated.create_release.yaml` for CLI-flavored repos.

The GH Actions `create-release` workflow uses `architect 6.14.1` (hardcoded) to produce versioned tarballs with no signing. CLI repos now use `architect/upload-release-assets` in CircleCI (orb 9.1.0+), which produces signed bare binaries with cosign `.bundle` files and covers all platforms including `windows/arm64`.

The only active package manager depending on the tarball format is krew (kubectl-gs), which is handled separately.

Once merged, each CLI repo needs one `devctl gen` run to regenerate its `zz_generated.create_release.yaml` with `build-release-artifacts: false`.