### PR TITLE
fix(version): derive version from runtime/debug build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ devctl*
 bin-dist/
 TODO
 
+# Scratch files architect's go-build/go-test write into the worktree. Ignored so
+# an untracked artifact doesn't mark the build +dirty in the version embedded
+# via runtime/debug build info (pkg/project).
+.ldflags
+.platforms
+
 # OS & IDE
 .DS_Store
 .idea/

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,11 +1,32 @@
 package project
 
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// dev is the default for unset build identifiers. Local `go build`
+// invocations without ldflags keep this so `devctl version` stays printable.
+const dev = "dev"
+
+// devel is the module version runtime/debug reports for a build that carries
+// no resolvable VCS tag (no .git, or built outside a module checkout).
+const devel = "(devel)"
+
 var (
 	description = "Command line tool for the development daily business."
-	gitSHA      = "n/a"
-	name        = "devctl"
-	source      = "https://github.com/giantswarm/devctl"
-	version     = "8.23.0"
+	// gitSHA is injected at link time via `-X` ldflags by architect-orb's
+	// `go-build` job (from `CIRCLE_SHA1`). architect does NOT inject `version`;
+	// the version is instead derived at runtime from the Go build info (see
+	// Version), which the toolchain stamps from the VCS tag — a clean semver
+	// when the build sits exactly on a tag (as release builds do, since they
+	// run on the tagged commit). `version` is left as an escape hatch for an
+	// explicit `-X` override (the Makefile sets it from `gitsemver get`) but is
+	// normally unset for architect-built release binaries.
+	gitSHA  = "n/a"
+	name    = "devctl"
+	source  = "https://github.com/giantswarm/devctl"
+	version = dev
 )
 
 func Description() string {
@@ -24,6 +45,38 @@ func Source() string {
 	return source
 }
 
+// Version returns the best human-readable build identifier available, in
+// order: an explicitly injected `version` ldflag, the VCS version stamped into
+// the Go build info, the injected commit SHA, and finally the placeholder
+// "dev". The leading "v" is trimmed so the result is a bare semver that
+// `pkg/updater` (blang/semver.Parse) and the self-update version comparison can
+// consume.
 func Version() string {
-	return version
+	if version != dev && version != "" {
+		return version
+	}
+	if v := buildInfoVersion(); v != "" {
+		return v
+	}
+	if gitSHA != "n/a" {
+		return gitSHA
+	}
+	return dev
+}
+
+// buildInfoVersion reads the main module version the Go toolchain embedded from
+// version control, trimming the leading "v" so it parses as a bare semver. It
+// returns "" when no usable version is present — either no build info, or the
+// "(devel)" placeholder a tag-less build produces — so Version can fall through
+// to the next source.
+var buildInfoVersion = func() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	v := info.Main.Version
+	if v == "" || v == devel {
+		return ""
+	}
+	return strings.TrimPrefix(v, "v")
 }

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,0 +1,33 @@
+package project
+
+import "testing"
+
+func TestVersionFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		buildInfo string
+		gitSHA    string
+		want      string
+	}{
+		{"nothing available", dev, "", "n/a", dev},
+		{"explicit version ldflag wins", "8.23.1", "8.0.0", "abc1234", "8.23.1"},
+		{"build info supplies version", dev, "8.23.1", "abc1234", "8.23.1"},
+		{"build info absent; sha fallback", dev, "", "abc1234", "abc1234"},
+		{"build info beats sha", dev, "8.23.1", "abc1234", "8.23.1"},
+	}
+
+	origVersion, origSHA, origBuildInfo := version, gitSHA, buildInfoVersion
+	t.Cleanup(func() { version, gitSHA, buildInfoVersion = origVersion, origSHA, origBuildInfo })
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			version = tc.version
+			gitSHA = tc.gitSHA
+			buildInfoVersion = func() string { return tc.buildInfo }
+			if got := Version(); got != tc.want {
+				t.Errorf("Version() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

After onboarding devctl onto the push-based git-cliff auto-release flow ([#2030](https://github.com/giantswarm/devctl/pull/2030)), released binaries report the **wrong version**. architect's `go-build` injects `gitSHA`/`buildTimestamp` via `-X` ldflags but **never `version`**. The legacy CHANGELOG-driven flow compensated by rewriting the `version` literal in `pkg/project` on each release; git-cliff does not rewrite source, so the literal sat stale at `8.23.0` — and `v8.23.1` shipped a binary that reports `8.23.0`.

For devctl this is worse than a cosmetic version string: devctl checks for updates on every command and self-updates against the latest release. With a stale embedded version, `devctl version` / `devctl version check` compare `8.23.0` against the latest tag and **perpetually report "update available" — and re-apply the update even right after updating** (verified: a v8.22.1 binary self-updated to the v8.23.1 binary, which still reported `8.23.0` and still claimed a new version was available).

## Solution

Derive the version from the Go build info (`runtime/debug`), which the toolchain stamps from the VCS tag — the same fix Jose landed for muster ([muster#860](https://github.com/giantswarm/muster/pull/860)).

- **Release builds** run on the tagged commit (CircleCI checks out `CIRCLE_TAG`), so binaries report the **clean** tag version.
- **Off-tag builds** report an honest pseudo-version (`8.23.1-0.2026…-<sha>`).
- **Tag-less builds** fall back to the injected `gitSHA`, then `dev`.

`Version()` precedence: explicit `version` ldflag → build-info `Main.Version` → injected `gitSHA` → `dev`. The leading `v` is trimmed so the result stays a **bare semver** that `pkg/updater`'s `semver.Parse` (and thus self-update) consumes — devctl-specific vs muster, which keeps the `v`. `version` defaults back to `dev` and remains an `-X` escape hatch (the Makefile still sets it from `gitsemver`). `.ldflags`/`.platforms` (architect's worktree scratch files) are gitignored so an untracked artifact doesn't mark the build `+dirty`.

## Acceptance criteria

- A clean tag build embeds the bare tag version (e.g. `8.23.2`); `devctl version` reports it.
- After self-updating to the latest release, `devctl version check` reports "already using the latest version".
- `go test ./pkg/project/` passes (added `project_test.go` covering the fallback chain).

> Validated locally: build-info derivation works and the `v` is trimmed; end-to-end clean-tag confirmation comes on the first release after merge (same orb/mechanism muster#860 validated across all six arches).

Made with [Cursor](https://cursor.com)