### PR TITLE
feat(gen/circleci): validate image builds on branches with push-less build-image job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `gen circleci`: the default branch path now emits a `build-image` job (`push-to-registries` with
+  `push: false`, new in architect orb 9.4.0) that validates the multi-arch image build on every
+  branch without pushing anything. Dockerfile regressions now surface on the PR instead of at tag
+  time. Repos with `branchPublish` keep their pushing branch job instead (it already exercises the
+  Dockerfile); cli-flavour repos get the same two-linux-platform cap as the release push.
+
 ### Changed
 
 - Auto-detect the `RepoName` used in the `gen precommit` command and make the `--repo-name` flag optional.
+- The baked architect orb pin moved to 9.4.0 (adds the `push` parameter on `push-to-registries`).
 
 ## [8.11.1] - 2026-06-11
 

--- a/cmd/app/bootstrap/runner.go
+++ b/cmd/app/bootstrap/runner.go
@@ -63,7 +63,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Repository created from template")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Repository created from template")
 
 	// Wait for repository to be fully created and initialized
 	s.Suffix = " Waiting for repository to be initialized..."
@@ -80,7 +80,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Repository cloned locally")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Repository cloned locally")
 
 	// Replace placeholders
 	s.Suffix = " Replacing placeholders..."
@@ -91,7 +91,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Placeholders replaced")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Placeholders replaced")
 
 	// Configure sync method (vendir/kustomize)
 	s.Suffix = fmt.Sprintf(" Configuring sync method (%s)...", r.flag.SyncMethod)
@@ -102,7 +102,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Sync method configured")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Sync method configured")
 
 	// Configure patch method (script/kustomize)
 	s.Suffix = fmt.Sprintf(" Configuring patch method (%s)...", r.flag.PatchMethod)
@@ -113,7 +113,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Patch method configured")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Patch method configured")
 
 	// Setup CI/CD without branch protection
 	s.Suffix = " Setting up CI/CD..."
@@ -124,7 +124,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ CI/CD setup complete")
+	_, _ = fmt.Fprintln(r.stdout, "✓ CI/CD setup complete")
 
 	// Generate workflows and Makefile
 	s.Suffix = " Generating workflows and Makefile..."
@@ -135,19 +135,19 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Workflows and Makefile generated")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Workflows and Makefile generated")
 
 	// Create PR for giantswarm/github repository
 	s.Suffix = " Creating PR for giantswarm/github..."
 	s.Start()
 	var prURL string
-	err, prURL = r.createGithubRepoPR(ctx)
+	prURL, err = r.createGithubRepoPR(ctx)
 	if err != nil {
 		s.Stop()
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ PR created in giantswarm/github")
+	_, _ = fmt.Fprintln(r.stdout, "✓ PR created in giantswarm/github")
 
 	// Initial commit and push
 	s.Suffix = " Pushing changes to main branch..."
@@ -158,7 +158,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Changes pushed to main branch")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Changes pushed to main branch")
 
 	// Enable branch protection
 	s.Suffix = " Enabling branch protection..."
@@ -169,20 +169,20 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 	s.Stop()
-	fmt.Fprintln(r.stdout, "✓ Branch protection enabled")
+	_, _ = fmt.Fprintln(r.stdout, "✓ Branch protection enabled")
 
-	fmt.Fprintf(r.stdout, "\n✨ Successfully bootstrapped app repository %s\n\n", r.flag.Name)
-	fmt.Fprintf(r.stdout, "Next steps:\n")
-	fmt.Fprintf(r.stdout, "1. Visit your new repository: https://github.com/giantswarm/%s-app\n", r.flag.Name)
+	_, _ = fmt.Fprintf(r.stdout, "\n✨ Successfully bootstrapped app repository %s\n\n", r.flag.Name)
+	_, _ = fmt.Fprintf(r.stdout, "Next steps:\n")
+	_, _ = fmt.Fprintf(r.stdout, "1. Visit your new repository: https://github.com/giantswarm/%s-app\n", r.flag.Name)
 	if prURL != "" {
-		fmt.Fprintf(r.stdout, "2. Review and merge the PR: %s\n", prURL)
+		_, _ = fmt.Fprintf(r.stdout, "2. Review and merge the PR: %s\n", prURL)
 	} else {
-		fmt.Fprintf(r.stdout, "2. Review and merge the PR: https://github.com/giantswarm/github/pulls\n")
+		_, _ = fmt.Fprintf(r.stdout, "2. Review and merge the PR: https://github.com/giantswarm/github/pulls\n")
 	}
-	fmt.Fprintf(r.stdout, "3. Update the Chart.yaml with appropriate metadata and version\n")
-	fmt.Fprintf(r.stdout, "4. Configure your image registry in values.yaml\n")
-	fmt.Fprintf(r.stdout, "5. Create a release by pushing a tag (e.g., v0.1.0)\n")
-	fmt.Fprintf(r.stdout, "\nFor more information, visit: https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-guide/\n")
+	_, _ = fmt.Fprintf(r.stdout, "3. Update the Chart.yaml with appropriate metadata and version\n")
+	_, _ = fmt.Fprintf(r.stdout, "4. Configure your image registry in values.yaml\n")
+	_, _ = fmt.Fprintf(r.stdout, "5. Create a release by pushing a tag (e.g., v0.1.0)\n")
+	_, _ = fmt.Fprintf(r.stdout, "\nFor more information, visit: https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-guide/\n")
 
 	return nil
 }
