### PR TITLE
feat(gen circleci): add --image-dockerfile knob + branch pre-build wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `gen circleci`: new `--image-dockerfile` flag for repos whose Dockerfile is not at the repo root
+  (e.g. `backstage` builds from `packages/backend/Dockerfile`). It sets the `dockerfile` param on the
+  generated image build jobs (`build-image` and `push-to-registries-release`) and, because the image
+  pipeline is otherwise derived from a root `os.Stat("Dockerfile")` that misses a nested Dockerfile, a
+  non-empty value also turns the image pipeline on. The append-only `.circleci/custom.yml` merge cannot
+  set the Dockerfile path on a generated job, so the generator carries it. Default off, so repos that do
+  not set it get the identical config as before.
+
+- `gen circleci`: the branch image-validation job (`build-image`, and the branch-publish
+  `push-to-registries` when `--branch-publish` is set) now also gains the `--image-pre-build-job`
+  `requires` entry. Previously only the release image (`push-to-registries-release`) waited on the
+  pre-build job; the branch build compiles the same Dockerfile and needs the same workspace handoff, so
+  it would otherwise fail building a Dockerfile that consumes pre-build artifacts. No change for repos
+  that do not set `--image-pre-build-job`.
+
 ## [8.19.0] - 2026-06-17
 
 ### Added

