### PR TITLE
fix(gen): scope auto-release bump baseline to current branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `gen workflows`: the auto-release `cliff.toml` now scopes `git-cliff --bump`'s
+  baseline to the current branch (`use_branch_tags = true`) and ignores
+  pre-release tags (`ignore_tags`). Previously `--bump` picked the globally
+  highest-semver tag in the repo regardless of reachability, which (a) broke
+  backports — a fix on `release-2.x` would bump from the latest `main` tag and
+  tag e.g. `v3.1.1` on the 2.x line instead of `v2.8.1` — and (b) let a stray
+  pre-release tag on an unmerged side branch (e.g. `v1.2.9-dev.0`) become the
+  baseline for `main`, so a real `feat:` produced `v1.2.9-dev.1` instead of
+  `v1.3.0`. Also corrects the misleading `topo_order` comment (it governs
+  changelog section order, not the bump baseline).
+
 ## [8.20.0] - 2026-06-17
 
 ### Added

--- a/pkg/gen/input/workflows/internal/file/cliff.toml.template
+++ b/pkg/gen/input/workflows/internal/file/cliff.toml.template
@@ -27,9 +27,9 @@ conventional_commits = true
 # unclassified work -- the bump-decider should only act on intent-bearing
 # commits.
 filter_unconventional = true
-# `topo_order` only governs the ORDER of sections in the rendered changelog,
-# NOT which tag `--bump` treats as the baseline. Left false (version-ordered
-# output).
+# Changelog presentation order. `topo_order = false` orders releases
+# chronologically (by tag date); `sort_commits = "oldest"` lists the commits
+# within each release oldest-first.
 topo_order = false
 sort_commits = "oldest"
 

--- a/pkg/gen/input/workflows/internal/file/cliff.toml.template
+++ b/pkg/gen/input/workflows/internal/file/cliff.toml.template
@@ -27,10 +27,38 @@ conventional_commits = true
 # unclassified work -- the bump-decider should only act on intent-bearing
 # commits.
 filter_unconventional = true
-# Highest-version tag (not creation date) is the baseline when computing what
-# changed since last release.
+# `topo_order` only governs the ORDER of sections in the rendered changelog,
+# NOT which tag `--bump` treats as the baseline. Left false (version-ordered
+# output).
 topo_order = false
 sort_commits = "oldest"
+
+# Scope `--bump`'s baseline to the current branch. This is load-bearing for
+# two reasons:
+#
+#   1. Backports. The auto-release workflow also fires on `release-*`
+#      maintenance branches. Without this, git-cliff's `--bump` picks the
+#      GLOBALLY highest-semver tag in the repo regardless of reachability --
+#      so a fix on `release-2.x` would bump from v3.1.0 (latest on main) and
+#      tag v3.1.1 ON the 2.x line instead of the intended v2.8.1. With
+#      `use_branch_tags`, git-cliff only considers tags reachable from the
+#      checked-out branch, so the 2.x line correctly bumps from v2.8.0.
+#
+#   2. Stray tags on side branches. A pre-release/preview tag created on an
+#      unmerged branch (e.g. someone tags v1.2.9-dev.0 on a `bump/*` branch)
+#      is the global semver max but is NOT reachable from main. Without this,
+#      it silently becomes the baseline for every subsequent main release and,
+#      because bumping a pre-release only increments the pre-release counter,
+#      a real `feat:` on main produces v1.2.9-dev.1 instead of v1.3.0.
+#      Branch-scoped tags exclude it.
+use_branch_tags = true
+
+# Belt-and-suspenders for the pre-release case above: drop `-dev`/`-rc`/etc.
+# tags from `--bump`'s consideration entirely. `use_branch_tags` only excludes
+# a stray pre-release tag when it lives on a SIDE branch; if one is ever
+# created directly on a release branch it would be reachable, and only this
+# filter keeps it from poisoning the version line.
+ignore_tags = '.*-(dev|rc|alpha|beta)\..*'
 
 # Strip the trailing " (#N)" that GitHub appends to squash-merge commit
 # messages. Our template renders the PR link explicitly via cliff's GitHub


### PR DESCRIPTION
## What

Fix the auto-release `cliff.toml` template so `git-cliff --bump` computes the next version from a **branch-scoped** baseline instead of the globally highest-semver tag in the repo.

```toml
[git]
use_branch_tags = true                       # only consider tags reachable from the current branch
ignore_tags     = '.*-(dev|rc|alpha|beta)\..*'  # drop pre-release tags from --bump consideration
```

(Also corrects the misleading `topo_order` comment — it governs changelog section order, not the bump baseline.)

## Why

`git-cliff --bump` picks the **globally highest-semver tag** as its baseline, ignoring reachability. That breaks two real scenarios for the push-based auto-release flow:

1. **Backports.** The workflow also fires on `release-*` maintenance branches. Without branch scoping, a `fix:` on `release-2.x` bumps from the latest `main` tag (e.g. `v3.1.0` → `v3.1.1`) and tags it on the 2.x line, instead of the intended `v2.8.1`. The workflow's `git describe` skip-guard is reachable-aware, but the git-cliff version computation was not — so the two disagreed and backports were effectively broken as written.

2. **Stray pre-release tags.** A `-dev`/`-rc` tag created on an unmerged side branch becomes the global semver max and silently becomes the baseline for `main`. Because bumping a pre-release only increments the pre-release counter, a real `feat:` on `main` produces `vX.Y.Z-dev.N` instead of `vX.Y+1.0`. This actually happened in `agentic-platform`: a manual `v1.2.9-dev.0` tag on a `bump/*` branch caused a `feat:` merge to release `v1.2.9-dev.2` instead of `v1.3.0`.

## Evidence (reproduced with git-cliff 2.13.1)

Built a throwaway repo with two major families (`v2.8.0`, `v3.0.0`, `v3.1.0`), a `release-2.x` backport branch, and an unreachable `…-dev.0` tag on a side branch:

| Scenario | before (`topo_order` false **or** true) | after (`use_branch_tags`) | wanted |
|---|---|---|---|
| `fix:` on `release-2.x` | `v3.1.1` ❌ | `v2.8.1` ✅ | `v2.8.1` |
| `feat:` on `main` + stray `-dev` tag | `v3.1.1-dev.1` ❌ | `v3.2.0` ✅ | `v3.2.0` |

Notably `topo_order` (true vs false) made **no difference** to the baseline in either case — it only orders changelog output — so it was the wrong lever; `use_branch_tags` is the correct one.

`ignore_tags` is belt-and-suspenders: `use_branch_tags` only excludes a stray pre-release tag when it lives on a *side* branch; one created directly on a release branch would be reachable, and only `ignore_tags` keeps it from poisoning the line.

## Notes

- The two levers are complementary, not redundant (see above).
- `cliff.toml.template.sha` is gitignored / regenerated at build time — no change needed.
- `go build ./pkg/gen/input/workflows/...` passes.

## Test plan

- [x] git-cliff repro table above
- [x] rendered config is valid TOML (single-quoted literal regex, matching the existing `commit_preprocessors` convention)
- [x] package builds
- [ ] regenerate a consuming repo with `devctl gen workflows` and confirm the rendered `cliff.toml`
