### PR TITLE
feat(gen/circleci): add --app-catalog/--app-catalog-test overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `gen circleci`: new `--app-catalog`/`--app-catalog-test` flags override the catalog the chart
+  pipeline publishes to (the `push-to-app-catalog` `app_catalog`/`app_catalog_test` params). Empty
+  defaults to `giantswarm-catalog`/`giantswarm-test-catalog`, so repos that do not set them get the
+  identical config as before. Repos that ship to a different catalog (e.g. the internal
+  `giantswarm-operations-platform`) set them so generation does not silently migrate their chart to
+  the public catalog.
 - `gen renovate`: support for an optional repo-owned `renovate-custom.json5`. When the file exists
   in the repo root at generation time, the generated `renovate.json5` references it as the last
   `extends` entry (`github>giantswarm/<repo>:renovate-custom.json5`), so repo-specific rules win

--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -11,20 +11,26 @@ import (
 )
 
 const (
-	flagBranchPublish = "branch-publish"
-	flagFlavour       = "flavour"
-	flagLanguage      = "language"
-	flagRepoName      = "repo-name"
+	flagAppCatalog     = "app-catalog"
+	flagAppCatalogTest = "app-catalog-test"
+	flagBranchPublish  = "branch-publish"
+	flagFlavour        = "flavour"
+	flagLanguage       = "language"
+	flagRepoName       = "repo-name"
 )
 
 type flag struct {
-	BranchPublish bool
-	Flavours      gen.FlavourSlice
-	Language      gen.Language
-	RepoName      string
+	AppCatalog     string
+	AppCatalogTest string
+	BranchPublish  bool
+	Flavours       gen.FlavourSlice
+	Language       gen.Language
+	RepoName       string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.AppCatalog, flagAppCatalog, "", `Catalog the chart pipeline publishes to (push-to-app-catalog app_catalog). Empty defaults to "giantswarm-catalog"; set it for repos that ship to a different catalog (e.g. the internal "giantswarm-operations-platform") so generation does not migrate the chart to the public catalog.`)
+	cmd.Flags().StringVar(&f.AppCatalogTest, flagAppCatalogTest, "", `Test catalog the chart pipeline publishes to (push-to-app-catalog app_catalog_test). Empty defaults to "giantswarm-test-catalog". Kept paired with --app-catalog.`)
 	cmd.Flags().BoolVar(&f.BranchPublish, flagBranchPublish, false, "Publish a dev image and chart on branch builds. By default branches build + test only (no push); when set, the branch path additionally pushes an amd64 dev image and the dev chart (coupled).")
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`List of project flavours. The "app" flavour selects the chart pipeline. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().VarP(gen.NewLanguageFlagValue(&f.Language, gen.Language("")), flagLanguage, "l", fmt.Sprintf(`The programming language. "go" selects the go-build job. Possible values: <%s>`, strings.Join(gen.AllLanguages(), "|")))

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -48,11 +48,13 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 	var circleciInput *circleci.CircleCI
 	{
 		c := circleci.Config{
-			RepoName:      r.flag.RepoName,
-			Language:      r.flag.Language,
-			Flavours:      r.flag.Flavours,
-			HasDockerfile: hasDockerfile,
-			BranchPublish: r.flag.BranchPublish,
+			RepoName:       r.flag.RepoName,
+			Language:       r.flag.Language,
+			Flavours:       r.flag.Flavours,
+			HasDockerfile:  hasDockerfile,
+			AppCatalog:     r.flag.AppCatalog,
+			AppCatalogTest: r.flag.AppCatalogTest,
+			BranchPublish:  r.flag.BranchPublish,
 		}
 
 		circleciInput, err = circleci.New(c)

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -31,6 +31,15 @@ const OrbVersion = "9.4.0"
 // renovate: datasource=orb depName=circleci/continuation
 const ContinuationOrbVersion = "2.0.1"
 
+// DefaultAppCatalog and DefaultAppCatalogTest are the catalogs the chart
+// pipeline publishes to when a repo does not override them. They match the
+// long-standing template hardcodes, so repos that do not set a catalog get the
+// identical config they had before the override existed.
+const (
+	DefaultAppCatalog     = "giantswarm-catalog"
+	DefaultAppCatalogTest = "giantswarm-test-catalog"
+)
+
 type Config struct {
 	// RepoName is the repository name, used for the binary, chart, and job
 	// names.
@@ -43,6 +52,14 @@ type Config struct {
 	// HasDockerfile selects the image pipeline. The runner derives this from
 	// the presence of a Dockerfile in the repo.
 	HasDockerfile bool
+	// AppCatalog overrides the catalog the chart pipeline publishes to. Empty
+	// defaults to "giantswarm-catalog". Set it for repos that ship to a
+	// different catalog (e.g. the internal "giantswarm-operations-platform")
+	// so generation does not migrate their chart to the public catalog.
+	AppCatalog string
+	// AppCatalogTest overrides the test catalog. Empty defaults to
+	// "giantswarm-test-catalog". Kept paired with AppCatalog.
+	AppCatalogTest string
 	// BranchPublish opts the repo into publishing a dev image and chart on
 	// branch builds. By default branches build + test only (no push). When
 	// set, the branch path additionally pushes an amd64 dev image and the
@@ -70,12 +87,23 @@ func New(config Config) (*CircleCI, error) {
 		return nil, microerror.Maskf(invalidConfigError, "no jobs would be generated: set --language=go, add a Dockerfile, or use the app flavour")
 	}
 
+	appCatalog := config.AppCatalog
+	if appCatalog == "" {
+		appCatalog = DefaultAppCatalog
+	}
+	appCatalogTest := config.AppCatalogTest
+	if appCatalogTest == "" {
+		appCatalogTest = DefaultAppCatalogTest
+	}
+
 	c := &CircleCI{
 		params: params.Params{
 			RepoName:               config.RepoName,
 			Language:               config.Language.String(),
 			HasDockerfile:          config.HasDockerfile,
 			HasApp:                 hasApp,
+			AppCatalog:             appCatalog,
+			AppCatalogTest:         appCatalogTest,
 			BranchPublish:          config.BranchPublish,
 			ReleaseBinaries:        config.shipsBinaries(),
 			OrbVersion:             OrbVersion,

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -349,6 +349,40 @@ func Test_GoldenCLIWorkflows(t *testing.T) {
 	}
 }
 
+// Test_AppCatalogOverride verifies the chart pipeline publishes to the
+// overridden catalog when set, and falls back to the public defaults when not.
+// Repos on the internal giantswarm-operations-platform catalog rely on this so
+// generation does not silently migrate their chart to the public catalog.
+func Test_AppCatalogOverride(t *testing.T) {
+	got := render(t, Config{
+		RepoName:       repoSitesearch,
+		Flavours:       gen.FlavourSlice{gen.FlavourApp},
+		AppCatalog:     "giantswarm-operations-platform-catalog",
+		AppCatalogTest: "giantswarm-operations-platform-test-catalog",
+	})
+
+	if !contains(got, "app_catalog: giantswarm-operations-platform-catalog") {
+		t.Errorf("override not applied; want app_catalog override in:\n%s", got)
+	}
+	if !contains(got, "app_catalog_test: giantswarm-operations-platform-test-catalog") {
+		t.Errorf("override not applied; want app_catalog_test override in:\n%s", got)
+	}
+	if contains(got, "app_catalog: giantswarm-catalog") {
+		t.Errorf("default catalog leaked through despite override:\n%s", got)
+	}
+
+	def := render(t, Config{
+		RepoName: repoSitesearch,
+		Flavours: gen.FlavourSlice{gen.FlavourApp},
+	})
+	if !contains(def, "app_catalog: "+DefaultAppCatalog) {
+		t.Errorf("empty override should default to %q:\n%s", DefaultAppCatalog, def)
+	}
+	if !contains(def, "app_catalog_test: "+DefaultAppCatalogTest) {
+		t.Errorf("empty override should default to %q:\n%s", DefaultAppCatalogTest, def)
+	}
+}
+
 func Test_OrbVersion(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      repoMCPKubernetes,

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -42,6 +42,8 @@ func NewWorkflowsInput(p params.Params) input.Input {
 			"Language":        p.Language,
 			"HasDockerfile":   p.HasDockerfile,
 			"HasApp":          p.HasApp,
+			"AppCatalog":      p.AppCatalog,
+			"AppCatalogTest":  p.AppCatalogTest,
 			"BranchPublish":   p.BranchPublish,
 			"ReleaseBinaries": p.ReleaseBinaries,
 			"OrbVersion":      p.OrbVersion,

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -133,8 +133,8 @@ workflows:
         executor: app-build-suite
         context: architect
         name: build-chart
-        app_catalog: giantswarm-catalog
-        app_catalog_test: giantswarm-test-catalog
+        app_catalog: {{ .AppCatalog }}
+        app_catalog_test: {{ .AppCatalogTest }}
         chart: {{ .RepoName }}
         push_to_appcatalog: false
         push_to_oci_registry: false
@@ -188,8 +188,8 @@ workflows:
         executor: app-build-suite
         context: architect
         name: push-chart
-        app_catalog: giantswarm-catalog
-        app_catalog_test: giantswarm-test-catalog
+        app_catalog: {{ .AppCatalog }}
+        app_catalog_test: {{ .AppCatalogTest }}
         chart: {{ .RepoName }}
         requires:
         - execute-chart-tests
@@ -209,8 +209,8 @@ workflows:
         executor: app-build-suite
         context: architect
         name: push-chart-release
-        app_catalog: giantswarm-catalog
-        app_catalog_test: giantswarm-test-catalog
+        app_catalog: {{ .AppCatalog }}
+        app_catalog_test: {{ .AppCatalogTest }}
         chart: {{ .RepoName }}
         requires:
         - execute-chart-tests-release

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -19,6 +19,16 @@ type Params struct {
 	// Helm chart). It selects the chart pipeline (push-to-app-catalog with the
 	// app-build-suite executor and run-tests-with-ats).
 	HasApp bool
+	// AppCatalog is the catalog the chart pipeline publishes to (the
+	// push-to-app-catalog `app_catalog` param). Defaults to "giantswarm-catalog".
+	// Repos that ship to a different catalog (e.g. the internal
+	// "giantswarm-operations-platform") set it so generation does not silently
+	// migrate their chart to the public catalog.
+	AppCatalog string
+	// AppCatalogTest is the test catalog the chart pipeline publishes to (the
+	// push-to-app-catalog `app_catalog_test` param). Defaults to
+	// "giantswarm-test-catalog". Kept paired with AppCatalog.
+	AppCatalogTest string
 	// BranchPublish is true when the repo opts into publishing a dev image and
 	// chart on branch builds. By default branches build + test only; when set,
 	// the branch path additionally pushes an amd64 dev image and the dev chart


### PR DESCRIPTION
## Problem

The CircleCI generator hardcodes the chart catalog in the workflows template:

```
app_catalog: giantswarm-catalog
app_catalog_test: giantswarm-test-catalog
```

There is no way to express a repo that ships to a different catalog. This blocks generating config for repos on the internal `giantswarm-operations-platform` catalog (e.g. `agentic-platform-ui`, `sitesearch`, and the wider operations-platform set): generation would silently migrate their chart from the internal catalog to the public `giantswarm-catalog`.

## Solution

Add `--app-catalog` / `--app-catalog-test` flags to `gen circleci`, plumbed through `Config` and `Params` into all three `push-to-app-catalog` jobs (`build-chart`, `push-chart`, `push-chart-release`).

Empty defaults to the previous hardcodes (`giantswarm-catalog` / `giantswarm-test-catalog`), so **every repo that does not set the flags generates byte-identical config** — the golden tests are unchanged. Repos on a different catalog set the flags so generation preserves it.

## Acceptance criteria

- [x] `--app-catalog`/`--app-catalog-test` override the three push-to-app-catalog jobs
- [x] empty flags default to the previous hardcodes (golden tests unchanged)
- [x] `Test_AppCatalogOverride` covers override + default fallback
- [x] `go build`, `go vet`, `go test ./pkg/gen/input/circleci/...` pass

Made with [Cursor](https://cursor.com)