### PR TITLE
chore(renovate): bump golden fixtures together with the orb constant

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,17 @@
         '// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*const OrbVersion = "(?<currentValue>[^"]+)"',
       ],
     },
+    // The golden fixtures pin the same orb version the generator emits. Same
+    // depName/datasource as the OrbVersion constant above, so Renovate bumps
+    // constant and goldens in one PR and the byte-for-byte golden tests stay
+    // green -- without this, every orb bump needs a manual fixture regen.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pkg/gen/input/circleci/testdata/.*\\.config\\.yml$/'],
+      matchStrings: ['architect: giantswarm/architect@(?<currentValue>\\S+)'],
+      depNameTemplate: 'giantswarm/architect',
+      datasourceTemplate: 'orb',
+    },
     // Pre-commit hook revisions in the pre-commit config template.
     // The built-in pre-commit manager cannot parse this file because it contains
     // Go template directives ({{- if ... }}) that make the YAML invalid.


### PR DESCRIPTION
## Summary

- Adds a Renovate regex custom manager covering `pkg/gen/input/circleci/testdata/*.config.yml`, extracting the `architect: giantswarm/architect@X.Y.Z` pin with the same `depName`/`datasource` as the `OrbVersion` constant manager.
- Renovate groups updates of the same dependency into one branch, so the constant and the golden fixtures move together and the byte-for-byte golden tests stay green. Without this, every orb bump fails `go-build-devctl` until someone regenerates the fixtures manually (happened on #1909 for 9.1.0 and again on #1934 for 9.3.0).

## Test plan

- [x] `renovate-config-validator` passes
- [ ] Next architect orb bump produces a single green PR touching `circleci.go` + both testdata fixtures

Made with [Cursor](https://cursor.com)