### PR TITLE
feat(gen/circleci): add --image-name and --image-platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `gen circleci`: new `--image-name` and `--image-platforms` flags for repos whose image pipeline
+  does not fit the default shape. `--image-name` overrides the `giantswarm/<repo>` default image name
+  on the generated image jobs (`push-to-registries` branch + release and `sync-china-registry`) for
+  repos whose published image differs from the repo name (e.g. `kserve` publishes
+  `giantswarm/kserve-controller`). `--image-platforms` overrides the buildx platform list on the
+  `build-image` and `push-to-registries-release` jobs for single-architecture images (e.g. `vllm`
+  ships `linux/arm64` only; an amd64 build has no prebuilt wheels and fails). The append-only
+  `.circleci/custom.yml` merge cannot rename or re-platform a generated job, so the generator carries
+  both. Both default off, so repos that do not set them get the identical config as before.
+
 ### Changed
 
 - `gen workflows` / `gen precommit`: add the `merge_group` trigger to the generated GitHub Actions workflows so they also run for GitHub merge queues.

--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -16,6 +16,8 @@ const (
 	flagBranchPublish    = "branch-publish"
 	flagImagePreBuildJob = "image-pre-build-job"
 	flagImagePrivateOnly = "image-private-only"
+	flagImageName        = "image-name"
+	flagImagePlatforms   = "image-platforms"
 	flagFlavour          = "flavour"
 	flagLanguage         = "language"
 	flagRepoName         = "repo-name"
@@ -27,6 +29,8 @@ type flag struct {
 	BranchPublish    bool
 	ImagePreBuildJob string
 	ImagePrivateOnly bool
+	ImageName        string
+	ImagePlatforms   string
 	Flavours         gen.FlavourSlice
 	Language         gen.Language
 	RepoName         string
@@ -38,6 +42,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.BranchPublish, flagBranchPublish, false, "Publish a dev image and chart on branch builds. By default branches build + test only (no push); when set, the branch path additionally pushes an amd64 dev image and the dev chart (coupled).")
 	cmd.Flags().StringVar(&f.ImagePreBuildJob, flagImagePreBuildJob, "", "Name of a repo-owned job (defined in .circleci/custom.yml) the release image build must wait on. Adds a `requires` entry to push-to-registries-release, which the append-only custom.yml merge cannot inject into a generated job. Used for workspace-handoff pre-steps. Empty for the common case.")
 	cmd.Flags().BoolVar(&f.ImagePrivateOnly, flagImagePrivateOnly, false, "Ship the image to the private registry only (gsociprivate), replacing split-china-push and omitting the sync-china-registry job. Set it for private repos whose image must not land in the public catalog.")
+	cmd.Flags().StringVar(&f.ImageName, flagImageName, "", "Override the `giantswarm/<repo>` default image name on the image jobs (push-to-registries / sync-china-registry `image` param). Set it for repos whose published image differs from the repo name (e.g. kserve -> giantswarm/kserve-controller). The append-only custom.yml merge cannot rename a generated job's image. Empty keeps the orb default.")
+	cmd.Flags().StringVar(&f.ImagePlatforms, flagImagePlatforms, "", "Override the buildx platform list on the image jobs (push-to-registries `platforms` param). Empty lets the orb default apply (linux/amd64,linux/arm64 when no go-build .platforms file). Set it for single-architecture images (e.g. vllm -> linux/arm64, whose amd64 build has no prebuilt wheels).")
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`List of project flavours. The "app" flavour selects the chart pipeline. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().VarP(gen.NewLanguageFlagValue(&f.Language, gen.Language("")), flagLanguage, "l", fmt.Sprintf(`The programming language. "go" selects the go-build job. Possible values: <%s>`, strings.Join(gen.AllLanguages(), "|")))
 	cmd.Flags().StringVarP(&f.RepoName, flagRepoName, "r", "", "Repository name under the giantswarm organization (used for the binary, chart, and job names).")

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -57,6 +57,8 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			BranchPublish:    r.flag.BranchPublish,
 			ImagePreBuildJob: r.flag.ImagePreBuildJob,
 			ImagePrivateOnly: r.flag.ImagePrivateOnly,
+			ImageName:        r.flag.ImageName,
+			ImagePlatforms:   r.flag.ImagePlatforms,
 		}
 
 		circleciInput, err = circleci.New(c)

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -74,6 +74,15 @@ type Config struct {
 	// (gsociprivate), replacing split-china-push and omitting sync-china-registry.
 	// Set it for private repos whose image must not land in the public catalog.
 	ImagePrivateOnly bool
+	// ImageName overrides the `giantswarm/<repo>` default image name on the
+	// image jobs. Set it for repos whose published image differs from the repo
+	// name (e.g. kserve -> giantswarm/kserve-controller). Empty keeps the orb
+	// default.
+	ImageName string
+	// ImagePlatforms overrides the buildx platform list on the image jobs.
+	// Empty lets the orb default apply. Set it for single-architecture images
+	// (e.g. vllm -> linux/arm64).
+	ImagePlatforms string
 }
 
 // shipsBinaries reports whether the repo distributes cross-platform Go binaries
@@ -116,6 +125,8 @@ func New(config Config) (*CircleCI, error) {
 			BranchPublish:          config.BranchPublish,
 			ImagePreBuildJob:       config.ImagePreBuildJob,
 			ImagePrivateOnly:       config.ImagePrivateOnly,
+			ImageName:              config.ImageName,
+			ImagePlatforms:         config.ImagePlatforms,
 			ReleaseBinaries:        config.shipsBinaries(),
 			OrbVersion:             OrbVersion,
 			ContinuationOrbVersion: ContinuationOrbVersion,

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -447,6 +447,68 @@ func Test_ImagePrivateOnly(t *testing.T) {
 	}
 }
 
+// Test_ImageName verifies the image-name override is applied to every image
+// job (the branch validation, the release push, and the sync-china-registry
+// mirror) so a repo whose published image differs from its repo name (e.g.
+// kserve -> giantswarm/kserve-controller) is generated correctly, and that
+// omitting it leaves the orb's giantswarm/<repo> default in place (no image
+// param emitted).
+func Test_ImageName(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      "kserve",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{},
+		HasDockerfile: true,
+		ImageName:     "giantswarm/kserve-controller",
+	})
+
+	// Every image job (build-image, push-to-registries-release,
+	// sync-china-registry) must carry the overridden image name.
+	if n := strings.Count(got, "image: giantswarm/kserve-controller"); n != 3 {
+		t.Errorf("expected image override on all 3 image jobs, found %d:\n%s", n, got)
+	}
+
+	def := render(t, Config{
+		RepoName:      "kserve",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{},
+		HasDockerfile: true,
+	})
+	if contains(def, "image:") {
+		t.Errorf("no image param should be emitted without ImageName (orb default applies):\n%s", def)
+	}
+}
+
+// Test_ImagePlatforms verifies the platform override caps the buildx platform
+// list on both the branch validation (build-image) and the release push for a
+// single-architecture image (e.g. vllm -> linux/arm64), and that omitting it
+// emits no platforms param (the orb falls back to its default).
+func Test_ImagePlatforms(t *testing.T) {
+	got := render(t, Config{
+		RepoName:       "vllm",
+		Language:       gen.Language(""),
+		Flavours:       gen.FlavourSlice{},
+		HasDockerfile:  true,
+		ImagePlatforms: "linux/arm64",
+	})
+
+	// build-image (branch) and push-to-registries-release (tag) must both
+	// carry the single-arch cap.
+	if n := strings.Count(got, "platforms: linux/arm64"); n != 2 {
+		t.Errorf("expected platforms cap on build-image and release push, found %d:\n%s", n, got)
+	}
+
+	def := render(t, Config{
+		RepoName:      "vllm",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{},
+		HasDockerfile: true,
+	})
+	if contains(def, "platforms:") {
+		t.Errorf("no platforms param should be emitted without ImagePlatforms (orb default applies):\n%s", def)
+	}
+}
+
 func Test_OrbVersion(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      repoMCPKubernetes,

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -47,6 +47,8 @@ func NewWorkflowsInput(p params.Params) input.Input {
 			"BranchPublish":    p.BranchPublish,
 			"ImagePreBuildJob": p.ImagePreBuildJob,
 			"ImagePrivateOnly": p.ImagePrivateOnly,
+			"ImageName":        p.ImageName,
+			"ImagePlatforms":   p.ImagePlatforms,
 			"ReleaseBinaries":  p.ReleaseBinaries,
 			"OrbVersion":       p.OrbVersion,
 		},

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -51,7 +51,14 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+{{- if .ImageName }}
+        image: {{ .ImageName }}
+{{- end }}
+{{- if .ImagePlatforms }}
+        platforms: {{ .ImagePlatforms }}
+{{- else }}
         platforms: linux/amd64
+{{- end }}
 {{- if eq .Language "go" }}
         requires:
         - go-build
@@ -70,7 +77,12 @@ workflows:
         context: architect
         name: build-image
         push: false
-{{- if .ReleaseBinaries }}
+{{- if .ImageName }}
+        image: {{ .ImageName }}
+{{- end }}
+{{- if .ImagePlatforms }}
+        platforms: {{ .ImagePlatforms }}
+{{- else if .ReleaseBinaries }}
         # Same platform cap as the release job: go-build's six-target
         # architectures matrix writes all of them to .platforms, and buildx
         # must not attempt the darwin/windows manifests under QEMU.
@@ -92,6 +104,9 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries-release
+{{- if .ImageName }}
+        image: {{ .ImageName }}
+{{- end }}
 {{- if .ImagePrivateOnly }}
         # Private repo: ship the image to the private registry only. No public
         # gsoci copy and no Aliyun mirror, so split-china-push and the paired
@@ -101,7 +116,9 @@ workflows:
 {{- else }}
         split-china-push: true
 {{- end }}
-{{- if .ReleaseBinaries }}
+{{- if .ImagePlatforms }}
+        platforms: {{ .ImagePlatforms }}
+{{- else if .ReleaseBinaries }}
         # Cap buildx to the two linux platforms. go-build's architectures
         # matrix above writes all six targets to .platforms; without this cap
         # the orb auto-derives --platform from that file and buildx tries to
@@ -133,6 +150,9 @@ workflows:
     - architect/sync-china-registry:
         context: architect
         name: sync-china-registry
+{{- if .ImageName }}
+        image: {{ .ImageName }}
+{{- end }}
         requires:
         - push-to-registries-release
         filters:

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -49,6 +49,22 @@ type Params struct {
 	// job. Set it for private repos whose image must not land in the public
 	// catalog.
 	ImagePrivateOnly bool
+	// ImageName overrides the `giantswarm/<repo>` default the architect orb
+	// derives for the published image (the push-to-registries / sync-china-registry
+	// `image` param). Set it for repos whose image name differs from the repo
+	// name (e.g. kserve publishes `giantswarm/kserve-controller`). The
+	// append-only custom.yml merge cannot rename a generated job's image, so the
+	// generator carries it. Empty keeps the orb default.
+	ImageName string
+	// ImagePlatforms overrides the buildx platform list for the image build
+	// (the push-to-registries `platforms` param on the build-image and
+	// push-to-registries-release jobs). Empty lets the orb fall back to its
+	// default (linux/amd64,linux/arm64 when no go-build .platforms file). Set it
+	// for repos whose image targets a single architecture (e.g. vllm ships an
+	// arm64-only image for DGX Spark; an amd64 build has no prebuilt wheels and
+	// fails). The append-only custom.yml merge cannot cap a generated job's
+	// platforms, so the generator carries it.
+	ImagePlatforms string
 	// ReleaseBinaries is true when the repo distributes cross-platform Go
 	// binaries on its GitHub Release (derived from the "cli" flavour on a Go
 	// repo). It adds the six-platform architectures matrix to go-build and an


### PR DESCRIPTION
## Summary

Two more default-off `gen circleci` knobs for repos whose image pipeline does not fit the golden shape — the same signal-shaped pattern as the 8.16 catalog knobs and 8.17 `--image-pre-build-job`/`--image-private-only`. Both are needed to absorb `kserve` and `vllm` off the CircleCI override list via the runtime-merged `.circleci/custom.yml` mechanism, which is append-only and so cannot rename or re-platform a generated job.

- **`--image-name`** (`gen.ci.image.name`) overrides the `giantswarm/<repo>` default image name on the generated image jobs (`push-to-registries` branch + release, `sync-china-registry`). `kserve` publishes `giantswarm/kserve-controller`, not `giantswarm/kserve`.
- **`--image-platforms`** (`gen.ci.image.platforms`) overrides the buildx platform list on `build-image` and `push-to-registries-release`. `vllm` ships an `linux/arm64`-only image (DGX Spark); an amd64 build has no prebuilt wheels and fails.

Both default off, so every repo that sets neither renders **byte-identical** config (existing golden tests unchanged).

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` — new `Test_ImageName` / `Test_ImagePlatforms` plus all existing golden tests green
- [x] `gofmt` / `go vet` clean on changed packages
- [x] Generated `kserve` (image-name + branch-publish) and `vllm` (image-platforms) configs merge with their authored `custom.yml` and pass `circleci config validate`, reproducing today's jobs
- [ ] Companion `giantswarm/github` PR wires `ci.image.name` / `ci.image.platforms` / `ci.branchPublish` and opts in `kserve` + `vllm` (gated on this release being pinned)

Note: the repo's local pre-commit `golangci-lint` hook reports ~244 pre-existing issues unrelated to this diff (golangci-lint v2 vs the v1-era hook config, all in untouched files); CI runs the authoritative lint. This diff itself introduces no new lint issues.

Made with [Cursor](https://cursor.com)