### PR TITLE
feat: ship cross-platform binaries for cli-flavour repos in gen circleci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `gen circleci`: Go repos that also carry the `cli` flavour now ship cross-platform binaries on their GitHub Release. `go-build` gets the six-platform `architectures` matrix, an `architect/upload-release-assets` job is added (tag-only) to attach the binaries, and the multi-arch release image push is capped to `linux/amd64,linux/arm64` so buildx does not try the darwin/windows targets under QEMU. Derived from the `cli` flavour -- no new flag or config. Non-cli Go repos (services, operators) are unaffected.
+
 ## [8.6.0] - 2026-06-05
 
 ### Added

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -41,6 +41,14 @@ type Config struct {
 	BranchPublish bool
 }
 
+// shipsBinaries reports whether the repo distributes cross-platform Go binaries
+// on its GitHub Release. The "cli" flavour is the signal: it marks a repo whose
+// users download a binary, as opposed to a chart-wrapped service or operator.
+// Requires Go -- the binary comes from go-build.
+func (c Config) shipsBinaries() bool {
+	return c.Language == gen.LanguageGo && c.Flavours.Contains(gen.FlavourCLI)
+}
+
 type CircleCI struct {
 	params params.Params
 }
@@ -55,12 +63,13 @@ func New(config Config) (*CircleCI, error) {
 
 	c := &CircleCI{
 		params: params.Params{
-			RepoName:      config.RepoName,
-			Language:      config.Language.String(),
-			HasDockerfile: config.HasDockerfile,
-			HasApp:        hasApp,
-			BranchPublish: config.BranchPublish,
-			OrbVersion:    OrbVersion,
+			RepoName:        config.RepoName,
+			Language:        config.Language.String(),
+			HasDockerfile:   config.HasDockerfile,
+			HasApp:          hasApp,
+			BranchPublish:   config.BranchPublish,
+			ReleaseBinaries: config.shipsBinaries(),
+			OrbVersion:      OrbVersion,
 		},
 	}
 

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -16,7 +16,8 @@ const (
 	jobPushCatalog    = "architect/push-to-app-catalog"
 	jobRunTests       = "architect/run-tests-with-ats"
 
-	goldenPath = "testdata/mcp-kubernetes.config.yml"
+	goldenPath    = "testdata/mcp-kubernetes.config.yml"
+	goldenCLIPath = "testdata/mcp-kubernetes.cli.config.yml"
 
 	repoMCPKubernetes = "mcp-kubernetes"
 )
@@ -74,6 +75,29 @@ func Test_GoldenServiceConfig(t *testing.T) {
 
 	if got != string(want) {
 		t.Errorf("generated config does not match golden %s\n--- got ---\n%s\n--- want ---\n%s", goldenPath, got, string(want))
+	}
+}
+
+// Test_GoldenCLIConfig is the golden test for the cli-flavour shape: a Go repo
+// that also carries the cli flavour ships cross-platform binaries on its GitHub
+// Release. Generating must reproduce the aligned standard byte-for-byte (the
+// six-platform architectures on go-build, the upload-release-assets job, and the
+// capped release image push).
+func Test_GoldenCLIConfig(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp, gen.FlavourCLI},
+		HasDockerfile: true,
+	})
+
+	want, err := os.ReadFile(goldenCLIPath) // #nosec G304 -- fixed in-package testdata path
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+
+	if got != string(want) {
+		t.Errorf("generated config does not match golden %s\n--- got ---\n%s\n--- want ---\n%s", goldenCLIPath, got, string(want))
 	}
 }
 
