### PR TITLE
feat(gen circleci): add --chart-name and --force-public knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `gen circleci`: new `--chart-name` and `--force-public` flags for repos whose chart/registry shape
+  does not fit the default. `--chart-name` overrides the chart name on every chart job (the
+  `push-to-app-catalog` `chart` param and the `helm/<chart>` directory) for repos whose chart
+  directory does not match the repo name (e.g. `docs-proxy` ships `helm/docs-proxy-app`).
+  `--force-public` adds architect's `force-public: true` to the image (`push-to-registries`) and chart
+  (`push-to-app-catalog`) release pushes for private repos that publish public artifacts (e.g.
+  `web-assets`), which architect otherwise derives as private from the repo visibility; it is mutually
+  exclusive with `--image-private-only`. The append-only `.circleci/custom.yml` merge cannot rename a
+  generated job's chart or add `force-public` to it, so the generator carries both. Both default off,
+  so repos that do not set them get the identical config as before.
 - `gen circleci`: new `--image-name` and `--image-platforms` flags for repos whose image pipeline
   does not fit the default shape. `--image-name` overrides the `giantswarm/<repo>` default image name
   on the generated image jobs (`push-to-registries` branch + release and `sync-china-registry`) for

--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -14,6 +14,8 @@ const (
 	flagAppCatalog       = "app-catalog"
 	flagAppCatalogTest   = "app-catalog-test"
 	flagBranchPublish    = "branch-publish"
+	flagChartName        = "chart-name"
+	flagForcePublic      = "force-public"
 	flagImagePreBuildJob = "image-pre-build-job"
 	flagImagePrivateOnly = "image-private-only"
 	flagImageName        = "image-name"
@@ -27,6 +29,8 @@ type flag struct {
 	AppCatalog       string
 	AppCatalogTest   string
 	BranchPublish    bool
+	ChartName        string
+	ForcePublic      bool
 	ImagePreBuildJob string
 	ImagePrivateOnly bool
 	ImageName        string
@@ -40,6 +44,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.AppCatalog, flagAppCatalog, "", `Catalog the chart pipeline publishes to (push-to-app-catalog app_catalog). Empty defaults to "giantswarm-catalog"; set it for repos that ship to a different catalog (e.g. the internal "giantswarm-operations-platform") so generation does not migrate the chart to the public catalog.`)
 	cmd.Flags().StringVar(&f.AppCatalogTest, flagAppCatalogTest, "", `Test catalog the chart pipeline publishes to (push-to-app-catalog app_catalog_test). Empty defaults to "giantswarm-test-catalog". Kept paired with --app-catalog.`)
 	cmd.Flags().BoolVar(&f.BranchPublish, flagBranchPublish, false, "Publish a dev image and chart on branch builds. By default branches build + test only (no push); when set, the branch path additionally pushes an amd64 dev image and the dev chart (coupled).")
+	cmd.Flags().StringVar(&f.ChartName, flagChartName, "", "Override the chart name (the push-to-app-catalog `chart` param and the helm/<chart> directory). Empty defaults to the repo name. Set it for repos whose chart directory does not match the repo name (e.g. docs-proxy -> docs-proxy-app). The append-only custom.yml merge cannot rename a generated job's chart.")
+	cmd.Flags().BoolVar(&f.ForcePublic, flagForcePublic, false, "Push the image and chart as public artifacts even though the repo is private (architect `force-public: true`). Set it for private repos that publish public artifacts (e.g. web-assets). Mutually exclusive with --image-private-only. The append-only custom.yml merge cannot add this to a generated job.")
 	cmd.Flags().StringVar(&f.ImagePreBuildJob, flagImagePreBuildJob, "", "Name of a repo-owned job (defined in .circleci/custom.yml) the release image build must wait on. Adds a `requires` entry to push-to-registries-release, which the append-only custom.yml merge cannot inject into a generated job. Used for workspace-handoff pre-steps. Empty for the common case.")
 	cmd.Flags().BoolVar(&f.ImagePrivateOnly, flagImagePrivateOnly, false, "Ship the image to the private registry only (gsociprivate), replacing split-china-push and omitting the sync-china-registry job. Set it for private repos whose image must not land in the public catalog.")
 	cmd.Flags().StringVar(&f.ImageName, flagImageName, "", "Override the `giantswarm/<repo>` default image name on the image jobs (push-to-registries / sync-china-registry `image` param). Set it for repos whose published image differs from the repo name (e.g. kserve -> giantswarm/kserve-controller). The append-only custom.yml merge cannot rename a generated job's image. Empty keeps the orb default.")
@@ -52,6 +58,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 func (f *flag) Validate() error {
 	if f.RepoName == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRepoName)
+	}
+	if f.ForcePublic && f.ImagePrivateOnly {
+		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagForcePublic, flagImagePrivateOnly)
 	}
 
 	return nil

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -54,6 +54,8 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			HasDockerfile:    hasDockerfile,
 			AppCatalog:       r.flag.AppCatalog,
 			AppCatalogTest:   r.flag.AppCatalogTest,
