### PR TITLE
fix: make `make test` regenerate go:embed provenance before building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- devctl now dogfoods its own generated CircleCI + auto-release standard. The repo-owned
+  `Makefile.zzz.custom.mk` makes `make test` depend on `generate-go`, so the gitignored
+  `*.template.sha` provenance files (consumed via `//go:embed`) are regenerated before tests
+  and the cross-compile run. This lets the generated `go-build` job (`test_target: test`) build
+  devctl from a clean CI checkout and also fixes clean local `make test`.
 - `gen makefile`: the generated `make test` target is now cgo-adaptive. It runs `go test … -race ./...`
   wherever a C toolchain is available (laptops, coding agents, GitHub Actions, any cgo-capable runner)
   and degrades to cgo-free `go test … ./...` where it is not. This unblocks the make-target CI interface

--- a/Makefile.zzz.custom.mk
+++ b/Makefile.zzz.custom.mk
@@ -5,3 +5,9 @@ generate-go: # Generate template files needed to run
 $(SOURCES): generate-go
 
 install: generate-go
+
+# `go generate` writes gitignored *.template.sha provenance files that are pulled
+# in via //go:embed, so a clean checkout cannot compile (or run tests) until they
+# exist. Make `make test` regenerate them first — this is what lets the generated
+# CircleCI go-build (test_target: test) build devctl from a clean CI checkout.
+test: generate-go


### PR DESCRIPTION
## Problem

devctl's build runs `go generate ./...`, which writes gitignored `*.template.sha` provenance files pulled in via `//go:embed`. A clean checkout therefore cannot compile (or run tests) until `go generate` runs first. The hand-written `.circleci/config.yml` works around this with `pre_test_target: generate-go`, but the generated `go-build` job (`test_target: test`, no `pre_test_target`) would fail on a clean CI checkout.

## Proposed solution

Make the repo-owned `Makefile.zzz.custom.mk` add `generate-go` as a prerequisite of `test` (matching the existing `$(SOURCES): generate-go` / `install: generate-go` lines). The architect orb's `go-build` runs `test_target` before the binary compile, so `make test` regenerating the `.sha` embeds covers both the test and the cross-compile. Also fixes clean local `make test`.

This drains the current non-empty `## [Unreleased]` for devctl's final legacy release, before onboarding devctl onto generated CI + auto-release.

## Acceptance criteria

- `make test` runs `go generate` before `go test`.
- A clean checkout (no `*.template.sha`) builds and tests successfully.
- Final legacy release ships the drained Unreleased section.

Made with [Cursor](https://cursor.com)