### PR TITLE
chore(deps): bump architect orb to 9.5.5 (build-cache key v2)

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.4
+  architect: giantswarm/architect@9.5.5
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Bump the aligned `giantswarm/architect` orb to `9.5.4` (from `9.5.2`/`9.5.3`). `9.5.4` writes
+- Bump the aligned `giantswarm/architect` orb to `9.5.5` (from `9.5.2`/`9.5.3`). `9.5.4` writes
   the nancy scan log to `/tmp` instead of the repo root, so it no longer dirties the working tree
   between `make test` and the binary link. Without it, every `go-build` release binary (devctl
   included) embedded `vX.Y.Z+dirty`, which broke the align-files `DEVCTL_UNSAFE_FORCE_VERSION`
-  self-update bypass that compares against a `+dirty`-stripped version.
+  self-update bypass that compares against a `+dirty`-stripped version. `9.5.5` additionally bumps
+  the Go build-cache key (`go-build-cache-v1-` -> `v2-`) so `restore_cache` stops unpacking the
+  stale `9.5.2`-era archive at the wrong `GOCACHE` path; the permanent cold compile that caused
+  was OOM-killing memory-heavy parallel cross-compiles (observed on `mcp-kubernetes`).
 
 ### Fixed
 

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -26,7 +26,7 @@ import (
 // custom manager that reads this annotation lives in renovate-custom.json5.
 //
 // renovate: datasource=github-tags depName=giantswarm/architect-orb
-const OrbVersion = "9.5.4"
+const OrbVersion = "9.5.5"
 
 // ContinuationOrbVersion pins the circleci/continuation orb used by the
 // generated setup config (.circleci/config.yml) to merge the optional

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.cli.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.4
+  architect: giantswarm/architect@9.5.5
 
 workflows:
   build:

--- a/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/mcp-kubernetes.workflows.yml
@@ -5,7 +5,7 @@
 # workflow in .circleci/config.yml merges into this file at pipeline runtime.
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.5.4
+  architect: giantswarm/architect@9.5.5
 
 workflows:
   build:


### PR DESCRIPTION
## Change

Bump the baked-in `OrbVersion` constant `9.5.4` -> `9.5.5`, regenerate devctl's own `.circleci/workflows.yml`, and update the circleci golden testdata.

`9.5.5` ([architect-orb CHANGELOG](https://github.com/giantswarm/architect-orb/blob/main/CHANGELOG.md)) bumps the Go build-cache key `go-build-cache-v1-` -> `v2-`. `9.5.3` had moved `GOCACHE` to `$HOME/.cache/go-build` without changing the key, so `restore_cache` kept unpacking the stale `9.5.2`-era archive (old path) where `GOCACHE` no longer points -- a permanent cold compile. On `build_concurrency` repos that meant parallel cold cross-compiles, OOM-killing memory-heavy builds (observed on `mcp-kubernetes`). `v2` opens a fresh namespace at the new path so warm caching takes effect.

Stacks on the `9.5.4` nancy-`/tmp` fix already pinned here (released in devctl v8.23.6, which verified clean: `vcs.modified=false`).

## Test plan

- [ ] `go test ./pkg/gen/input/circleci/...` green (done locally).
- [ ] devctl go-build on this PR runs on orb 9.5.5 (self-test).
- [ ] After release, follow up by bumping the align-files devctl pin in `giantswarm/github`.

Made with [Cursor](https://cursor.com)