### PR TITLE
feat(gen): parallel six-arch build at large resource_class for cli repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: for `cli`-flavour Go repos (the six-arch cross-compile that attaches binaries to the
+  GitHub Release), the generated `go-build` job now sets `build_concurrency: auto` and
+  `resource_class: large`. The GOCACHE persistence from architect-orb #838 (orb v9.5.0+) makes warm
+  builds fast, but the cross-compile is still cold after every `go.sum` bump; compiling the six
+  architectures concurrently on a larger box instead of sequentially on 2 vCPUs removes the remaining
+  critical-path cost. Service (non-cli) repos are unchanged. No signing or nancy changes. Reaches repos
+  via the next align-files run.
+
 ## [8.21.0] - 2026-06-22
 
 ### Fixed

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -349,6 +349,38 @@ func Test_GoldenCLIWorkflows(t *testing.T) {
 	}
 }
 
+// Test_CLIParallelBuild verifies the cli flavour (six-arch cross-compile)
+// gets the orb's build_concurrency + a larger resource_class so the cold
+// post-go.sum-bump build parallelises, and that a non-cli Go service does not
+// pay for the larger box (the knobs live in the ReleaseBinaries block).
+func Test_CLIParallelBuild(t *testing.T) {
+	cli := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp, gen.FlavourCLI},
+		HasDockerfile: true,
+	})
+	if !contains(cli, "build_concurrency: auto") {
+		t.Errorf("cli flavour missing build_concurrency: auto:\n%s", cli)
+	}
+	if !contains(cli, "resource_class: large") {
+		t.Errorf("cli flavour missing resource_class: large:\n%s", cli)
+	}
+
+	svc := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	})
+	if contains(svc, "build_concurrency") {
+		t.Errorf("non-cli service should not set build_concurrency:\n%s", svc)
+	}
+	if contains(svc, "resource_class") {
+		t.Errorf("non-cli service should not set resource_class:\n%s", svc)
+	}
+}
+
 // Test_AppCatalogOverride verifies the chart pipeline publishes to the
 // overridden catalog when set, and falls back to the public defaults when not.
 // Repos on the internal giantswarm-operations-platform catalog rely on this so

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -21,6 +21,12 @@ workflows:
         # line-length rule for the 132-char matrix value.
         # yamllint disable-line rule:line-length
         architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+        # The six-arch cross-compile is cold after every go.sum bump (the GOCACHE
+        # restore misses), so compile the architectures concurrently on a larger
+        # box instead of sequentially on 2 vCPUs. build_concurrency is opt-in in
+        # the orb because it only pays off at a bigger resource_class.
+        build_concurrency: auto
+        resource_class: large
 {{- end }}
         filters:
           tags:

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -19,6 +19,12 @@ workflows:
         # line-length rule for the 132-char matrix value.
         # yamllint disable-line rule:line-length
         architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+        # The six-arch cross-compile is cold after every go.sum bump (the GOCACHE
+        # restore misses), so compile the architectures concurrently on a larger
+        # box instead of sequentially on 2 vCPUs. build_concurrency is opt-in in
+        # the orb because it only pays off at a bigger resource_class.
+        build_concurrency: auto
+        resource_class: large
         filters:
           tags:
             only: /^v.*/


### PR DESCRIPTION
## Problem

The generated `architect/go-build` job is the critical-path CI gate on every `ci.generate: true` Go repo. architect-orb #838 (orb v9.5.0+, already the pinned `OrbVersion: 9.5.2`) persists `$GOCACHE` so warm builds are fast (measured 5.1x on muster), but the `cli`-flavour six-arch cross-compile is still **cold after every `go.sum` bump** and runs sequentially on 2 vCPUs.

## Proposed solution

For `cli`-flavour Go repos (the `{{- if .ReleaseBinaries }}` six-arch matrix block), the generated `go-build` job now sets the orb's `build_concurrency: auto` and `resource_class: large`, so the cold cross-compile parallelises across cores instead of running sequentially. `build_concurrency` is opt-in in the orb precisely because it only pays off at a larger `resource_class`.

- `OrbVersion` already points at `9.5.2` (contains #838 from v9.5.0) — no bump needed.
- Service (non-cli) repos are unchanged.
- No signing or nancy parameter changes.
- Golden testdata (`mcp-kubernetes.cli.workflows.yml`) regenerated; new `Test_CLIParallelBuild` asserts the knobs are cli-only.

## Acceptance criteria

- [x] `OrbVersion` points at the architect-orb release containing #838 (9.5.2).
- [x] Generated `workflows.yml` for a cli-flavour repo sets `build_concurrency` + `resource_class: large` on `go-build`.
- [x] No signing or nancy parameter changes in the generated config.
- [x] Golden testdata regenerated; `circleci_test.go` passes.
- [ ] A devctl release is cut so the new pin can flow into giantswarm/github align-files.

Implements #2017; part of giantswarm/giantswarm#36941.

Made with [Cursor](https://cursor.com)