+			ChartName:        r.flag.ChartName,
+			ForcePublic:      r.flag.ForcePublic,
 			BranchPublish:    r.flag.BranchPublish,
 			ImagePreBuildJob: r.flag.ImagePreBuildJob,
 			ImagePrivateOnly: r.flag.ImagePrivateOnly,

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -60,6 +60,16 @@ type Config struct {
 	// AppCatalogTest overrides the test catalog. Empty defaults to
 	// "giantswarm-test-catalog". Kept paired with AppCatalog.
 	AppCatalogTest string
+	// ChartName overrides the chart name (the push-to-app-catalog `chart`
+	// param and the helm/<chart> directory). Empty defaults to RepoName. Set it
+	// for repos whose chart directory does not match the repo name (e.g.
+	// docs-proxy ships helm/docs-proxy-app).
+	ChartName string
+	// ForcePublic pushes the image and chart as public artifacts even though
+	// the repo is private (architect force-public: true). Set it for private
+	// repos that publish public artifacts (e.g. web-assets). Mutually exclusive
+	// with ImagePrivateOnly.
+	ForcePublic bool
 	// BranchPublish opts the repo into publishing a dev image and chart on
 	// branch builds. By default branches build + test only (no push). When
 	// set, the branch path additionally pushes an amd64 dev image and the
@@ -105,6 +115,10 @@ func New(config Config) (*CircleCI, error) {
 		return nil, microerror.Maskf(invalidConfigError, "no jobs would be generated: set --language=go, add a Dockerfile, or use the app flavour")
 	}
 
+	if config.ForcePublic && config.ImagePrivateOnly {
+		return nil, microerror.Maskf(invalidConfigError, "ForcePublic and ImagePrivateOnly are mutually exclusive")
+	}
+
 	appCatalog := config.AppCatalog
 	if appCatalog == "" {
 		appCatalog = DefaultAppCatalog
@@ -114,12 +128,19 @@ func New(config Config) (*CircleCI, error) {
 		appCatalogTest = DefaultAppCatalogTest
 	}
 
+	chartName := config.ChartName
+	if chartName == "" {
+		chartName = config.RepoName
+	}
+
 	c := &CircleCI{
 		params: params.Params{
 			RepoName:               config.RepoName,
 			Language:               config.Language.String(),
 			HasDockerfile:          config.HasDockerfile,
 			HasApp:                 hasApp,
+			ChartName:              chartName,
+			ForcePublic:            config.ForcePublic,
 			AppCatalog:             appCatalog,
 			AppCatalogTest:         appCatalogTest,
 			BranchPublish:          config.BranchPublish,

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -509,6 +509,83 @@ func Test_ImagePlatforms(t *testing.T) {
 	}
 }
 
+// Test_ChartName verifies the chart-name override is applied to every chart
+// job (build-chart and the tag-only push-chart-release) for a repo whose chart
+// directory does not match the repo name (e.g. docs-proxy ships
+// helm/docs-proxy-app), and that omitting it falls back to the repo name.
+func Test_ChartName(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      "docs-proxy",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+		ChartName:     "docs-proxy-app",
+	})
+
+	// build-chart and push-chart-release must both carry the chart name.
+	if n := strings.Count(got, "chart: docs-proxy-app"); n != 2 {
+		t.Errorf("expected chart-name override on build-chart and push-chart-release, found %d:\n%s", n, got)
+	}
+	if contains(got, "chart: docs-proxy\n") {
+		t.Errorf("repo name leaked through despite chart-name override:\n%s", got)
+	}
+
+	def := render(t, Config{
+		RepoName:      "docs-proxy",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	})
+	if !contains(def, "chart: docs-proxy\n") {
+		t.Errorf("empty chart-name should default to the repo name:\n%s", def)
+	}
+}
+
+// Test_ForcePublic verifies that force-public: true lands on the release image
+// push and the release chart push for a private repo that publishes public
+// artifacts (e.g. web-assets), and that the default emits no force-public.
+func Test_ForcePublic(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      "web-assets",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+		ForcePublic:   true,
+	})
+
+	// push-to-registries-release (image) and push-chart-release (chart) must
+	// both force the public push.
+	if n := strings.Count(got, "force-public: true"); n != 2 {
+		t.Errorf("expected force-public on the release image and chart pushes, found %d:\n%s", n, got)
+	}
+
+	def := render(t, Config{
+		RepoName:      "web-assets",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	})
+	if contains(def, "force-public: true") {
+		t.Errorf("force-public leaked without ForcePublic:\n%s", def)
+	}
+}
+
+// Test_ForcePublicPrivateOnlyConflict verifies the two mutually-exclusive
+// registry-scope knobs are rejected when both are set (one forces public, the
+// other forces private).
+func Test_ForcePublicPrivateOnlyConflict(t *testing.T) {
+	_, err := New(Config{
+		RepoName:         "web-assets",
+		Flavours:         gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile:    true,
+		ForcePublic:      true,
+		ImagePrivateOnly: true,
+	})
+	if !IsInvalidConfig(err) {
+		t.Errorf("expected invalidConfigError for ForcePublic+ImagePrivateOnly, got %v", err)
+	}
+}
+
 func Test_OrbVersion(t *testing.T) {
 	got := render(t, Config{
 		RepoName:      repoMCPKubernetes,

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -42,6 +42,8 @@ func NewWorkflowsInput(p params.Params) input.Input {
 			"Language":         p.Language,
 			"HasDockerfile":    p.HasDockerfile,
 			"HasApp":           p.HasApp,
+			"ChartName":        p.ChartName,
+			"ForcePublic":      p.ForcePublic,
 			"AppCatalog":       p.AppCatalog,
 			"AppCatalogTest":   p.AppCatalogTest,
 			"BranchPublish":    p.BranchPublish,

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -51,6 +51,11 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+{{- if .ForcePublic }}
+        # Private repo that publishes a public image: architect otherwise
+        # derives private from the repo visibility, so force the public push.
+        force-public: true
+{{- end }}
 {{- if .ImageName }}
         image: {{ .ImageName }}
 {{- end }}
@@ -104,6 +109,11 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries-release
+{{- if .ForcePublic }}
+        # Private repo that publishes a public image: architect otherwise
+        # derives private from the repo visibility, so force the public push.
+        force-public: true
+{{- end }}
 {{- if .ImageName }}
         image: {{ .ImageName }}
 {{- end }}
@@ -173,7 +183,7 @@ workflows:
         name: build-chart
         app_catalog: {{ .AppCatalog }}
         app_catalog_test: {{ .AppCatalogTest }}
-        chart: {{ .RepoName }}
+        chart: {{ .ChartName }}
         push_to_appcatalog: false
         push_to_oci_registry: false
         persist_chart_archive: true
@@ -226,9 +236,13 @@ workflows:
         executor: app-build-suite
         context: architect
         name: push-chart
+{{- if .ForcePublic }}
+        # Private repo that publishes a public chart: force the public catalog push.
+        force-public: true
+{{- end }}
         app_catalog: {{ .AppCatalog }}
         app_catalog_test: {{ .AppCatalogTest }}
-        chart: {{ .RepoName }}
+        chart: {{ .ChartName }}
         requires:
         - execute-chart-tests
 {{- if .HasDockerfile }}
@@ -247,9 +261,13 @@ workflows:
         executor: app-build-suite
         context: architect
         name: push-chart-release
+{{- if .ForcePublic }}
+        # Private repo that publishes a public chart: force the public catalog push.
+        force-public: true
+{{- end }}
         app_catalog: {{ .AppCatalog }}
         app_catalog_test: {{ .AppCatalogTest }}
-        chart: {{ .RepoName }}
+        chart: {{ .ChartName }}
         requires:
         - execute-chart-tests-release
 {{- if .HasDockerfile }}

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -19,6 +19,18 @@ type Params struct {
 	// Helm chart). It selects the chart pipeline (push-to-app-catalog with the
 	// app-build-suite executor and run-tests-with-ats).
 	HasApp bool
+	// ChartName is the chart name used for the push-to-app-catalog `chart`
+	// param and the helm/<chart> directory. Defaults to RepoName. Set it for
+	// repos whose chart directory does not match the repo name (e.g.
+	// docs-proxy ships helm/docs-proxy-app). The append-only custom.yml merge
+	// cannot rename a generated job's chart, so the generator carries it.
+	ChartName string
+	// ForcePublic pushes the image and chart as public artifacts even though
+	// the repo is private (architect `force-public: true` on push-to-registries
+	// and push-to-app-catalog). Set it for private repos that publish public
+	// artifacts (e.g. web-assets); architect otherwise derives private from the
+	// repo visibility. Mutually exclusive with ImagePrivateOnly.
+	ForcePublic bool
 	// AppCatalog is the catalog the chart pipeline publishes to (the
 	// push-to-app-catalog `app_catalog` param). Defaults to "giantswarm-catalog".
 	// Repos that ship to a different catalog (e.g. the internal


### PR DESCRIPTION
## Summary

Two default-off, signal-shaped `gen circleci` overrides for the non-Go `service` rollout wave (docs-indexer, docs-proxy, web-assets), each expressing a shape the append-only `.circleci/custom.yml` merge cannot patch onto a generated job:

- **`--chart-name`** — overrides the chart name on every chart job (`push-to-app-catalog` `chart` param + the `helm/<chart>` directory). These three repos ship `helm/<repo>-app` (e.g. `helm/docs-proxy-app`), which can't be renamed without breaking deployed App CRs. Defaults to the repo name when unset.
- **`--force-public`** — adds architect's `force-public: true` to the image (`push-to-registries`) and chart (`push-to-app-catalog`) release pushes. `web-assets` is a **private** repo that publishes a **public** image+chart; architect otherwise derives private from the GitHub repo visibility (the opposite of intent). Mutually exclusive with `--image-private-only`.

Same pattern as the existing `--image-name` / `--image-private-only` / `--app-catalog` knobs: each is default-off and signal-shaped, so **every other repo renders byte-identical config** (the service/cli goldens are unchanged).

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` — new `Test_ChartName`, `Test_ForcePublic`, `Test_ForcePublicPrivateOnlyConflict`; existing goldens unchanged (knobs default off)
- [x] `go build ./...`, `go vet`, `gofmt -l` clean on changed files
- [ ] CircleCI green

Made with [Cursor](https://cursor.com)