### PR TITLE
feat(releases): Remove description placeholder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Removed
+
+- Releases: Remove description placeholder.
+
 ## [8.14.1] - 2026-06-11
 
 ### Changed

--- a/pkg/release/release_notes.go
+++ b/pkg/release/release_notes.go
@@ -18,8 +18,6 @@ import (
 
 const releaseNotesTemplate = `# :zap: Giant Swarm Release {{ .Name }} for {{ .Provider }} :zap:
 
-{{ .Description }}
-
 ## Changes compared to {{ .PreviousName }}
 {{ if .Components }}
 ### Components
@@ -77,7 +75,6 @@ type releaseNotesTemplateData struct {
 	Name         string
 	PreviousName string
 	Provider     string
-	Description  string
 	Components   []releaseNotes
 	Apps         []releaseNotes
 }
@@ -276,7 +273,6 @@ func createReleaseNotes(release, baseRelease v1alpha1.Release, provider string, 
 		Name:         releaseToDirectory(release),
 		PreviousName: releaseToDirectory(baseRelease),
 		Provider:     providerTitleMap[provider],
-		Description:  "<< Add description here >>",
 		Components:   components,
 		Apps:         apps,
 	}


### PR DESCRIPTION
We fill it manually anyway and since you don't want the placeholder in the release, it just needs to be removed/changed every time you re-run the command, which is annoying.