### PR TITLE
fix(gen/precommit): exclude .yarn/ from whitespace hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `gen precommit`: exclude the `.yarn/` directory from the `trailing-whitespace` and
+  `end-of-file-fixer` hooks. Vendored yarn releases (`.yarn/releases/yarn-*.cjs`) must not be
+  modified; yarn 4.15.0 ships with trailing whitespace in its bundle, which made the hooks fail.
 - Auto-detect the `RepoName` used in the `gen precommit` command and make the `--repo-name` flag optional.
 - The baked architect orb pin moved to 9.4.0 (adds the `push` parameter on `push-to-registries`).
 

--- a/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
@@ -10,10 +10,10 @@ repos:
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: end-of-file-fixer
-        exclude: ".*testdata/.*"
+        exclude: "(.*testdata/.*|^\\.yarn/.*)"
       - id: mixed-line-ending
       - id: trailing-whitespace
-        exclude: ".*testdata/.*"
+        exclude: "(.*testdata/.*|^\\.yarn/.*)"
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0


### PR DESCRIPTION
## Summary

- Exclude the `.yarn/` directory from the `trailing-whitespace` and `end-of-file-fixer` pre-commit hooks in the generated `.pre-commit-config.yaml`.
- Vendored yarn releases (`.yarn/releases/yarn-*.cjs`) must not be modified by hooks. Yarn 4.15.0 ships with trailing whitespace in its bundle, which makes the `pre-commit` check fail on every repo that vendors it (first seen on giantswarm/backstage#1572).

## Test plan

- [x] `pre-commit run --all-files` passes on giantswarm/backstage with the same exclusion applied to its generated config

Made with [Cursor](https://cursor.com)