### PR TITLE
chore(deps): bump architect orb to 9.5.4 (fixes +dirty release binaries)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.2
+  architect: giantswarm/architect@9.5.4
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Bump the aligned `giantswarm/architect` orb to `9.5.4` (from `9.5.2`/`9.5.3`). `9.5.4` writes
+  the nancy scan log to `/tmp` instead of the repo root, so it no longer dirties the working tree
+  between `make test` and the binary link. Without it, every `go-build` release binary (devctl
+  included) embedded `vX.Y.Z+dirty`, which broke the align-files `DEVCTL_UNSAFE_FORCE_VERSION`
+  self-update bypass that compares against a `+dirty`-stripped version.
+
 ### Fixed
 
 - `update-template-sha`: derive the embedded provenance SHA from `git rev-list -1 HEAD`

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -26,7 +26,7 @@ import (
 // custom manager that reads this annotation lives in renovate-custom.json5.
 //
 // renovate: datasource=github-tags depName=giantswarm/architect-orb
-const OrbVersion = "9.5.3"
+const OrbVersion = "9.5.4"
 
 // ContinuationOrbVersion pins the circleci/continuation orb used by the
 // generated setup config (.circleci/config.yml) to merge the optional

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.3
+  architect: giantswarm/architect@9.5.4
 
 workflows:
   build:

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.3
+  architect: giantswarm/architect@9.5.4
 
 workflows:
   build:


### PR DESCRIPTION
## Problem

devctl's own release binaries (and every repo's, via the generated CircleCI config) embed `vX.Y.Z+dirty`. Root cause: architect orb's `go-test` nancy step wrote `./nancy-results.txt` into the repo root between `make test` and the binary link, dirtying the working tree so Go's buildvcs stamped `vcs.modified=true`. Confirmed on the released `devctl v8.23.5+dirty` and `muster v0.18.9+dirty` binaries.

This also broke the `align-files` workflow's `DEVCTL_UNSAFE_FORCE_VERSION` self-update bypass, which compares against a `+dirty`-stripped version string and so never matched devctl's own build-info version.

Fixed upstream in [architect-orb#857](https://github.com/giantswarm/architect-orb/pull/857), released as `giantswarm/architect@9.5.4`.

## Change

- Bump the baked-in `OrbVersion` constant `9.5.3` → `9.5.4` (`pkg/gen/input/circleci/circleci.go`).
- Regenerate devctl's own `.circleci/workflows.yml` to pin `9.5.4` (was stale at `9.5.2`).
- Update the circleci golden testdata to `9.5.4`.

Once released, the new devctl build will no longer be `+dirty`, and `align-files` should be pointed at this devctl version (follow-up in `giantswarm/github`).

## Test plan

- [ ] `go test ./pkg/gen/input/circleci/...` green (done locally).
- [ ] After release, `go version -m` of the devctl release binary shows `vcs.modified=false` (no `+dirty`).

Made with [Cursor](https://cursor.com)