### PR TITLE
docs: add changelog entries for orb 9.3.0 pin and x/crypto CVE fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: bump the baked architect orb pin to 9.3.0 (additive `push-to-app-catalog` override params, cosign duplicate-Rekor-entry fix, gitsemver 2.0.1; no template shape change). Golden fixtures regenerated.
+
+### Fixed
+
+- Bump `golang.org/x/crypto` to v0.53.0 to resolve CVE-2026-46598 (`ssh/agent` ed25519 panic), which failed the nancy vulnerability check on every CI run.
+
 ## [8.9.0] - 2026-06-08
 
 ### Changed


### PR DESCRIPTION
## Summary

- Adds the missing Unreleased CHANGELOG entries for #1934 (architect orb pin 9.1.0 -> 9.3.0 in `gen circleci`), #1937 (own CI config orb bump), and #1939 (x/crypto CVE-2026-46598 fix), so the next release PR carries them.

## Test plan

- [ ] validate-changelog check green

Made with [Cursor](https://cursor.com)