@@ -585,10 +585,10 @@ func (r *runner) generateWorkflowsAndMakefile(ctx context.Context, repoPath stri
 	return nil
 }
 
-func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
+func (r *runner) createGithubRepoPR(ctx context.Context) (string, error) {
 	token := os.Getenv(r.flag.GithubToken)
 	if token == "" {
-		return microerror.Maskf(envVarNotFoundError, "environment variable %#q not found", r.flag.GithubToken), ""
+		return "", microerror.Maskf(envVarNotFoundError, "environment variable %#q not found", r.flag.GithubToken)
 	}
 
 	// Create a logger that only outputs in debug mode
@@ -608,7 +608,7 @@ func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
 
 	client, err := githubclient.New(config)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Clone giantswarm/github repository
@@ -617,14 +617,14 @@ func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
 
 	err = r.execCommand(ctx, "", "git", "clone", "git@github.com:giantswarm/github.git", repoPath)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Create new branch
 	branchName := fmt.Sprintf("add-%s-app", r.flag.Name)
 	err = r.execCommand(ctx, repoPath, "git", "checkout", "-b", branchName)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Update team YAML file
@@ -641,7 +641,7 @@ func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
 	// Read existing file
 	content, err := os.ReadFile(teamFile)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Parse YAML as a list, preserving comments
@@ -651,14 +651,14 @@ func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
 	var repositories []map[string]interface{}
 	err = decoder.Decode(&repositories)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Parse new entry
 	var newEntries []map[string]interface{}
 	err = yaml.Unmarshal([]byte(newEntry), &newEntries)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 	newRepo := newEntries[0]
 
@@ -682,29 +682,29 @@ func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
 	encoder.SetIndent(2)
 	err = encoder.Encode(repositories)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	err = os.WriteFile(teamFile, buf.Bytes(), fileMode0600)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Commit changes
 	err = r.execCommand(ctx, repoPath, "git", "add", teamFile)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	err = r.execCommand(ctx, repoPath, "git", "commit", "-m", fmt.Sprintf("Add %s-app to team-%s repositories", r.flag.Name, r.flag.Team))
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Push changes using token
 	err = r.execCommand(ctx, repoPath, "git", "push", "origin", branchName)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Create pull request using githubclient
@@ -712,12 +712,12 @@ func (r *runner) createGithubRepoPR(ctx context.Context) (error, string) {
 
 	createdPR, err := client.CreatePullRequest(ctx, "giantswarm", "github", branchName, prTitle)
 	if err != nil {
-		return microerror.Mask(err), ""
+		return "", microerror.Mask(err)
 	}
 
 	// Store PR URL for final message
 	if createdPR.HTMLURL != nil {
-		return nil, *createdPR.HTMLURL
+		return *createdPR.HTMLURL, nil
 	}
-	return nil, ""
+	return "", nil
 }

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -20,7 +20,7 @@ import (
 // and only then reaches repos via the align-files devctl pin.
 //
 // renovate: datasource=orb depName=giantswarm/architect
-const OrbVersion = "9.3.1"
+const OrbVersion = "9.4.0"
 
 // ContinuationOrbVersion pins the circleci/continuation orb used by the
 // generated setup config (.circleci/config.yml) to merge the optional

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -442,9 +442,11 @@ func Test_ChartOnlyOmitsImage(t *testing.T) {
 }
 
 // Test_BranchPublishOffOmitsBranchPushes verifies the default branch shape:
-// branches build + test only. The branch image push (name: push-to-registries)
-// and the branch chart push (name: push-chart) must be absent, while the
-// tag-only release jobs and the shared build-chart job remain.
+// branches build + test only, plus the push-less image validation. The branch
+// image push (name: push-to-registries) and the branch chart push (name:
+// push-chart) must be absent, while the build-only image validation (name:
+// build-image with push: false), the tag-only release jobs, and the shared
+// build-chart job remain.
 func Test_BranchPublishOffOmitsBranchPushes(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      repoMCPKubernetes,
@@ -456,6 +458,8 @@ func Test_BranchPublishOffOmitsBranchPushes(t *testing.T) {
 
 	for _, want := range []string{
 		"name: go-build",
+		"name: build-image",
+		"push: false",
 		"name: build-chart",
 		"name: execute-chart-tests",
 		"name: push-to-registries-release",
@@ -480,7 +484,9 @@ func Test_BranchPublishOffOmitsBranchPushes(t *testing.T) {
 // Test_BranchPublishOnAddsCoupledBranchPushes verifies the opt-in branch shape:
 // the branch path additionally emits an amd64 image push (name:
 // push-to-registries with platforms: linux/amd64) and the coupled branch chart
-// push (name: push-chart), without disturbing the tag-only release jobs.
+// push (name: push-chart), without disturbing the tag-only release jobs. The
+// push-less build-image validation is omitted -- the branch image push already
+// exercises the Dockerfile.
 func Test_BranchPublishOnAddsCoupledBranchPushes(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      repoMCPKubernetes,
@@ -499,6 +505,14 @@ func Test_BranchPublishOnAddsCoupledBranchPushes(t *testing.T) {
 	} {
 		if !contains(got, want) {
 			t.Errorf("branch-publish config missing %q:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		"name: build-image",
+		"push: false",
+	} {
+		if contains(got, unwanted) {
+			t.Errorf("branch-publish config should not contain build-only validation %q:\n%s", unwanted, got)
 		}
 	}
 }

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -60,6 +60,30 @@ workflows:
           branches:
             ignore:
             - main
+{{- else }}
+
+    # Branches: validate the image build without pushing anything (push: false
+    # keeps the buildx result in the BuildKit cache). Same hadolint lint and
+    # multi-arch build as the release job, so Dockerfile regressions surface
+    # on the PR instead of at tag time.
+    - architect/push-to-registries:
+        context: architect
+        name: build-image
+        push: false
+{{- if .ReleaseBinaries }}
+        # Same platform cap as the release job: go-build's six-target
+        # architectures matrix writes all of them to .platforms, and buildx
+        # must not attempt the darwin/windows manifests under QEMU.
+        platforms: "linux/amd64,linux/arm64"
+{{- end }}
+{{- if eq .Language "go" }}
+        requires:
+        - go-build
+{{- end }}
+        filters:
+          branches:
+            ignore:
+            - main
 {{- end }}
 
     # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.3.1
+  architect: giantswarm/architect@9.4.0
 
 workflows:
   build:
@@ -36,6 +36,25 @@ workflows:
             only: /^v.*/
           branches:
             ignore: /.*/
+
+    # Branches: validate the image build without pushing anything (push: false
+    # keeps the buildx result in the BuildKit cache). Same hadolint lint and
+    # multi-arch build as the release job, so Dockerfile regressions surface
+    # on the PR instead of at tag time.
+    - architect/push-to-registries:
+        context: architect
+        name: build-image
+        push: false
+        # Same platform cap as the release job: go-build's six-target
+        # architectures matrix writes all of them to .platforms, and buildx
+        # must not attempt the darwin/windows manifests under QEMU.
+        platforms: "linux/amd64,linux/arm64"
+        requires:
+        - go-build
+        filters:
+          branches:
+            ignore:
+            - main
 
     # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is
     # handled by the sync-china-registry job below (orb's split-china-push

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.3.1
+  architect: giantswarm/architect@9.4.0
 
 workflows:
   build:
@@ -17,6 +17,21 @@ workflows:
         filters:
           tags:
             only: /^v.*/
+
+    # Branches: validate the image build without pushing anything (push: false
+    # keeps the buildx result in the BuildKit cache). Same hadolint lint and
+    # multi-arch build as the release job, so Dockerfile regressions surface
+    # on the PR instead of at tag time.
+    - architect/push-to-registries:
+        context: architect
+        name: build-image
+        push: false
+        requires:
+        - go-build
+        filters:
+          branches:
+            ignore:
+            - main
 
     # Tag builds: push multi-arch image to gsoci + gsociprivate. Aliyun is
     # handled by the sync-china-registry job below (orb's split-china-push


### PR DESCRIPTION
## Summary

- The generated branch path now emits a `build-image` job: `architect/push-to-registries` with `push: false` (new in [architect orb 9.4.0](https://github.com/giantswarm/architect-orb/pull/828)). It runs the same hadolint lint and multi-arch buildx build as the release job but pushes nothing — the result stays in the BuildKit cache. Dockerfile regressions now surface on the PR instead of at tag time.
- `branchPublish` repos keep their pushing branch job instead of `build-image` (it already exercises the Dockerfile).
- cli-flavour repos get the same `linux/amd64,linux/arm64` cap as the release push, so buildx doesn't attempt darwin/windows manifests under QEMU.
- Baked orb pin: 9.3.1 → 9.4.0; both goldens regenerated.
- Drive-by: fixed pre-existing errcheck/ST1008 lint errors in `cmd/app/bootstrap` that blocked the pre-commit hook (separate commit, no behaviour change).

## Motivation

The golden config shape accepted "no PR image validation" as the cost of the orb lacking a build-only mode. That gap bit on giantswarm/search-mcp#150, where a Dockerfile change had no CI signal before tagging. The orb-side fix shipped in 9.4.0; this wires it into the generated shape.

`push: false` was validated end-to-end on a search-mcp test branch with the dev orb: `build-image` green using the workspace-attached CI binary, and no new tags appeared in gsoci.

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` green (goldens byte-for-byte, branch-publish on/off shapes asserted)
- [x] Orb-side `push: false` validated on a real consuming repo branch
- [ ] CI green

Made with [Cursor](https://cursor.com)