### PR TITLE
fix(nancy): Use `go list -json -m all` for producing the dependency list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Nancy: Use `go list -json -m all` for producing the dependency list.
+
 ## [8.14.0] - 2026-06-11
 
 ### Added

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -162,7 +162,7 @@ vet: ## Run go vet against code.
 .PHONY: nancy
 nancy: ## Runs nancy (requires v1.0.37 or newer).
 	@echo "====> $@"
-	CGO_ENABLED=0 go list -json -deps ./... | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
+	CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
 .PHONY: test
 test: ## Runs go test with default values.


### PR DESCRIPTION
Building `cluster-standup-teardown` started to give me the following error:

```
Error: stdin input exceeded 10 MB limit; ensure you are piping valid 'go list' output
```

According to Claude, Nancy does also work with `go list -json -m all`, which produces a much smaller output.

Tested here: https://github.com/giantswarm/cluster-standup-teardown/pull/424.