@@ -228,5 +252,67 @@ func Test_BranchPublishOnAddsCoupledBranchPushes(t *testing.T) {
 		if !contains(got, want) {
 			t.Errorf("branch-publish config missing %q:\n%s", want, got)
 		}
+	}
+}
+
+// Test_NoCLIOmitsReleaseBinaries verifies the default: a Go service/chart repo
+// without the cli flavour carries no architectures matrix, no
+// upload-release-assets job, and no platforms cap on the release image push.
+func Test_NoCLIOmitsReleaseBinaries(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	})
+
+	for _, unwanted := range []string{
+		"architectures:",
+		"name: upload-release-assets",
+		"platforms: \"linux/amd64,linux/arm64\"",
+	} {
+		if contains(got, unwanted) {
+			t.Errorf("non-cli config should not contain release-binaries %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+// Test_CLIAddsReleaseBinaries verifies the derivation: the cli flavour on a Go
+// repo emits the six-platform architectures matrix on go-build, an
+// upload-release-assets job (tag-only), and caps the multi-arch release image
+// push to the two linux platforms so buildx does not try darwin/windows under
+// QEMU.
+func Test_CLIAddsReleaseBinaries(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp, gen.FlavourCLI},
+		HasDockerfile: true,
+	})
+
+	for _, want := range []string{
+		`architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"`,
+		"name: upload-release-assets",
+		`platforms: "linux/amd64,linux/arm64"`,
+	} {
+		if !contains(got, want) {
+			t.Errorf("cli config missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// Test_CLIWithoutGoOmitsReleaseBinaries verifies the Go guard: the cli flavour
+// on a repo with no Go build never emits the binary jobs (there would be no
+// binary to upload).
+func Test_CLIWithoutGoOmitsReleaseBinaries(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      "sitesearch",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp, gen.FlavourCLI},
+		HasDockerfile: false,
+	})
+
+	if contains(got, "name: upload-release-assets") {
+		t.Errorf("non-go config should not contain upload-release-assets:\n%s", got)
 	}
 }

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -15,12 +15,13 @@ func NewConfigInput(p params.Params) input.Input {
 		Path:         ".circleci/config.yml",
 		TemplateBody: configTemplate,
 		TemplateData: map[string]interface{}{
-			"RepoName":      p.RepoName,
-			"Language":      p.Language,
-			"HasDockerfile": p.HasDockerfile,
-			"HasApp":        p.HasApp,
-			"BranchPublish": p.BranchPublish,
-			"OrbVersion":    p.OrbVersion,
+			"RepoName":        p.RepoName,
+			"Language":        p.Language,
+			"HasDockerfile":   p.HasDockerfile,
+			"HasApp":          p.HasApp,
+			"BranchPublish":   p.BranchPublish,
+			"ReleaseBinaries": p.ReleaseBinaries,
+			"OrbVersion":      p.OrbVersion,
 		},
 	}
 

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -24,6 +24,13 @@ type Params struct {
 	// the branch path additionally pushes an amd64 dev image and the dev chart
 	// (coupled).
 	BranchPublish bool
+	// ReleaseBinaries is true when the repo distributes cross-platform Go
+	// binaries on its GitHub Release (derived from the "cli" flavour on a Go
+	// repo). It adds the six-platform architectures matrix to go-build and an
+	// upload-release-assets job, and caps the multi-arch image push to
+	// linux/amd64,linux/arm64 (otherwise buildx tries the darwin/windows
+	// targets under QEMU and hangs).
+	ReleaseBinaries bool
 	// OrbVersion is the giantswarm/architect orb version to pin.
 	OrbVersion string
 }

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.config.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.config.yml
@@ -3,34 +3,30 @@
 # (pkg/gen/input/circleci) or the gen.ci config in giantswarm/github, not here.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@{{ .OrbVersion }}
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   build:
     jobs:
-{{- if eq .Language "go" }}
     - architect/go-build:
         name: go-build
-        binary: {{ .RepoName }}
+        binary: mcp-kubernetes
         context: architect
-{{- if .ReleaseBinaries }}
         # Cross-platform binaries attached to the GitHub Release by the
         # upload-release-assets job below (cli flavour). yamllint disables the
         # line-length rule for the 132-char matrix value.
         # yamllint disable-line rule:line-length
         architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
-{{- end }}
         filters:
           tags:
             only: /^v.*/
-{{- if .ReleaseBinaries }}
 
     # Attach the cross-platform go-build binaries to the GitHub Release on tag
     # builds. The release itself is created by the repo's auto-release flow.
     - architect/upload-release-assets:
         context: architect
         name: upload-release-assets
-        binary: {{ .RepoName }}
+        binary: mcp-kubernetes
         requires:
         - go-build
         filters:
@@ -38,27 +34,6 @@ workflows:
             only: /^v.*/
           branches:
             ignore: /.*/
-{{- end }}
-{{- end }}
-{{- if .HasDockerfile }}
-{{- if .BranchPublish }}
-
-    # Branch builds (opt-in): amd64 dev image to gsoci for PR validation,
-    # coupled with the branch chart push below. v9's push-to-registries always
-    # uses buildx; platforms is pinned to amd64 to keep branch builds fast.
-    - architect/push-to-registries:
-        context: architect
-        name: push-to-registries
-        platforms: linux/amd64
-{{- if eq .Language "go" }}
-        requires:
-        - go-build
-{{- end }}
-        filters:
-          branches:
-            ignore:
-            - main
-{{- end }}
 
     # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is
     # handled by the sync-china-registry job below (orb's split-china-push
@@ -67,17 +42,13 @@ workflows:
         context: architect
         name: push-to-registries-release
         split-china-push: true
-{{- if .ReleaseBinaries }}
         # Cap buildx to the two linux platforms. go-build's architectures
         # matrix above writes all six targets to .platforms; without this cap
         # the orb auto-derives --platform from that file and buildx tries to
         # build the darwin/windows manifests under QEMU and hangs.
         platforms: "linux/amd64,linux/arm64"
-{{- end }}
-{{- if eq .Language "go" }}
         requires:
         - go-build
-{{- end }}
         filters:
           tags:
             only: /^v.*/
@@ -97,8 +68,6 @@ workflows:
             only: /^v.*/
           branches:
             ignore: /.*/
-{{- end }}
-{{- if .HasApp }}
 
     # build-chart: package + lint via app-build-suite and persist the archive
     # (no push). Shared by the branch and tag paths -- branches get build + test
@@ -109,14 +78,12 @@ workflows:
         name: build-chart
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
-        chart: {{ .RepoName }}
+        chart: mcp-kubernetes
         push_to_appcatalog: false
         push_to_oci_registry: false
         persist_chart_archive: true
-{{- if eq .Language "go" }}
         requires:
         - go-build
-{{- end }}
         filters:
           tags:
             only: /^v.*/
@@ -132,9 +99,6 @@ workflows:
         name: execute-chart-tests
         requires:
         - build-chart
-{{- if and .HasDockerfile .BranchPublish }}
-        - push-to-registries
-{{- end }}
         filters:
           branches:
             ignore:
@@ -146,35 +110,12 @@ workflows:
         name: execute-chart-tests-release
         requires:
         - build-chart
-{{- if .HasDockerfile }}
         - push-to-registries-release
-{{- end }}
         filters:
           tags:
             only: /^v.*/
           branches:
             ignore: /.*/
-{{- if .BranchPublish }}
-
-    # Branch chart push (opt-in): publish the dev chart after tests + the amd64
-    # branch image, coupled with push-to-registries above.
-    - architect/push-to-app-catalog:
-        executor: app-build-suite
-        context: architect
-        name: push-chart
-        app_catalog: giantswarm-catalog
-        app_catalog_test: giantswarm-test-catalog
-        chart: {{ .RepoName }}
-        requires:
-        - execute-chart-tests
-{{- if .HasDockerfile }}
-        - push-to-registries
-{{- end }}
-        filters:
-          branches:
-            ignore:
-            - main
-{{- end }}
 
     # Tag: push chart after tests + the gsoci image. Intentionally does NOT
     # depend on sync-china-registry so the chart catalog can publish even if
@@ -185,15 +126,12 @@ workflows:
         name: push-chart-release
         app_catalog: giantswarm-catalog
         app_catalog_test: giantswarm-test-catalog
-        chart: {{ .RepoName }}
+        chart: mcp-kubernetes
         requires:
         - execute-chart-tests-release
-{{- if .HasDockerfile }}
         - push-to-registries-release
-{{- end }}
         filters:
           tags:
             only: /^v.*/
           branches:
             ignore: /.*/
-{{- end }}


### PR DESCRIPTION
## Summary

`gen circleci` now emits the cross-platform binary jobs for Go repos that also carry the **`cli` flavour**, so those repos ship binaries on their GitHub Release. This is required before the cli/binary repos (`mcp-kubernetes`, `mcp-prometheus`) can be aligned via align-files — without it, regenerating their `.circleci/config.yml` would strip the hand-added binary distribution (regressing mcp-kubernetes#455).

## What changes (cli flavour + Go only)

- six-platform `architectures` matrix on `architect/go-build`
- a tag-only `architect/upload-release-assets` job to attach the binaries to the Release
- a `platforms: "linux/amd64,linux/arm64"` cap on `push-to-registries-release` — without it the orb auto-derives all six targets from go-build's `.platforms` file and buildx hangs building darwin/windows under QEMU

## Why derive from the `cli` flavour (no flag)

The `cli` flavour already marks "users download a binary" and is exactly the signal the binary repos carry: `mcp-kubernetes` and `mcp-prometheus` (the two `ci.generate` repos that ship binaries) have it; the non-binary `ci.generate` repos (`klaus-operator`, `mcp-capi`, `search-mcp`) don't. align-files already passes the full flavour list to `gen circleci`, so **no align-files change and no new team-YAML knob are needed.**

## Scope

This is the `gen circleci` half only. The push-based **auto-release workflow** generation (`auto-release.yaml` + `cliff.toml` in `gen workflows`) is separate and owned by @fiunchinho. Until both land, don't dispatch align-files for `mcp-kubernetes`/`mcp-prometheus`.

## Test plan

- [x] `go build`, `go vet`, `go test ./pkg/gen/input/circleci/...` pass.
- [x] `golangci-lint --new-from-rev=origin/main` → 0 issues.
- [x] Default (no-cli) golden unchanged; new byte-for-byte `mcp-kubernetes.cli.config.yml` golden covers the cli shape (matches mcp-kubernetes#455's hand edits).

Made with [Cursor](https://cursor.com)