### PR TITLE
feat: cgo-adaptive make test target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen makefile`: the generated `make test` target is now cgo-adaptive. It runs `go test … -race ./...`
+  wherever a C toolchain is available (laptops, coding agents, GitHub Actions, any cgo-capable runner)
+  and degrades to cgo-free `go test … ./...` where it is not. This unblocks the make-target CI interface
+  (8.22.0's `test_target: test`): the architect `go-build`/`go-test` image has no C compiler and runs
+  with `CGO_ENABLED=0`, so a hardcoded `-race` made `make test` fail with `-race requires cgo` on every
+  generated-CircleCI Go repo. The single `make test` command is now correct in every environment — CI
+  runs it verbatim and local runs keep race detection — so it stays the one relocation target for the
+  hand-written `ci.yaml` removal workstream.
+
 ## [8.22.0] - 2026-06-24
 
 ### Changed

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -161,10 +161,15 @@ nancy: ## Runs nancy (requires v1.0.37 or newer).
 	@echo "====> $@"
 	CGO_ENABLED=0 go list -json -deps ./... | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
+# Race detector needs a C toolchain. The architect CI image has none and runs
+# with CGO_ENABLED=0, so degrade to cgo-free there; everywhere a compiler exists
+# (laptops, coding agents, GitHub Actions, any cgo-capable runner) keeps -race.
+RACE := $(shell { [ "$${CGO_ENABLED:-1}" != "0" ] && { command -v gcc || command -v clang; } >/dev/null 2>&1; } && echo -race)
+
 .PHONY: test
-test: ## Runs go test with default values.
+test: ## Runs go test with default values (race detector when a C toolchain is available).
 	@echo "====> $@"
-	go test -ldflags "$(LDFLAGS)" -race ./...
+	go test -ldflags "$(LDFLAGS)" $(RACE) ./...
 
 .PHONY: build-docker
 build-docker: build-linux ## Builds docker image to registry.

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -164,10 +164,15 @@ nancy: ## Runs nancy (requires v1.0.37 or newer).
 	@echo "====> $@"
 	CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
+# Race detector needs a C toolchain. The architect CI image has none and runs
+# with CGO_ENABLED=0, so degrade to cgo-free there; everywhere a compiler exists
+# (laptops, coding agents, GitHub Actions, any cgo-capable runner) keeps -race.
+RACE := $(shell { [ "$${CGO_ENABLED:-1}" != "0" ] && { command -v gcc || command -v clang; } >/dev/null 2>&1; } && echo -race)
+
 .PHONY: test
-test: ## Runs go test with default values.
+test: ## Runs go test with default values (race detector when a C toolchain is available).
 	@echo "====> $@"
-	go test -ldflags "$(LDFLAGS)" -race ./...
+	go test -ldflags "$(LDFLAGS)" $(RACE) ./...
 
 .PHONY: build-docker
 build-docker: build-linux ## Builds docker image to registry.


### PR DESCRIPTION
## Summary

Follow-up to #2034/#2035 (devctl 8.22.0). `8.22.0` added `test_target: test` to the generated CircleCI `go-build` job, pointing CI at each repo's `make test`. But the architect `go-build`/`go-test` image **has no C compiler** and runs with `CGO_ENABLED=0`, so the hardcoded `go test -race` failed fleet-wide:

```
go test -ldflags "…" -race ./...
go: -race requires cgo; enable cgo by setting CGO_ENABLED=1
make: *** [Makefile.gen.go.mk:121: test] Error 2
```

(18/18 active CircleCI Go repos in team-bumblebee went red on `go-build`.)

This makes the generated `make test` **cgo-adaptive**:

```make
RACE := $(shell { [ "$${CGO_ENABLED:-1}" != "0" ] && { command -v gcc || command -v clang; } >/dev/null 2>&1; } && echo -race)
test:
	go test -ldflags "$(LDFLAGS)" $(RACE) ./...
```

- Runs `-race` wherever a C toolchain exists (laptops, coding agents, GitHub Actions, any cgo-capable runner).
- Degrades to cgo-free `go test … ./...` in the architect CI image (which physically cannot run `-race`).
- **One `make test` command, correct in every environment** — CI runs it verbatim, local keeps race detection. No second `test-ci` target, no orb change, no team loses local `-race`. Stays the single relocation target for the `ci.yaml`-removal workstream.

Verified the detection: `-race` when gcc/clang present and cgo not disabled; cgo-free under `CGO_ENABLED=0`.

## Test plan

- [x] `make -f` smoke test of the RACE detection across CGO_ENABLED unset/0/1
- [ ] After release: bump align-files pin, re-dispatch team-bumblebee, confirm go-build green

Made with [Cursor](https://cursor.com)