### PR TITLE
refactor(gen): rename auto-release.yaml to zz_generated.auto_release.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen workflows --release-workflow=auto-release` now writes `.github/workflows/zz_generated.auto_release.yaml` instead of the un-prefixed `auto-release.yaml`, bringing the file in line with the rest of the generated workflows (regenerable-via-`zz_generated.`-prefix instead of via `SkipRegenCheck`). Both the `auto-release` and `legacy` branches now also delete the legacy un-prefixed `auto-release.yaml`, so repos that adopted the flow before the rename are migrated automatically on next `devctl gen` run.
+
 ## [8.8.0] - 2026-06-08
 
 ### Added

--- a/cmd/gen/workflows/flag.go
+++ b/cmd/gen/workflows/flag.go
@@ -49,7 +49,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.PublishTechdocs, flagPublishTechdocs, false, "If true, also generate the Publish Techdocs workflow. Possible values: false (default), true.")
 	cmd.Flags().BoolVar(&f.UpstreamSyncAutomation, flagUpstreamSyncAutomation, false, "If true, also generate a workflow to dispatch update events for charts. Only valid for app flavor.")
 	cmd.Flags().StringVar(&f.DispatchUpdateChartEventsRepo, flagDispatchUpdateChartEventsRepo, "", "The repository to dispatch update chart events to. Only valid if --upstream-sync-automation is true.")
-	cmd.Flags().StringVar(&f.ReleaseWorkflow, flagReleaseWorkflow, releaseWorkflowLegacy, fmt.Sprintf("Release workflow to generate. Possible values: %s (default), %s. %s generates the create-release-pr / create-release / validate-changelog trio; %s generates a single push-based auto-release.yaml + cliff.toml that tags + publishes a GitHub Release from conventional commits.", releaseWorkflowLegacy, releaseWorkflowAutoRelease, releaseWorkflowLegacy, releaseWorkflowAutoRelease))
+	cmd.Flags().StringVar(&f.ReleaseWorkflow, flagReleaseWorkflow, releaseWorkflowLegacy, fmt.Sprintf("Release workflow to generate. Possible values: %s (default), %s. %s generates the create-release-pr / create-release / validate-changelog trio; %s generates a single push-based zz_generated.auto_release.yaml + cliff.toml that tags + publishes a GitHub Release from conventional commits.", releaseWorkflowLegacy, releaseWorkflowAutoRelease, releaseWorkflowLegacy, releaseWorkflowAutoRelease))
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gen/workflows/runner.go
+++ b/cmd/gen/workflows/runner.go
@@ -59,11 +59,12 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	// files it owns AND deletion inputs for the OTHER flow's files, so
 	// flipping `--release-workflow` (or the matching `releaseWorkflow:` in
 	// giantswarm/github) in either direction leaves the repo with exactly
-	// one set of release files. Stale stragglers from manual migrations
-	// (cliff.toml at root, .github/workflows/auto-release.yaml without the
-	// zz_generated. prefix) are covered by the same deletion inputs.
+	// one set of release files. The un-prefixed `auto-release.yaml` left
+	// over from manual migrations predating the `zz_generated.` rename is
+	// deleted in BOTH branches via AutoReleaseLegacyDeletion.
 	if r.flag.ReleaseWorkflow == releaseWorkflowAutoRelease {
 		inputs = append(inputs,
+			workflowsInput.AutoReleaseLegacyDeletion(),
 			workflowsInput.AutoRelease(),
 			workflowsInput.CliffToml(),
 			workflowsInput.CreateReleaseDeletion(),
@@ -75,6 +76,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			workflowsInput.CreateRelease(),
 			workflowsInput.CreateReleasePR(),
 			workflowsInput.ValidateChangelog(),
+			workflowsInput.AutoReleaseLegacyDeletion(),
 			workflowsInput.AutoReleaseDeletion(),
 			workflowsInput.CliffTomlDeletion(),
 		)

--- a/pkg/gen/input/workflows/internal/file/auto_release.go
+++ b/pkg/gen/input/workflows/internal/file/auto_release.go
@@ -15,20 +15,16 @@ var autoReleaseTemplate string
 //go:embed auto_release.yaml.template.sha
 var autoReleaseTemplateSha string
 
-// NewAutoReleaseInput emits .github/workflows/auto-release.yaml -- the
-// push-based release tagger + GitHub-Release publisher used by the
-// `releaseWorkflow: auto-release` flow.
-//
-// The file is NOT prefixed with `zz_generated.` because the same path is
-// already in use across the 13+ repos manually migrated to this flow. Using
-// the prefix would cause both files to coexist and race. `SkipRegenCheck`
-// forces overwrite-on-every-run, restoring the regenerable-file behavior the
-// prefix would otherwise provide.
+// NewAutoReleaseInput emits .github/workflows/zz_generated.auto_release.yaml --
+// the push-based release tagger + GitHub-Release publisher used by the
+// `releaseWorkflow: auto-release` flow. The `zz_generated.` prefix marks the
+// file as regenerable so subsequent `devctl gen` runs overwrite it. Repos
+// that adopted this flow before the rename still carry the un-prefixed
+// `auto-release.yaml`; NewAutoReleaseLegacyDeletionInput removes it.
 func NewAutoReleaseInput(p params.Params) input.Input {
 	return input.Input{
-		Path:           filepath.Join(p.Dir, "auto-release.yaml"),
-		SkipRegenCheck: true,
-		TemplateBody:   autoReleaseTemplate,
+		Path:         params.RegenerableFileName(p, "auto_release.yaml"),
+		TemplateBody: autoReleaseTemplate,
 		TemplateDelims: input.InputTemplateDelims{
 			Left:  "{{{{",
 			Right: "}}}}",
@@ -42,8 +38,20 @@ func NewAutoReleaseInput(p params.Params) input.Input {
 // NewAutoReleaseDeletionInput returns an Input that deletes the file
 // NewAutoReleaseInput would generate. Wired into the `legacy` branch in
 // runner.go so a repo switched back from `auto-release` to `legacy` (or
-// never on it in the first place) doesn't keep a stale auto-release.yaml.
+// never on it in the first place) doesn't keep a stale workflow.
 func NewAutoReleaseDeletionInput(p params.Params) input.Input {
+	return input.Input{
+		Delete: true,
+		Path:   params.RegenerableFileName(p, "auto_release.yaml"),
+	}
+}
+
+// NewAutoReleaseLegacyDeletionInput deletes the un-prefixed
+// `.github/workflows/auto-release.yaml` from repos that adopted the
+// auto-release flow before the file was migrated to use the `zz_generated.`
+// prefix. Wired into BOTH branches in runner.go so every regeneration
+// cleans up the legacy path regardless of which flow the repo is on.
+func NewAutoReleaseLegacyDeletionInput(p params.Params) input.Input {
 	return input.Input{
 		Delete: true,
 		Path:   filepath.Join(p.Dir, "auto-release.yaml"),

--- a/pkg/gen/input/workflows/internal/file/create_release.go
+++ b/pkg/gen/input/workflows/internal/file/create_release.go
@@ -36,7 +36,7 @@ func NewCreateReleaseInput(p params.Params) input.Input {
 // NewCreateReleaseDeletionInput returns an Input that deletes the file
 // NewCreateReleaseInput would generate. Wired into the `auto-release` branch
 // in runner.go so a repo that switches from the legacy flow no longer has
-// the legacy create-release.yaml sitting next to auto-release.yaml.
+// the legacy create-release.yaml sitting next to zz_generated.auto_release.yaml.
 func NewCreateReleaseDeletionInput(p params.Params) input.Input {
 	return input.Input{
 		Delete: true,

--- a/pkg/gen/input/workflows/internal/file/create_release_pr.go
+++ b/pkg/gen/input/workflows/internal/file/create_release_pr.go
@@ -35,7 +35,7 @@ func NewCreateReleasePRInput(p params.Params) input.Input {
 // NewCreateReleasePRInput would generate. Wired into the `auto-release`
 // branch in runner.go so a repo that switches from the legacy flow no
 // longer has the legacy create-release-pr.yaml sitting alongside
-// auto-release.yaml.
+// zz_generated.auto_release.yaml.
 func NewCreateReleasePRDeletionInput(p params.Params) input.Input {
 	return input.Input{
 		Delete: true,

--- a/pkg/gen/input/workflows/workflows.go
+++ b/pkg/gen/input/workflows/workflows.go
@@ -53,6 +53,10 @@ func (w *Workflows) AutoReleaseDeletion() input.Input {
 	return file.NewAutoReleaseDeletionInput(w.params)
 }
 
+func (w *Workflows) AutoReleaseLegacyDeletion() input.Input {
+	return file.NewAutoReleaseLegacyDeletionInput(w.params)
+}
+
 func (w *Workflows) CliffToml() input.Input {
 	return file.NewCliffTomlInput()
 }


### PR DESCRIPTION
## Summary

- Renames the `--release-workflow=auto-release` output from `.github/workflows/auto-release.yaml` to `.github/workflows/zz_generated.auto_release.yaml`, bringing it in line with the rest of the generated workflows (regenerable via the `zz_generated.` prefix instead of via `SkipRegenCheck: true`).
- Adds a legacy-deletion input wired into **both** the `auto-release` and `legacy` branches, so the un-prefixed `auto-release.yaml` left behind by manual migrations is removed on the next `devctl gen` run regardless of which flow the repo is on.
- Updates stale comments / help text that still referenced `auto-release.yaml` (in `flag.go`, `create_release.go`, `create_release_pr.go`) and adds a `## [Unreleased]` `### Changed` entry to `CHANGELOG.md`.

## Why

The auto-release workflow was the only `zz_generated.*` cousin that lacked the prefix. It used `SkipRegenCheck: true` instead because at the time the file was already deployed across 13+ repos under the un-prefixed name and renaming would have left both files coexisting and racing in GitHub Actions. This PR closes that loop: the rename happens AND the legacy file is deleted in the same gen run, so no repo ever sees both files at once.

## Test plan

- [ ] `go build ./...` passes (verified locally).
- [ ] `go test ./pkg/gen/... ./cmd/gen/...` passes (verified locally).
- [ ] Run `devctl gen workflows --release-workflow=auto-release` against a repo that currently has the un-prefixed `auto-release.yaml`; confirm the old file is deleted and `zz_generated.auto_release.yaml` is created.
- [ ] Run `devctl gen workflows --release-workflow=legacy` against the same repo; confirm both `auto-release.yaml` and `zz_generated.auto_release.yaml` end up deleted.
- [ ] Flip the flag back and forth once more and confirm there's never a moment where both files coexist.