### PR TITLE
fix(renovate): restore devctl custom rules via renovate-custom.json5

### DIFF
--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -19,7 +19,13 @@ import (
 // Renovate keeps this current; a major bump lands as a devctl PR, gets released,
 // and only then reaches repos via the align-files devctl pin.
 //
-// renovate: datasource=orb depName=giantswarm/architect
+// Tracked via github-tags on the architect-orb source repo rather than the
+// `orb` datasource: the generated renovate.json5 disables `orb` updates for
+// giantswarm/architect (so they stop fighting align-files in .circleci/config.yml),
+// and that root packageRule would otherwise also block this constant. The
+// custom manager that reads this annotation lives in renovate-custom.json5.
+//
+// renovate: datasource=github-tags depName=giantswarm/architect-orb
 const OrbVersion = "9.5.2"
 
 // ContinuationOrbVersion pins the circleci/continuation orb used by the

--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -1,0 +1,122 @@
+// Repo-specific Renovate rules for devctl, layered on top of the generated
+// renovate.json5 (which extends this file last). devctl never touches this
+// file. Rules for a whole class of repos belong in giantswarm/renovate-presets.
+//
+// devctl is special: it is the generator. Several upstream tool versions are
+// pinned inside the generator's own source (Go constants, golden fixtures, and
+// workflow templates) rather than in a manifest a built-in manager understands,
+// so the custom managers below keep them current. These were dropped from
+// renovate.json5 by the 2026-06-24 align-files run (#2030) and restored here.
+{
+  // Let the github-actions manager also scan the workflow templates devctl
+  // emits, so action versions baked into the templates get bumped too.
+  'github-actions': {
+    managerFilePatterns: [
+      '/.*.yaml.template$/',
+    ],
+  },
+  customManagers: [
+    // The orb versions baked into the `gen circleci` generator, pinned as Go
+    // constants next to the config template so a major orb bump forces a devctl
+    // release rather than silently skewing against a stale template. Renovate
+    // bumps them here, not in giantswarm/github.
+    //
+    // The giantswarm/architect entry is tracked via github-tags on the
+    // architect-orb source repo (not the `orb` datasource): the generated
+    // renovate.json5 disables `orb` updates for giantswarm/architect (so they
+    // stop fighting align-files in .circleci/config.yml), and that root rule
+    // would otherwise also block the constant. github-tags on architect-orb
+    // carries the same versions and is not matched by the disable rule.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pkg/gen/input/circleci/circleci\\.go$/'],
+      matchStrings: [
+        '// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*const \\w*OrbVersion = "(?<currentValue>[^"]+)"',
+      ],
+    },
+    // The golden fixtures pin the same orb versions the generator emits. Same
+    // depName/datasource as the constants above, so Renovate bumps constant and
+    // goldens in one PR and the byte-for-byte golden tests stay green -- without
+    // this, every orb bump needs a manual fixture regen.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pkg/gen/input/circleci/testdata/.*\\.workflows\\.yml$/'],
+      matchStrings: ['architect: giantswarm/architect@(?<currentValue>\\S+)'],
+      depNameTemplate: 'giantswarm/architect-orb',
+      datasourceTemplate: 'github-tags',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pkg/gen/input/circleci/testdata/setup\\.config\\.yml$/'],
+      matchStrings: ['continuation: circleci/continuation@(?<currentValue>\\S+)'],
+      depNameTemplate: 'circleci/continuation',
+      datasourceTemplate: 'orb',
+    },
+    // Pre-commit hook revisions in the pre-commit config template.
+    // The built-in pre-commit manager cannot parse this file because it contains
+    // Go template directives ({{- if ... }}) that make the YAML invalid.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pre-commit-config\\.yaml\\.template$/'],
+      matchStrings: [
+        '- repo: https://github\\.com/(?<depName>[^\\n]+)\\n\\s+rev: [\'"]?(?<currentValue>[^\'"\\n]+)',
+      ],
+      datasourceTemplate: 'github-tags',
+    },
+    // Helm CLI version pinned as an env var in the pre-commit GitHub Actions workflow template.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pre-commit-action\\.yaml\\.template$/'],
+      matchStrings: ['HELM_VERSION: "(?<currentValue>[^"]+)"'],
+      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-releases',
+    },
+    // helm-docs version pinned as an env var in the pre-commit GitHub Actions workflow template.
+    // Renovate will consolidate updates with the pre-commit hook rev for the same package.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pre-commit-action\\.yaml\\.template$/'],
+      matchStrings: ['HELM_DOCS_VERSION: "(?<currentValue>[^"]+)"'],
+      depNameTemplate: 'norwoodj/helm-docs',
+      datasourceTemplate: 'github-releases',
+    },
+    // helm-values-schema-json version pinned as an env var in the pre-commit GitHub Actions workflow template.
+    // Renovate will consolidate updates with the pre-commit hook rev for the same package.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pre-commit-action\\.yaml\\.template$/'],
+      matchStrings: ['HELM_VALUES_SCHEMA_JSON_VERSION: "(?<currentValue>[^"]+)"'],
+      depNameTemplate: 'losisin/helm-values-schema-json',
+      datasourceTemplate: 'github-releases',
+    },
+    // golangci-lint version used in install-binary-action. The two-line match avoids
+    // false-positives with other `version:` fields in the same file.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pre-commit-action\\.yaml\\.template$/'],
+      matchStrings: ['binary: golangci-lint\\n\\s+version: "(?<currentValue>[^"]+)"'],
+      depNameTemplate: 'golangci/golangci-lint',
+      datasourceTemplate: 'github-releases',
+    },
+    // goimports module version pinned in a `go install` run step.
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/pre-commit-action\\.yaml\\.template$/'],
+      matchStrings: ['go install golang\\.org/x/tools/cmd/goimports@(?<currentValue>[^\\s]+)'],
+      depNameTemplate: 'golang.org/x/tools',
+      datasourceTemplate: 'go',
+    },
+  ],
+  packageRules: [
+    {
+      // architect-orb git tags are vX.Y.Z; the pinned constant and the golden
+      // fixtures hold the bare version, so strip the leading `v` before
+      // comparison. Scoped to the architect-orb source repo, so it never
+      // touches the `orb`-datasource giantswarm/architect the root config
+      // disables.
+      matchDatasources: ['github-tags'],
+      matchPackageNames: ['giantswarm/architect-orb'],
+      extractVersion: '^v(?<version>.+)$',
+    },
+  ],
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,10 @@
     'github>giantswarm/renovate-presets:default.json5',
     // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
     'github>giantswarm/renovate-presets:lang-go.json5',
