### PR TITLE
fix: keep -race in generated make test target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- `gen circleci` / `gen makefile`: the make-target CI command interface. The generated `go-build` job now
-  sets `test_target: test`, so the architect orb runs `make test` instead of its hardcoded
-  `go test ./...`; CI and local agent runs converge on one command. The generic `gen makefile` `test`
-  target is now plain `go test ./...` (previously `go test -ldflags … -race ./...`). `-race` becomes a
-  per-repo decision: repos with real concurrency override their own `make test` (`go test -race ./...`),
-  as do repos that need integration suites, `govulncheck`, `helm-unittest`, or CRD-freshness checks.
-  This is the relocation target for the hand-written `ci.yaml` removal and is the configurable-default /
-  make-target interface resolved in the make-target-ci-interface ADR (no architect-orb change required —
-  the orb already exposes `test_target`). Reaches repos via the next align-files run.
+- `gen circleci`: the make-target CI command interface. The generated `go-build` job now sets
+  `test_target: test`, so the architect orb runs the repo's `make test` instead of its hardcoded
+  `go test … ./...`; CI and local runs converge on one command. The generated `make test`
+  (`gen makefile`) is unchanged (`go test -ldflags … -race ./...`), so CI runs the same test command
+  developers already run locally. A repo that wants a different CI test command (e.g. drop `-race`, add
+  an integration suite, `govulncheck`, `helm-unittest`, or a CRD-freshness check) overrides its own
+  `make test`. This is the relocation target for the hand-written `ci.yaml` removal and the make-target
+  interface from the make-target-ci-interface ADR (no architect-orb change — the orb already exposes
+  `test_target`). Reaches repos via the next align-files run.
 - `gen circleci`: for `cli`-flavour Go repos (the six-arch cross-compile that attaches binaries to the
   GitHub Release), the generated `go-build` job now sets `build_concurrency: auto` and
   `resource_class: large`. The GOCACHE persistence from architect-orb #838 (orb v9.5.0+) makes warm

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -165,9 +165,9 @@ nancy: ## Runs nancy (requires v1.0.37 or newer).
 	CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
 .PHONY: test
-test: ## Runs go test. This is the CI test command (architect test_target).
+test: ## Runs go test with default values.
 	@echo "====> $@"
-	go test ./...
+	go test -ldflags "$(LDFLAGS)" -race ./...
 
 .PHONY: build-docker
 build-docker: build-linux ## Builds docker image to registry.


### PR DESCRIPTION
## Summary

Follow-up to #2034. That PR changed the shared `gen makefile` `test` target to plain `go test ./...`, which — on the next align-files run — would have silently stripped `-race` from `make test` for **every repo** using the standard generated makefile (local dev and any CI that calls `make test`). That is a fleet-wide downgrade of a shared default and was not the intent.

This restores the original target:

```make
test: ## Runs go test with default values.
	go test -ldflags "$(LDFLAGS)" -race ./...
```

The `gen circleci` `test_target: test` addition from #2034 **stays**. Net effect of the combined change: CI now runs each repo's real `make test` (the same command developers run locally, `-race` included) instead of the orb's hardcoded `go test ./...`. A repo that wants a different CI test command (drop `-race`, add an integration suite, `govulncheck`, `helm-unittest`, CRD-freshness) overrides its own `make test` — i.e. `-race` is opt-*out*, not silently removed for everyone.

Nothing from #2034 has reached repos yet (align-files pins devctl `8.21.1`; #2034 is unreleased), so this is a clean fix-forward.

## Test plan

- [x] `go test ./pkg/gen/input/circleci/...` green (test_target golden + test unchanged)
- [x] Diff scoped to CHANGELOG + `Makefile.gen.go.mk.template` only

Made with [Cursor](https://cursor.com)