### PR TITLE
feat: make-target CI command interface (test_target)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `gen circleci` / `gen makefile`: the make-target CI command interface. The generated `go-build` job now
+  sets `test_target: test`, so the architect orb runs `make test` instead of its hardcoded
+  `go test ./...`; CI and local agent runs converge on one command. The generic `gen makefile` `test`
+  target is now plain `go test ./...` (previously `go test -ldflags … -race ./...`). `-race` becomes a
+  per-repo decision: repos with real concurrency override their own `make test` (`go test -race ./...`),
+  as do repos that need integration suites, `govulncheck`, `helm-unittest`, or CRD-freshness checks.
+  This is the relocation target for the hand-written `ci.yaml` removal and is the configurable-default /
+  make-target interface resolved in the make-target-ci-interface ADR (no architect-orb change required —
+  the orb already exposes `test_target`). Reaches repos via the next align-files run.
 - `gen circleci`: for `cli`-flavour Go repos (the six-arch cross-compile that attaches binaries to the
   GitHub Release), the generated `go-build` job now sets `build_concurrency: auto` and
   `resource_class: large`. The GOCACHE persistence from architect-orb #838 (orb v9.5.0+) makes warm

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -670,6 +670,34 @@ func Test_OrbVersion(t *testing.T) {
 	}
 }
 
+// Test_GoBuildTestTarget verifies the go-build job routes unit tests through
+// the `make test` target (architect test_target) so CI and local agent runs
+// share one command. The generic Makefile target is `go test ./...`; per-repo
+// Makefiles override it for -race, integration suites, etc. (make-target CI
+// interface). A repo with no Go build emits no go-build job and thus no
+// test_target.
+func Test_GoBuildTestTarget(t *testing.T) {
+	got := render(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	})
+	if !contains(got, "test_target: test") {
+		t.Errorf("go-build job missing test_target: test:\n%s", got)
+	}
+
+	chartOnly := render(t, Config{
+		RepoName:      repoSitesearch,
+		Language:      gen.Language(""),
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: false,
+	})
+	if contains(chartOnly, "test_target") {
+		t.Errorf("non-go config should not emit test_target:\n%s", chartOnly)
+	}
+}
+
 // Test_ImageOnlyOmitsChart verifies derivation: an image repo without the app
 // flavour gets the image pipeline but no chart jobs.
 func Test_ImageOnlyOmitsChart(t *testing.T) {

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -15,6 +15,13 @@ workflows:
         name: go-build
         binary: {{ .RepoName }}
         context: architect
+        # Run unit tests through `make test` rather than the orb's hardcoded
+        # `go test ./...`, so CI and local agent runs use the same command.
+        # The generic Makefile target is `go test ./...`; repos that need more
+        # (-race, integration suites, govulncheck, helm-unittest, CRD-freshness)
+        # override their own `make test`. See devctl makefile gen and the
+        # make-target-ci-interface ADR.
+        test_target: test
 {{- if .ReleaseBinaries }}
         # Cross-platform binaries attached to the GitHub Release by the
         # upload-release-assets job below (cli flavour). yamllint disables the

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -14,6 +14,13 @@ workflows:
         name: go-build
         binary: mcp-kubernetes
         context: architect
+        # Run unit tests through `make test` rather than the orb's hardcoded
+        # `go test ./...`, so CI and local agent runs use the same command.
+        # The generic Makefile target is `go test ./...`; repos that need more
+        # (-race, integration suites, govulncheck, helm-unittest, CRD-freshness)
+        # override their own `make test`. See devctl makefile gen and the
+        # make-target-ci-interface ADR.
+        test_target: test
         # Cross-platform binaries attached to the GitHub Release by the
         # upload-release-assets job below (cli flavour). yamllint disables the
         # line-length rule for the 132-char matrix value.

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
@@ -14,6 +14,13 @@ workflows:
         name: go-build
         binary: mcp-kubernetes
         context: architect
+        # Run unit tests through `make test` rather than the orb's hardcoded
+        # `go test ./...`, so CI and local agent runs use the same command.
+        # The generic Makefile target is `go test ./...`; repos that need more
+        # (-race, integration suites, govulncheck, helm-unittest, CRD-freshness)
+        # override their own `make test`. See devctl makefile gen and the
+        # make-target-ci-interface ADR.
+        test_target: test
         filters:
           tags:
             only: /^v.*/

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -165,9 +165,9 @@ nancy: ## Runs nancy (requires v1.0.37 or newer).
 	CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
 .PHONY: test
-test: ## Runs go test with default values.
+test: ## Runs go test. This is the CI test command (architect test_target).
 	@echo "====> $@"
-	go test -ldflags "$(LDFLAGS)" -race ./...
+	go test ./...
 
 .PHONY: build-docker
 build-docker: build-linux ## Builds docker image to registry.


### PR DESCRIPTION
## Summary

Implements the make-target CI command interface (#36734), the prereq that unblocks the hand-written `ci.yaml` removal workstream (epic #36729). No architect-orb change — the orb already exposes `test_target`.

- **`gen circleci`**: the generated `go-build` job now sets `test_target: test`, so the architect orb runs `make test` instead of its hardcoded `go test ./...`. CI and local agent runs converge on one command.
- **`gen makefile`**: the generic `test` target becomes plain `go test ./...` (was `go test -ldflags … -race ./...`). `-race` is now a **per-repo** decision — repos with real concurrency (e.g. `klaus-oci`) override their own `make test` (`go test -race ./...`), as do repos that need integration suites, `govulncheck`, `helm-unittest`, or CRD-freshness checks.

Both surface to repos automatically on the next align-files run (`giantswarm/github` already invokes `devctl gen makefile` and `devctl gen circleci`).

This is the configurable-default / make-target interface decided in the make-target-ci-interface ADR (Jose's make-target + Marian's configurable-default proposals collapse into one: the generic Makefile is the default, the per-repo Makefile is the override).

## Changes

- `pkg/gen/input/circleci/internal/file/workflows.yml.template`: add `test_target: test` to the go-build job.
- `pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template`: generic `test` target → `go test ./...`.
- Golden testdata (`mcp-kubernetes.workflows.yml`, `mcp-kubernetes.cli.workflows.yml`) updated.
- `Test_GoBuildTestTarget`: asserts the go-build job emits `test_target: test` and that non-Go configs emit none.

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` green (golden + new test)
- [x] `go build ./...` and full `go test ./...` green
- [ ] After release + align-files: verify a generated repo's `workflows.yml` carries `test_target: test` and `make test` runs `go test ./...`

Made with [Cursor](https://cursor.com)