### PR TITLE
fix(release create): stop fetching Flatcar releases JSON for changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `release create`: stop fetching the Flatcar releases JSON manifest during release-notes generation. The
+  manifest was downloaded and then discarded for Flatcar, and the request had no timeout, so a slow
+  `flatcar.org` would hang `devctl` even when the Flatcar version was pinned via `--component flatcar@<version>`.
+
+### Changed
+
+- `release create`: the changelog HTTP fetch now uses a 30s timeout instead of relying on the default client.
+- `release create`: the Flatcar releases JSON URL and channel are now configurable via the `FLATCAR_RELEASES_URL`
+  and `FLATCAR_CHANNEL` environment variables (defaulting to the stable channel).
+
 ## [8.20.5] - 2026-06-21
 
 ### Changed

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,6 +11,8 @@ import (
 var (
 	ConfigDir                = configDir{}
 	DevctlUnsafeForceVersion = devctlUnsafeForceVersion{}
+	FlatcarChannel           = flatcarChannel{}
+	FlatcarReleasesURL       = flatcarReleasesURL{}
 	GitHubToken              = gitHubToken{}
 )
 
@@ -33,6 +36,33 @@ type devctlUnsafeForceVersion struct{}
 
 func (devctlUnsafeForceVersion) Key() string { return "DEVCTL_UNSAFE_FORCE_VERSION" } // nolint:gosec
 func (devctlUnsafeForceVersion) Val() string { return os.Getenv(devctlUnsafeForceVersion{}.Key()) }
+
+type flatcarChannel struct{}
+
+func (flatcarChannel) Key() string { return "FLATCAR_CHANNEL" }
+
+// Val returns the Flatcar release channel to fetch versions from. Defaults to "stable".
+func (flatcarChannel) Val() string {
+	if c := os.Getenv(flatcarChannel{}.Key()); c != "" {
+		return c
+	}
+
+	return "stable"
+}
+
+type flatcarReleasesURL struct{}
+
+func (flatcarReleasesURL) Key() string { return "FLATCAR_RELEASES_URL" }
+
+// Val returns the URL of the Flatcar releases JSON manifest. If FLATCAR_RELEASES_URL
+// is not set, it is derived from the configured channel.
+func (flatcarReleasesURL) Val() string {
+	if u := os.Getenv(flatcarReleasesURL{}.Key()); u != "" {
+		return u
+	}
+
+	return fmt.Sprintf("https://www.flatcar.org/releases-json/releases-%s.json", FlatcarChannel.Val())
+}
 
 type gitHubToken struct{}
 

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -961,7 +961,8 @@ func autoDetectVersion(releaseName, componentName string) (string, error) {
 }
 
 func getLatestFlatcarRelease() (string, error) {
-	url := "https://www.flatcar.org/releases-json/releases-stable.json"
+	url := env.FlatcarReleasesURL.Val()
+	channel := env.FlatcarChannel.Val()
 
 	var myClient = &http.Client{Timeout: 10 * time.Second}
 
@@ -989,7 +990,7 @@ func getLatestFlatcarRelease() (string, error) {
 
 	var latest semver.Version
 	for name, rel := range target {
-		if rel.Channel == "stable" {
+		if rel.Channel == channel {
 			ver, err := semver.ParseTolerant(name)
 			if err != nil {
 				continue

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/giantswarm/microerror"
@@ -401,8 +402,9 @@ var KnownComponents = map[string]ParseParams{
 
 	// Core Components
 	"flatcar": {
-		Tag:       "https://www.flatcar.org/releases/#release-{{.Version}}",
-		Changelog: "https://www.flatcar.org/releases-json/releases-stable.json",
+		// Flatcar has no parseable changelog: the release notes only link to
+		// the Flatcar release page (Tag), so no Changelog URL is fetched.
+		Tag: "https://www.flatcar.org/releases/#release-{{.Version}}",
 	},
 	"kubernetes": {
 		Tag:          "https://github.com/kubernetes/kubernetes/releases/tag/v{{.Version}}",
@@ -465,6 +467,17 @@ func ParseChangelog(componentName, currentVersion, endVersion string, extraFilte
 		return nil, microerror.Mask(fmt.Errorf("unknown component: %s", componentName))
 	}
 
+	if componentName == "flatcar" {
+		// Flatcar's "changelog" is a large JSON manifest we don't parse. Skip
+		// fetching it entirely and just return a link to the release notes.
+		// This avoids a wasted (and frequently slow/timing-out) network request.
+		return &Version{
+			Name:    currentVersion,
+			Link:    strings.Replace(params.Tag, "{{.Version}}", currentVersion, 1),
+			Content: "",
+		}, nil
+	}
+
 	templateData := &versionTemplateData{}
 	templateData.Version = currentVersion
 
@@ -487,7 +500,8 @@ func ParseChangelog(componentName, currentVersion, endVersion string, extraFilte
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	response, err := http.Get(changelogURLBuilder.String())
+	client := &http.Client{Timeout: 30 * time.Second}
+	response, err := client.Get(changelogURLBuilder.String())
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -496,15 +510,6 @@ func ParseChangelog(componentName, currentVersion, endVersion string, extraFilte
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, microerror.Mask(err)
-	}
-
-	if componentName == "flatcar" {
-		// Skip parsing Flatcar
-		return &Version{
-			Name:    currentVersion,
-			Link:    strings.Replace(params.Tag, "{{.Version}}", currentVersion, 1),
-			Content: "",
-		}, nil
 	}
 
 	if componentName == "kubernetes" {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35421

`devctl release create` could hang on a slow `flatcar.org`, even when the Flatcar version was pinned via `--component flatcar@<version>`.

Root cause: during release-notes generation, `ParseChangelog` downloaded the Flatcar `releases-stable.json` manifest and then discarded it (release notes only link to the Flatcar release page, they don't embed its changelog). The request also had no timeout, so a slow response hung the whole command.

Changes:
- Skip the Flatcar changelog fetch entirely and drop the now-dead `Changelog` URL from the Flatcar component.
- Add a 30s timeout to the remaining changelog HTTP fetch.
- Make the Flatcar releases URL and channel configurable via `FLATCAR_RELEASES_URL` and `FLATCAR_CHANNEL` (defaults to the stable channel). This only affects the latest-version lookup used by an unpinned `--bumpall`; pinning a version skips it.
