### PR TITLE
chore(deps): bump architect orb pin to 9.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: bumped the pinned `giantswarm/architect` orb from `9.5.1` to `9.5.2`. v9.5.1's oversized-SBOM
+  fallback used `cosign attest --tlog-upload=false`, which cosign v3 rejects (`--tlog-upload=false is not
+  supported with --signing-config`), so large-SBOM releases (e.g. `vllm`) still failed at the attest step.
+  v9.5.2 opts out of the transparency log the cosign-v3 way: it re-attests through a signing config with Rekor
+  removed but the TSA kept (`--signing-config <file> --new-bundle-format`), so the SBOM attestation keeps a
+  trusted timestamp (no Rekor body-size limit) and stays attached as an OCI referrer. Reaches repos via the
+  next align-files run.
+
 ## [8.20.4] - 2026-06-21
 
 ### Changed

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -20,7 +20,7 @@ import (
 // and only then reaches repos via the align-files devctl pin.
 //
 // renovate: datasource=orb depName=giantswarm/architect
-const OrbVersion = "9.5.1"
+const OrbVersion = "9.5.2"
 
 // ContinuationOrbVersion pins the circleci/continuation orb used by the
 // generated setup config (.circleci/config.yml) to merge the optional

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.1
+  architect: giantswarm/architect@9.5.2
 
 workflows:
   build:

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.1
+  architect: giantswarm/architect@9.5.2
 
 workflows:
   build:


### PR DESCRIPTION
## Summary

Bumps the `giantswarm/architect` orb pinned by `gen circleci` from `9.5.1` to `9.5.2`.

v9.5.1's oversized-SBOM cosign fallback used `cosign attest --tlog-upload=false`, but cosign v3 rejects that flag when a signing config is in use, so large-SBOM releases (e.g. `vllm`) still failed at the attest step. v9.5.2 opts out of the transparency log the cosign-v3 way — re-attesting through a signing config with Rekor removed (TSA kept) via `--signing-config <file> --new-bundle-format` — so the SBOM attestation keeps a trusted timestamp and stays attached as an OCI referrer.

Generated golden testdata regenerated; `go test ./pkg/gen/input/circleci/...` passes.

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...`
- [ ] CI green

Made with [Cursor](https://cursor.com)