### PR TITLE
fix(gen): derive template provenance SHA from HEAD, not all refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `update-template-sha`: derive the embedded provenance SHA from `git rev-list -1 HEAD`
+  instead of `git rev-list --all`. `--all` spanned unmerged `origin/renovate/*` branches in
+  the build checkout, so the `*.template.sha` link could resolve to a commit that only exists
+  on an open PR branch. That made the SHA non-deterministic across release builds even when the
+  template content was unchanged, causing the align-files automation to emit no-op PRs (only the
+  source-link SHA in generated file headers changed) to every consuming repo.
+
 ## [8.23.0] - 2026-06-24
 
 ### Changed

--- a/pkg/gen/input/update-template-sha.go
+++ b/pkg/gen/input/update-template-sha.go
@@ -24,7 +24,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	shaCmd := exec.Command("git", "rev-list", "--all", "-1", "--", fmt.Sprintf("%s/%s", currentWorkingDirectory, filename))
+	// Scope the lookup to the current HEAD's history, not `--all`. `git rev-list --all`
+	// spans every ref in the checkout (including unmerged origin/renovate/* branches), so
+	// the "last commit that touched this template" could resolve to a commit that only
+	// exists on an open PR branch. That made the embedded provenance SHA non-deterministic:
+	// it churned release-to-release with no template content change, and the align-files
+	// automation propagated each flip as a no-op PR to every consuming repo. Restricting to
+	// HEAD resolves to the last commit reachable from the build's checkout (the release tag
+	// on tag builds) that touched the template, so the SHA only changes when the template does.
+	shaCmd := exec.Command("git", "rev-list", "-1", "HEAD", "--", fmt.Sprintf("%s/%s", currentWorkingDirectory, filename))
 	sha, err := shaCmd.CombinedOutput()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Problem

`devctl gen` embeds a provenance link in the header of every generated file, e.g.:

```
#    https://github.com/giantswarm/devctl/blob/<SHA>/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
```

That `<SHA>` is produced by `pkg/gen/input/update-template-sha.go`, which wrote the `*.template.sha` files via:

```go
git rev-list --all -1 -- <template>
```

`--all` spans **every ref in the build checkout**, including unmerged `origin/renovate/*` branches. So the "last commit that touched this template" could resolve to a commit that exists only on an open PR branch.

Reproduced locally — `--all` picked `7fe79dc` (tip of `origin/renovate/actions-cache-6.x`, *not on main*) over the actual main-line commit `27c0572`, purely because the Renovate branch had a newer commit date.

Because the `.sha` files are gitignored and regenerated at build time (`make test` → `generate-go` → `go generate`, see #2040), each release could embed a **different SHA for unchanged template content**. The `giantswarm/github` align-files automation then propagated every flip as a no-op PR — only the source-link SHA in generated file headers changed — to every consuming repo (e.g. [klaus-operator#162](https://github.com/giantswarm/klaus-operator/pull/162)).

## Fix

Scope the lookup to the build checkout's own history:

```go
git rev-list -1 HEAD -- <template>
```

On a tag build, `HEAD` is the release commit, so this resolves to the last commit *reachable from the release* that touched the template. Deterministic across builds; the SHA changes only when the template actually changes. CircleCI's checkout keeps full history, so `rev-list -- <path>` still resolves the touching commit.

## Verification

After the change, regenerating the precommit `.sha` resolves to `27c0572` (on `main`) instead of the Renovate-branch commit, and `git merge-base --is-ancestor` confirms it's reachable from HEAD.