### PR TITLE
chore: reset release state after failed 8.16.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [8.16.0] - 2026-06-16
-
 ### Added
 
 - `gen circleci`: new `--app-catalog`/`--app-catalog-test` flags override the catalog the chart
@@ -2121,8 +2119,7 @@ Renovate config
 
 - First release.
 
-[Unreleased]: https://github.com/giantswarm/devctl/compare/v8.16.0...HEAD
-[8.16.0]: https://github.com/giantswarm/devctl/compare/v8.15.2...v8.16.0
+[Unreleased]: https://github.com/giantswarm/devctl/compare/v8.15.2...HEAD
 [8.15.2]: https://github.com/giantswarm/devctl/compare/v8.15.1...v8.15.2
 [8.15.1]: https://github.com/giantswarm/devctl/compare/v8.15.0...v8.15.1
 [8.15.0]: https://github.com/giantswarm/devctl/compare/v8.14.1...v8.15.0

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "devctl"
 	source      = "https://github.com/giantswarm/devctl"
-	version     = "8.16.0"
+	version     = "8.15.3-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
## Problem

The 8.16.0 release PR (#1984) merged with an **empty** `## [8.16.0]` changelog section — the feature branch's entries were dropped in the squash because the v8.15.2 release had emptied `[Unreleased]` on `main`. `create-release` aborted ("No changelog entry found for version 8.16.0"), so no tag was cut, but `project.go` was already bumped to `8.16.0`, leaving the repo stuck mid-release. A later changelog fix (#1986) repopulated `[8.16.0]` but did not re-trigger the release (the workflow keys off a `chore(release): vX.Y.Z` commit title).

## Solution

Restore the pre-release invariant so the normal release flow can re-cut 8.16.0 cleanly:
- move the two `### Added` entries back under `[Unreleased]`
- drop the empty `## [8.16.0]` section and its link ref
- reset `project.go` to `8.15.3-dev`

After this merges, re-running the release-PR flow produces a proper `chore(release): v8.16.0` with the entries, and `create-release` cuts the tag.

Made with [Cursor](https://cursor.com)