### PR TITLE
chore(deps): update dependency giantswarm/architect to v9.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: bumped the pinned `giantswarm/architect` orb from `9.4.3` to `9.5.1`. v9.5.1 makes the
+  cosign SBOM attestation degrade gracefully when its transparency-log upload fails persistently (a
+  multi-MB SPDX predicate — e.g. the `vllm` CUDA image — overruns the public Rekor gateway and returns
+  `502`): the orb re-attests with `--tlog-upload=false` so the signed SBOM stays attached as an OCI
+  referrer (without a public Rekor entry) instead of failing the whole release. Image signing stays
+  strict and the normal sub-limit path keeps its Rekor entry. Reaches repos via the next align-files run.
+
 ## [8.20.3] - 2026-06-20
 
 ### Changed

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -20,7 +20,7 @@ import (
 // and only then reaches repos via the align-files devctl pin.
 //
 // renovate: datasource=orb depName=giantswarm/architect
-const OrbVersion = "9.4.3"
+const OrbVersion = "9.5.1"
 
 // ContinuationOrbVersion pins the circleci/continuation orb used by the
 // generated setup config (.circleci/config.yml) to merge the optional

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.4.3
+  architect: giantswarm/architect@9.5.1
 
 workflows:
   build:

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.4.3
+  architect: giantswarm/architect@9.5.1
 
 workflows:
   build:


### PR DESCRIPTION
## Problem

`gen circleci` pins `giantswarm/architect@9.4.3`. On that orb, a very large SBOM predicate (e.g. the `vllm` CUDA image) fails the cosign SBOM-attestation step of `push-to-registries-release`: the multi-MB SPDX envelope overruns the public Rekor gateway (`502`), aborting the publish even though the image + chart already pushed. Reproduced on vllm `v0.4.0`/`v0.4.1`.

## Proposed solution

Bump the pinned orb to **v9.5.1** ([architect-orb#848](https://github.com/giantswarm/architect-orb/pull/848)), which makes the SBOM attestation degrade gracefully: when the transparency-log upload fails persistently, it re-attests with `--tlog-upload=false` so the signed SBOM stays attached as an OCI referrer (no public Rekor entry) and the release completes. Image signing stays strict; the normal sub-limit path keeps its Rekor entry.

Golden testdata updated to the new pin. Reaches repos via the next align-files run.

## Acceptance criteria

- [x] `OrbVersion` is `9.5.1`; golden `workflows.yml` fixtures updated; `go test ./pkg/gen/input/circleci/...` passes.
- [ ] After release + align-files, generated repo configs pin `giantswarm/architect@9.5.1`.

Made with [Cursor](https://cursor.com)