--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -20,6 +20,7 @@ const (
 	flagImagePrivateOnly = "image-private-only"
 	flagImageName        = "image-name"
 	flagImagePlatforms   = "image-platforms"
+	flagImageDockerfile  = "image-dockerfile"
 	flagFlavour          = "flavour"
 	flagLanguage         = "language"
 	flagRepoName         = "repo-name"
@@ -35,6 +36,7 @@ type flag struct {
 	ImagePrivateOnly bool
 	ImageName        string
 	ImagePlatforms   string
+	ImageDockerfile  string
 	Flavours         gen.FlavourSlice
 	Language         gen.Language
 	RepoName         string
@@ -50,6 +52,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.ImagePrivateOnly, flagImagePrivateOnly, false, "Ship the image to the private registry only (gsociprivate), replacing split-china-push and omitting the sync-china-registry job. Set it for private repos whose image must not land in the public catalog.")
 	cmd.Flags().StringVar(&f.ImageName, flagImageName, "", "Override the `giantswarm/<repo>` default image name on the image jobs (push-to-registries / sync-china-registry `image` param). Set it for repos whose published image differs from the repo name (e.g. kserve -> giantswarm/kserve-controller). The append-only custom.yml merge cannot rename a generated job's image. Empty keeps the orb default.")
 	cmd.Flags().StringVar(&f.ImagePlatforms, flagImagePlatforms, "", "Override the buildx platform list on the image jobs (push-to-registries `platforms` param). Empty lets the orb default apply (linux/amd64,linux/arm64 when no go-build .platforms file). Set it for single-architecture images (e.g. vllm -> linux/arm64, whose amd64 build has no prebuilt wheels).")
+	cmd.Flags().StringVar(&f.ImageDockerfile, flagImageDockerfile, "", "Override the Dockerfile path on the image jobs (push-to-registries `dockerfile` param). Set it for repos whose Dockerfile is not at the repo root (e.g. backstage -> packages/backend/Dockerfile); a non-empty value also turns the image pipeline on, since the root-Dockerfile derivation misses a nested Dockerfile. The append-only custom.yml merge cannot set this on a generated job. Empty keeps the orb default.")
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`List of project flavours. The "app" flavour selects the chart pipeline. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().VarP(gen.NewLanguageFlagValue(&f.Language, gen.Language("")), flagLanguage, "l", fmt.Sprintf(`The programming language. "go" selects the go-build job. Possible values: <%s>`, strings.Join(gen.AllLanguages(), "|")))
 	cmd.Flags().StringVarP(&f.RepoName, flagRepoName, "r", "", "Repository name under the giantswarm organization (used for the binary, chart, and job names).")

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -61,6 +61,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			ImagePrivateOnly: r.flag.ImagePrivateOnly,
 			ImageName:        r.flag.ImageName,
 			ImagePlatforms:   r.flag.ImagePlatforms,
+			ImageDockerfile:  r.flag.ImageDockerfile,
 		}
 
 		circleciInput, err = circleci.New(c)

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -75,11 +75,19 @@ type Config struct {
 	// set, the branch path additionally pushes an amd64 dev image and the
 	// dev chart, coupled (both or neither).
 	BranchPublish bool
-	// ImagePreBuildJob names a repo-owned custom.yml job the release image
-	// build must wait on (adds a `requires` entry to push-to-registries-release).
-	// Used for workspace-handoff pre-steps the append-only custom.yml merge
-	// cannot inject into a generated job. Empty for the common case.
+	// ImagePreBuildJob names a repo-owned custom.yml job the image build must
+	// wait on (adds a `requires` entry to push-to-registries-release and the
+	// branch build-image / push-to-registries job). Used for workspace-handoff
+	// pre-steps the append-only custom.yml merge cannot inject into a generated
+	// job. Empty for the common case.
 	ImagePreBuildJob string
+	// ImageDockerfile overrides the Dockerfile path on the image jobs (the
+	// architect push-to-registries `dockerfile` param). A non-empty value also
+	// forces the image pipeline on, so a repo whose Dockerfile is not at the
+	// repo root (e.g. backstage -> packages/backend/Dockerfile) still generates
+	// image jobs. Empty keeps the orb default ("Dockerfile") and leaves the
+	// root-Dockerfile derivation untouched.
+	ImageDockerfile string
 	// ImagePrivateOnly ships the image to the private registry only
 	// (gsociprivate), replacing split-china-push and omitting sync-china-registry.
 	// Set it for private repos whose image must not land in the public catalog.
@@ -111,7 +119,11 @@ func New(config Config) (*CircleCI, error) {
 	// Every job is derived from a signal. With none of them set the template
 	// renders an empty `jobs:` list, which is an invalid CircleCI config.
 	hasApp := config.Flavours.Contains(gen.FlavourApp)
-	if config.Language != gen.LanguageGo && !config.HasDockerfile && !hasApp {
+	// A non-root Dockerfile is signalled by ImageDockerfile: the runner derives
+	// HasDockerfile from a root os.Stat that misses it, so the explicit path
+	// also turns the image pipeline on.
+	hasDockerfile := config.HasDockerfile || config.ImageDockerfile != ""
+	if config.Language != gen.LanguageGo && !hasDockerfile && !hasApp {
 		return nil, microerror.Maskf(invalidConfigError, "no jobs would be generated: set --language=go, add a Dockerfile, or use the app flavour")
 	}
 
@@ -137,7 +149,7 @@ func New(config Config) (*CircleCI, error) {
 		params: params.Params{
 			RepoName:               config.RepoName,
 			Language:               config.Language.String(),
-			HasDockerfile:          config.HasDockerfile,
+			HasDockerfile:          hasDockerfile,
 			HasApp:                 hasApp,
 			ChartName:              chartName,
 			ForcePublic:            config.ForcePublic,
@@ -148,6 +160,7 @@ func New(config Config) (*CircleCI, error) {
 			ImagePrivateOnly:       config.ImagePrivateOnly,
 			ImageName:              config.ImageName,
 			ImagePlatforms:         config.ImagePlatforms,
+			ImageDockerfile:        config.ImageDockerfile,
 			ReleaseBinaries:        config.shipsBinaries(),
 			OrbVersion:             OrbVersion,
 			ContinuationOrbVersion: ContinuationOrbVersion,

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -395,9 +395,11 @@ func Test_ImagePreBuildJob(t *testing.T) {
 		ImagePreBuildJob: "fetch-release-notes",
 	})
 
-	// The release image job must require the custom pre-build job.
-	if !contains(got, "- fetch-release-notes") {
-		t.Errorf("release image job missing requires on pre-build job:\n%s", got)
+	// Both the branch validation (build-image) and the release push must
+	// require the custom pre-build job: the branch build compiles the same
+	// Dockerfile and needs the same workspace handoff.
+	if n := strings.Count(got, "- fetch-release-notes"); n != 2 {
+		t.Errorf("expected pre-build requires on build-image and release push, found %d:\n%s", n, got)
 	}
 
 	def := render(t, Config{
@@ -506,6 +508,43 @@ func Test_ImagePlatforms(t *testing.T) {
 	})
 	if contains(def, "platforms:") {
 		t.Errorf("no platforms param should be emitted without ImagePlatforms (orb default applies):\n%s", def)
+	}
+}
+
+// Test_ImageDockerfile verifies the dockerfile-path override turns the image
+// pipeline on even when no root Dockerfile is detected (HasDockerfile false)
+// and applies the path to the build jobs (build-image and
+// push-to-registries-release; the sync-china-registry mirror does not build).
+// This is the backstage shape: a chart repo (app flavour, generic language)
+// whose image is built from packages/backend/Dockerfile. Omitting it emits no
+// dockerfile param so the orb default applies.
+func Test_ImageDockerfile(t *testing.T) {
+	got := render(t, Config{
+		RepoName:        "backstage",
+		Language:        gen.Language(""),
+		Flavours:        gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile:   false,
+		ImageDockerfile: "packages/backend/Dockerfile",
+	})
+
+	// The image pipeline must be generated despite HasDockerfile=false.
+	if !contains(got, "name: push-to-registries-release") {
+		t.Errorf("ImageDockerfile did not turn the image pipeline on:\n%s", got)
+	}
+	// build-image (branch) and push-to-registries-release (tag) carry the path;
+	// sync-china-registry mirrors and does not build, so it must not.
+	if n := strings.Count(got, "dockerfile: packages/backend/Dockerfile"); n != 2 {
+		t.Errorf("expected dockerfile path on build-image and release push, found %d:\n%s", n, got)
+	}
+
+	def := render(t, Config{
+		RepoName:      "backstage",
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	})
+	if contains(def, "dockerfile:") {
+		t.Errorf("no dockerfile param should be emitted without ImageDockerfile (orb default applies):\n%s", def)
 	}
 }
 

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -51,6 +51,7 @@ func NewWorkflowsInput(p params.Params) input.Input {
 			"ImagePrivateOnly": p.ImagePrivateOnly,
 			"ImageName":        p.ImageName,
 			"ImagePlatforms":   p.ImagePlatforms,
+			"ImageDockerfile":  p.ImageDockerfile,
 			"ReleaseBinaries":  p.ReleaseBinaries,
 			"OrbVersion":       p.OrbVersion,
 		},

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -56,6 +56,9 @@ workflows:
         # derives private from the repo visibility, so force the public push.
         force-public: true
 {{- end }}
+{{- if .ImageDockerfile }}
+        dockerfile: {{ .ImageDockerfile }}
+{{- end }}
 {{- if .ImageName }}
         image: {{ .ImageName }}
 {{- end }}
@@ -64,9 +67,17 @@ workflows:
 {{- else }}
         platforms: linux/amd64
 {{- end }}
-{{- if eq .Language "go" }}
+{{- if or (eq .Language "go") .ImagePreBuildJob }}
         requires:
+{{- if eq .Language "go" }}
         - go-build
+{{- end }}
+{{- if .ImagePreBuildJob }}
+        # Repo-owned pre-build job (defined in .circleci/custom.yml). The
+        # branch image build needs the same workspace handoff as the release
+        # job, so the generator carries the dependency.
+        - {{ .ImagePreBuildJob }}
+{{- end }}
 {{- end }}
         filters:
           branches:
@@ -82,6 +93,9 @@ workflows:
         context: architect
         name: build-image
         push: false
+{{- if .ImageDockerfile }}
+        dockerfile: {{ .ImageDockerfile }}
+{{- end }}
 {{- if .ImageName }}
         image: {{ .ImageName }}
 {{- end }}
@@ -93,9 +107,18 @@ workflows:
         # must not attempt the darwin/windows manifests under QEMU.
         platforms: "linux/amd64,linux/arm64"
 {{- end }}
-{{- if eq .Language "go" }}
+{{- if or (eq .Language "go") .ImagePreBuildJob }}
         requires:
+{{- if eq .Language "go" }}
         - go-build
+{{- end }}
+{{- if .ImagePreBuildJob }}
+        # Repo-owned pre-build job (defined in .circleci/custom.yml). The
+        # branch image validation needs the same workspace handoff as the
+        # release job (it builds the same Dockerfile), so the generator carries
+        # the dependency.
+        - {{ .ImagePreBuildJob }}
+{{- end }}
 {{- end }}
         filters:
           branches:
@@ -113,6 +136,9 @@ workflows:
         # Private repo that publishes a public image: architect otherwise
         # derives private from the repo visibility, so force the public push.
         force-public: true
+{{- end }}
+{{- if .ImageDockerfile }}
+        dockerfile: {{ .ImageDockerfile }}
 {{- end }}
 {{- if .ImageName }}
         image: {{ .ImageName }}

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -51,8 +51,10 @@ type Params struct {
 	// push-to-registries-release job gains a `requires` entry for it, which the
 	// append-only custom.yml merge cannot inject into a generated job. Used for
 	// workspace-handoff pre-steps (e.g. a job that persists a generated file the
-	// Docker build context overlays via attach_workspace). Empty for the common
-	// case.
+	// Docker build context overlays via attach_workspace). The branch
+	// build-image (and branch-publish push-to-registries) job gains the same
+	// `requires` entry, so the branch image validation also gets the workspace.
+	// Empty for the common case.
 	ImagePreBuildJob string
 	// ImagePrivateOnly is true when the repo's image must ship only to the
 	// private registry (gsociprivate). It replaces the default split-china-push
@@ -77,6 +79,15 @@ type Params struct {
 	// fails). The append-only custom.yml merge cannot cap a generated job's
 	// platforms, so the generator carries it.
 	ImagePlatforms string
+	// ImageDockerfile overrides the Dockerfile path on the image jobs (the
+	// architect push-to-registries `dockerfile` param). Set it for repos whose
+	// Dockerfile is not at the repo root (e.g. backstage builds from
+	// packages/backend/Dockerfile). A non-empty value also forces the image
+	// pipeline on, since the root-Dockerfile derivation misses a nested
+	// Dockerfile. The append-only custom.yml merge cannot set this on a
+	// generated job, so the generator carries it. Empty keeps the orb default
+	// ("Dockerfile").
+	ImageDockerfile string
 	// ReleaseBinaries is true when the repo distributes cross-platform Go
 	// binaries on its GitHub Release (derived from the "cli" flavour on a Go
 	// repo). It adds the six-platform architectures matrix to go-build and an


### PR DESCRIPTION
## Summary

Adds the last generator capability needed to roll `backstage` (the sole remaining P1 in the CircleCI-generation rollout) onto devctl-generated config.

`backstage` builds its image from `packages/backend/Dockerfile` (a non-root path), and that Dockerfile `COPY`s artifacts produced by a Node `buildjob` handed off via a CircleCI workspace. Two gaps blocked generating its pipeline:

- The image pipeline is derived from a root `os.Stat("Dockerfile")`, which misses a nested Dockerfile, so `backstage` would generate chart-only.
- `--image-pre-build-job` only added the `requires` to the **release** image; the branch `build-image` validation builds the same Dockerfile and needs the same workspace, so it would fail on the `COPY` of the pre-build artifacts.

This PR:

- **`--image-dockerfile <path>`** (`gen.ci.image.dockerfile`): sets the `dockerfile` param on the generated image jobs (`build-image`, `push-to-registries-release`) and, because the root-Dockerfile derivation misses a nested Dockerfile, a non-empty value also turns the image pipeline on.
- Wires **`--image-pre-build-job`** into the branch `build-image` (and the branch-publish `push-to-registries` when `--branch-publish` is set), so the branch image validation gets the same workspace handoff as the release job.

Both default off, so every other repo renders **byte-identical** config (existing golden/table tests unchanged).

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` (new `Test_ImageDockerfile`; `Test_ImagePreBuildJob` tightened to assert the branch job now also `requires` the pre-build job)
- [x] Manual render of the `backstage` shape (`--image-dockerfile packages/backend/Dockerfile --image-pre-build-job buildjob --app-catalog giantswarm-operations-platform-catalog`) produces gated `execute-chart-tests-release` (`requires: push-to-registries-release`) and a `dockerfile`-pathed, `buildjob`-gated image pipeline
- [x] All other repos render unchanged (knobs default off)

Made with [Cursor](https://cursor.com)