+    // Repo-owned overrides -- last entry, so its rules win over the presets.
+    // Renovate resolves this from the default branch on every run: edits are
+    // live on merge, no regeneration needed.
+    'github>giantswarm/devctl:renovate-custom.json5',
   ],
   packageRules: [
     {


### PR DESCRIPTION
## Summary

The align-files run #2030 ("align files according to platform standards") regenerated `renovate.json5` from the new template and **dropped all of devctl's repo-specific Renovate rules** — the `github-actions` template scanning and every `customManager` that keeps the generator's pinned tool versions current (architect/continuation orb constants, golden fixtures, pre-commit hook revs, helm / helm-docs / helm-values-schema-json / golangci-lint / goimports versions).

This restores them using the **new mechanism** (added in #1961): the repo-owned `renovate-custom.json5`, which the generated config references as its last `extends` entry and which align-files never overwrites.

## Changes

- **`renovate-custom.json5`** (new) — all restored custom managers + the `github-actions` `*.yaml.template` scanning.
- **`renovate.json5`** — adds the `github>giantswarm/devctl:renovate-custom.json5` extends entry (idempotent with what align-files now emits, since the custom file exists).
- **`pkg/gen/input/circleci/circleci.go`** — the architect orb constant's `// renovate:` annotation now points at `github-tags`/`giantswarm/architect-orb` instead of the `orb` datasource (comment only; no generated-output change).

## Notes / decisions

- **Not restored** (now redundant, covered by `renovate-presets:default.json5`):
  - `helpers:pinGitHubActionDigests` extends → preset already extends `helpers:pinGitHubActionDigestsToSemver`.
  - the `giantswarm/github-workflows` `pinDigest` disable → preset already sets `pinDigests:false` for all `giantswarm/*` actions.
- **Architect orb routed through `github-tags`:** the generated config disables the `orb` datasource for `giantswarm/architect` (so Renovate stops fighting align-files over `.circleci/config.yml`). A *direct* root `packageRule` beats anything an `extends` preset sets, so `renovate-custom.json5` cannot re-enable it. The generator's orb constant + golden fixtures are therefore tracked via `github-tags` on the `giantswarm/architect-orb` source repo (same versions, not matched by the disable rule), with a `packageRule` stripping the leading `v`. `circleci/continuation` is unaffected by the disable and stays on the `orb` datasource.

## Test plan

- [x] `go build ./...` and `go test ./pkg/gen/input/renovate/... ./pkg/gen/input/circleci/...` pass.
- [x] `renovate-config-validator` (v43.242.0) validates both `renovate.json5` and `renovate-custom.json5`.
- [ ] After merge: confirm Renovate opens a PR bumping the architect orb constant to the latest `architect-orb` tag (v9.5.3 currently > pinned 9.5.2) in lockstep with the golden fixtures.

Made with [Cursor](https://cursor.com)