### PR TITLE
fix(gen/workflows): pin cliff initial_tag to v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `gen workflows`: the generated `cliff.toml` now pins `[bump].initial_tag = "v0.1.0"`, so the first
+  auto-release in a repo with no tags yet is tagged `v0.1.0` instead of git-cliff's default `0.1.0`.
+  This keeps the inception release on the leading-`v` scheme the rest of the giantswarm stack expects
+  (architect's `/^v.*/` tag filter, the workflow's `--match='v*.*.*'` describe, gitsemver). Once any
+  `v*.*.*` tag exists, git-cliff already carries the prefix forward, so only the first release was
+  affected.
+
 ## [8.17.0] - 2026-06-16
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/cliff.toml.template
+++ b/pkg/gen/input/workflows/internal/file/cliff.toml.template
@@ -13,6 +13,13 @@
 features_always_bump_minor = true
 # `feat!:`/`BREAKING CHANGE` always bumps major.
 breaking_always_bump_major = true
+# First release in a repo with no tags yet. git-cliff defaults this to
+# "0.1.0" (no prefix); we pin it to "v0.1.0" because the whole giantswarm
+# stack (architect's /^v.*/ tag filter, the auto-release workflow's
+# `--match='v*.*.*'` describe, gitsemver) expects the leading `v`. Once any
+# v*.*.* tag exists, git-cliff carries that prefix forward on every bump, so
+# this only governs the inception release.
+initial_tag = "v0.1.0"
 
 [git]
 conventional_commits = true


### PR DESCRIPTION
## What

Add `initial_tag = "v0.1.0"` to the `[bump]` section of the generated `cliff.toml` template (`pkg/gen/input/workflows/internal/file/cliff.toml.template`).

## Why

The generated `cliff.toml` drives the push-based auto-release flow (`git-cliff --unreleased --bump` in `.github/workflows/auto-release.yaml`). In a **brand-new repo with no tags yet**, git-cliff has no existing tag to derive a prefix from, so `--bump` defaults the first version to `0.1.0` (no leading `v`) and the workflow tags the repo `0.1.0`.

That breaks the leading-`v` convention the rest of the giantswarm stack expects:

- architect's CircleCI pipelines fire on a `/^v.*/` tag filter
- the auto-release workflow's own `git describe --match='v*.*.*'` baseline
- gitsemver

`initial_tag` is git-cliff's purpose-built knob for the no-tags case. Once any `v*.*.*` tag exists, git-cliff already carries the `v` prefix forward on every bump, so **only the inception release** was affected and existing-tag repos are unchanged.

## Notes

- `cliff.toml` is generated with `SkipRegenCheck: true`, so consuming repos pick up `initial_tag` on their next `gen` run.
- The `cliff.toml.template.sha` artifact is gitignored and regenerated by `go generate` at build time, so it is not part of this diff.
- No Go tests assert on the template content.

## Verification

- `go build ./pkg/gen/...` passes.