### PR TITLE
fix(gen/circleci): salt the Node dependency-cache key (v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `gen circleci`: the generated Node dependency-cache key now carries a `v1` version salt
+  (`node-deps-<pm>-v1-{{ checksum "<lockfile>" }}`, restore prefix `node-deps-<pm>-v1-`). CircleCI
+  cache keys are immutable, so a repo that first adopts the Node job while still on Yarn's default
+  global cache would seed an empty `.yarn/cache` under the lockfile hash and could never save a real
+  cache until the lockfile changed. The salt invalidates such stale/empty seeds in one release and
+  gives a lever to bust caches on future cache-shape changes.
+
 ### Added
 
 - `gen renovate` gained a `--deprecated` flag. When set, the generated `renovate.json5`

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -308,7 +308,13 @@ func New(config Config) (*CircleCI, error) {
 		if pm == "" {
 			pm = PackageManagerYarn
 		}
-		nodeCacheRestoreKey = "node-deps-" + pm + "-"
+		// `v1` is a cache-version salt. CircleCI cache keys are immutable, so a
+		// repo that first adopts the Node job while still on Yarn's default
+		// global cache seeds an empty .yarn/cache under the lockfile hash; the
+		// real cache can then never be saved until the lockfile changes. Bumping
+		// the salt invalidates such stale/empty seeds in one release and gives a
+		// lever to invalidate caches on future cache-shape changes.
+		nodeCacheRestoreKey = "node-deps-" + pm + "-v1-"
 		nodeCacheKey = nodeCacheRestoreKey + `{{ checksum "` + tc.lockfile + `" }}`
 
 		nodeTestTarget = config.NodeTestTarget

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -1143,10 +1143,10 @@ func Test_NodePackageManagers(t *testing.T) {
 		cacheKey    string
 		wantCorepak bool
 	}{
-		{PackageManagerNPM, "npm ci", "~/.npm", `node-deps-npm-{{ checksum "package-lock.json" }}`, false},
-		{PackageManagerYarn, "yarn install --immutable", ".yarn/cache", `node-deps-yarn-{{ checksum "yarn.lock" }}`, false},
-		{PackageManagerYarnClassic, "yarn install --frozen-lockfile", "~/.cache/yarn", `node-deps-yarn-classic-{{ checksum "yarn.lock" }}`, false},
-		{PackageManagerPNPM, "pnpm install --frozen-lockfile", "~/.local/share/pnpm/store", `node-deps-pnpm-{{ checksum "pnpm-lock.yaml" }}`, true},
+		{PackageManagerNPM, "npm ci", "~/.npm", `node-deps-npm-v1-{{ checksum "package-lock.json" }}`, false},
+		{PackageManagerYarn, "yarn install --immutable", ".yarn/cache", `node-deps-yarn-v1-{{ checksum "yarn.lock" }}`, false},
+		{PackageManagerYarnClassic, "yarn install --frozen-lockfile", "~/.cache/yarn", `node-deps-yarn-classic-v1-{{ checksum "yarn.lock" }}`, false},
+		{PackageManagerPNPM, "pnpm install --frozen-lockfile", "~/.local/share/pnpm/store", `node-deps-pnpm-v1-{{ checksum "pnpm-lock.yaml" }}`, true},
 	}
 
 	for _, tc := range cases {

--- a/pkg/gen/input/circleci/testdata/node-npm.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/node-npm.workflows.yml
@@ -21,13 +21,13 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - node-deps-npm-{{ checksum "package-lock.json" }}
-        - node-deps-npm-
+        - node-deps-npm-v1-{{ checksum "package-lock.json" }}
+        - node-deps-npm-v1-
     - run:
         name: Install dependencies
         command: npm ci
     - save_cache:
-        key: node-deps-npm-{{ checksum "package-lock.json" }}
+        key: node-deps-npm-v1-{{ checksum "package-lock.json" }}
         paths:
         - ~/.npm
     - run:

--- a/pkg/gen/input/circleci/testdata/node-yarn-berry.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/node-yarn-berry.workflows.yml
@@ -21,13 +21,13 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - node-deps-yarn-{{ checksum "yarn.lock" }}
-        - node-deps-yarn-
+        - node-deps-yarn-v1-{{ checksum "yarn.lock" }}
+        - node-deps-yarn-v1-
     - run:
         name: Install dependencies
         command: yarn install --immutable
     - save_cache:
-        key: node-deps-yarn-{{ checksum "yarn.lock" }}
+        key: node-deps-yarn-v1-{{ checksum "yarn.lock" }}
         paths:
         - .yarn/cache
     - run:


### PR DESCRIPTION
## Summary

- Add a `v1` cache-version salt to the generated Node dependency-cache key and restore prefix: `node-deps-<pm>-v1-{{ checksum "<lockfile>" }}` (restore `node-deps-<pm>-v1-`).
- CircleCI cache keys are immutable. A repo that first adopts the generated `node-build`/`node-test` job while still on Yarn's default `enableGlobalCache: true` seeds an empty (~16 B) `.yarn/cache` under the lockfile hash; the real warm cache can then never be saved until the lockfile changes. The salt busts any stale/empty seed in one release and gives a lever to invalidate caches on future cache-shape changes.
- Golden tests (npm + Yarn-Berry) and the package-manager matrix test updated to assert the salted key.

Closes #2056. Discovered in giantswarm/backstage#1829 (Node/TypeScript CI workstream).

## Test plan

- [x] `make test` green
- [ ] CircleCI green
- [ ] After merge + release: bump the devctl pin in `giantswarm/github` align-files and confirm a warm `node-build` install on backstage

Made with [Cursor](https://cursor.com)