### PR TITLE
feat(gen): own and generate the canonical ATS Pipfile

### DIFF
--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -88,6 +88,11 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		circleciInput.SetupConfig(),
 		circleciInput.Workflows(),
 	}
+	// The canonical ATS Pipfile rides on the same chart/app (.HasApp) signal
+	// that emits the run-tests-with-ats jobs, so it is folded into this
+	// generator rather than invoked separately (which would risk leaking it
+	// into non-generated-CI repos). ATSInputs returns nil for non-app repos.
+	inputs = append(inputs, circleciInput.ATSInputs()...)
 
 	err = gen.Execute(ctx, inputs...)
 	if err != nil {

--- a/pkg/gen/input/ats/ats.go
+++ b/pkg/gen/input/ats/ats.go
@@ -1,0 +1,17 @@
+package ats
+
+import (
+	"github.com/giantswarm/devctl/v8/pkg/gen/input"
+	"github.com/giantswarm/devctl/v8/pkg/gen/input/ats/internal/file"
+)
+
+// CreateATS returns the inputs for the canonical app-test-suite (ATS) test
+// dependencies: tests/ats/Pipfile. Emission is gated on the chart/app
+// (.HasApp) flavour by the caller (devctl gen circleci) -- the same signal that
+// emits the run-tests-with-ats jobs -- so the Pipfile never lands in a non-app
+// or non-generated-CI repo.
+func CreateATS() []input.Input {
+	return []input.Input{
+		file.NewCreatePipfileInput(),
+	}
+}

--- a/pkg/gen/input/ats/ats_test.go
+++ b/pkg/gen/input/ats/ats_test.go
@@ -1,0 +1,87 @@
+package ats
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// renderPipfile executes the Pipfile input the same way pkg/gen/internal.Execute
+// does, returning the bytes that would be written to tests/ats/Pipfile.
+func renderPipfile(t *testing.T) string {
+	t.Helper()
+
+	inputs := CreateATS()
+	if len(inputs) != 1 {
+		t.Fatalf("CreateATS() returned %d inputs, want 1", len(inputs))
+	}
+	in := inputs[0]
+
+	if in.Path != "tests/ats/Pipfile" {
+		t.Errorf("Pipfile Path = %q, want tests/ats/Pipfile", in.Path)
+	}
+	// A plain Pipfile is not a name pkg/gen treats as regenerable, so the input
+	// must skip the regen check or an existing repo Pipfile would never be
+	// overwritten by a central bump.
+	if !in.SkipRegenCheck {
+		t.Errorf("Pipfile input must set SkipRegenCheck so align overwrites the repo copy")
+	}
+
+	tpl, err := template.New("Pipfile").Parse(in.TemplateBody)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+	var rendered bytes.Buffer
+	if err := tpl.Execute(&rendered, in.TemplateData); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+
+	return rendered.String()
+}
+
+// Test_PipfileRendersVerbatim verifies the embedded Pipfile passes through the
+// template engine byte-identical (it has no template actions), so the file
+// generated into each repo equals the canonical source Renovate bumps.
+func Test_PipfileRendersVerbatim(t *testing.T) {
+	got := renderPipfile(t)
+
+	source := filepath.Join("internal", "file", "Pipfile")
+	want, err := os.ReadFile(source) // #nosec G304 -- fixed in-package source path
+	if err != nil {
+		t.Fatalf("read embedded Pipfile source: %v", err)
+	}
+
+	if got != string(want) {
+		t.Errorf("rendered Pipfile differs from embedded source (template corruption?)\n--- got ---\n%s\n--- source ---\n%s", got, string(want))
+	}
+}
+
+// Test_PipfileCanonicalPins pins the exact == versions of the standard ATS
+// stack. The pytest pin must stay below 9 to remain compatible with
+// pytest-helm-charts (which requires pytest<9); a bare `pytest = "==9..."`
+// would reintroduce the resolution conflict this centralization exists to
+// prevent.
+func Test_PipfileCanonicalPins(t *testing.T) {
+	got := renderPipfile(t)
+
+	for _, want := range []string{
+		`pytest-helm-charts = "==1.3.4"`,
+		`pytest = "==8.4.2"`,
+		`pykube-ng = "==23.6.0"`,
+		`pytest-rerunfailures = "==16.3"`,
+		`requests = "==2.34.2"`,
+		`[packages]`,
+		`url = "https://pypi.org/simple"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("canonical Pipfile missing %q:\n%s", want, got)
+		}
+	}
+
+	if strings.Contains(got, `pytest = "==9`) {
+		t.Errorf("pytest must stay <9 for pytest-helm-charts compatibility:\n%s", got)
+	}
+}

--- a/pkg/gen/input/ats/internal/file/Pipfile
+++ b/pkg/gen/input/ats/internal/file/Pipfile
@@ -1,0 +1,21 @@
+# DO NOT EDIT. The canonical app-test-suite (ATS) test dependencies are owned
+# centrally in giantswarm/devctl and generated into tests/ats/Pipfile for
+# chart/app repos by `devctl gen circleci`. The stack is bumped by a single
+# Renovate PR against the embedded source in giantswarm/devctl (pipenv manager)
+# and propagated to every repo by the align-files regeneration. Per-repo
+# Renovate updates of this file are disabled via
+# github>giantswarm/renovate-presets:tests-ats.json5.
+#
+# Pins are exact == and chosen to resolve together: pytest is held below 9 so it
+# stays compatible with pytest-helm-charts (which requires pytest<9).
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[packages]
+pytest-helm-charts = "==1.3.4"
+pytest = "==8.4.2"
+pykube-ng = "==23.6.0"
+pytest-rerunfailures = "==16.3"
+requests = "==2.34.2"

--- a/pkg/gen/input/ats/internal/file/pipfile.go
+++ b/pkg/gen/input/ats/internal/file/pipfile.go
@@ -1,0 +1,27 @@
+package file
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/devctl/v8/pkg/gen/input"
+)
+
+//go:embed Pipfile
+var createPipfile string
+
+// NewCreatePipfileInput emits tests/ats/Pipfile: the canonical, centrally
+// pinned app-test-suite (ATS) test dependency set. It carries no per-repo
+// substitution -- the file is emitted verbatim from the embedded source so the
+// copy in every chart/app repo stays byte-identical to the one Renovate's
+// pipenv manager bumps within giantswarm/devctl.
+//
+// SkipRegenCheck keeps the file overwritten on every align run (a plain Pipfile
+// is not otherwise regenerable, so without it an existing repo Pipfile would
+// never be updated), which is what makes a central bump reliably propagate.
+func NewCreatePipfileInput() input.Input {
+	return input.Input{
+		Path:           "tests/ats/Pipfile",
+		TemplateBody:   createPipfile,
+		SkipRegenCheck: true,
+	}
+}

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/devctl/v8/pkg/gen"
 	"github.com/giantswarm/devctl/v8/pkg/gen/input"
+	"github.com/giantswarm/devctl/v8/pkg/gen/input/ats"
 	"github.com/giantswarm/devctl/v8/pkg/gen/input/circleci/internal/file"
 	"github.com/giantswarm/devctl/v8/pkg/gen/input/circleci/internal/params"
 )
@@ -405,4 +406,20 @@ func (c *CircleCI) SetupConfig() input.Input {
 // .circleci/workflows.yml.
 func (c *CircleCI) Workflows() input.Input {
 	return file.NewWorkflowsInput(c.params)
+}
+
+// ATSInputs returns the canonical app-test-suite (ATS) Pipfile input for
+// chart/app (.HasApp) repos, and nil otherwise. ATS chart tests run only for
+// .HasApp -- the same signal that gates the run-tests-with-ats jobs -- so the
+// Pipfile is emitted under exactly that condition and from the same generator
+// call site (devctl gen circleci, the only generator invoked inside align's
+// `if (ci && ci.generate)` guard). That makes "ATS Pipfile only when CI is
+// generated, and only for chart/app repos" structurally guaranteed rather than
+// dependent on a separate, differently-scoped invocation.
+func (c *CircleCI) ATSInputs() []input.Input {
+	if !c.params.HasApp {
+		return nil
+	}
+
+	return ats.CreateATS()
 }

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -1206,6 +1206,49 @@ func Test_NodeTestTargetConfigurable(t *testing.T) {
 	}
 }
 
+// Test_ATSPipfileForAppRepo verifies the canonical ATS Pipfile is emitted for
+// a chart/app (.HasApp) repo -- the same signal that gates run-tests-with-ats
+// -- and that it carries the centrally-pinned content at tests/ats/Pipfile.
+func Test_ATSPipfileForAppRepo(t *testing.T) {
+	inputs := newCircleCI(t, Config{
+		RepoName:      repoMCPKubernetes,
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{gen.FlavourApp},
+		HasDockerfile: true,
+	}).ATSInputs()
+
+	if len(inputs) != 1 {
+		t.Fatalf("expected 1 ATS input for an app repo, got %d", len(inputs))
+	}
+	if inputs[0].Path != "tests/ats/Pipfile" {
+		t.Errorf("ATS input Path = %q, want tests/ats/Pipfile", inputs[0].Path)
+	}
+
+	got := renderInput(t, inputs[0])
+	if !contains(got, `pytest-helm-charts = "==1.3.4"`) {
+		t.Errorf("generated ATS Pipfile missing the canonical pytest-helm-charts pin:\n%s", got)
+	}
+	if !contains(got, `pytest = "==8.4.2"`) {
+		t.Errorf("generated ATS Pipfile missing the canonical pytest pin:\n%s", got)
+	}
+}
+
+// Test_ATSPipfileOmittedForNonApp verifies a repo without the app flavour gets
+// no ATS Pipfile -- the file is scoped to chart/app repos exactly like the
+// run-tests-with-ats jobs.
+func Test_ATSPipfileOmittedForNonApp(t *testing.T) {
+	inputs := newCircleCI(t, Config{
+		RepoName:      "klausctl",
+		Language:      gen.LanguageGo,
+		Flavours:      gen.FlavourSlice{},
+		HasDockerfile: false,
+	}).ATSInputs()
+
+	if len(inputs) != 0 {
+		t.Errorf("expected no ATS inputs for a non-app repo, got %d: %+v", len(inputs), inputs)
+	}
+}
+
 // Test_GoUnaffectedByBuildJobName is a regression guard: generalizing the
 // image/chart requires wiring to BuildJobName must keep the Go path gating on
 // go-build exactly as before.

--- a/renovate-custom.json5
+++ b/renovate-custom.json5
@@ -118,5 +118,19 @@
       matchPackageNames: ['giantswarm/architect-orb'],
       extractVersion: '^v(?<version>.+)$',
     },
+    {
+      // The canonical ATS (app-test-suite) Pipfile is embedded here and
+      // generated verbatim into every chart/app repo's tests/ats/Pipfile by
+      // `devctl gen circleci`. It is the single source the built-in pipenv
+      // manager bumps -- group the whole stack into one PR so the pins move
+      // together (and stay mutually resolvable, e.g. pytest<9 for
+      // pytest-helm-charts), then propagate to all repos via one align-files
+      // regeneration. The per-repo copies are disabled for Renovate via
+      // renovate-presets:tests-ats.json5, so this is the only place the stack
+      // is updated.
+      matchManagers: ['pipenv'],
+      matchFileNames: ['pkg/gen/input/ats/internal/file/Pipfile'],
+      groupName: 'ATS test dependencies',
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Centralizes the app-test-suite (ATS) test dependency stack so it is owned once in devctl instead of hand-maintained (and Renovate-bumped) in ~57 chart/app repos.

- Adds the canonical pinned Pipfile as a static embedded file (`pkg/gen/input/ats/internal/file/Pipfile`), modelled on the `apptest` generator. Exact `==` pins chosen to resolve together (pytest held `<9` for `pytest-helm-charts`, avoiding the happa #4860 conflict).
- Folds emission into `devctl gen circleci`, gated on `.HasApp` (chart/app flavour) — the same signal that emits the `run-tests-with-ats` jobs and the only generator inside align's `if (ci && ci.generate)` guard. This structurally guarantees the Pipfile is generated only for chart/app repos on the generated-CI path; no standalone `devctl gen ats`, no new flag/signal.
- Groups the embedded Pipfile's Renovate (`pipenv`) bumps into one PR within devctl (`renovate-custom.json5`), so the stack is bumped once and propagated by align.

Part of the ATS centralization extension of the CI & build-system alignment epic (giantswarm/giantswarm#36729).

Closes #2058

## Test plan

- [x] `go build ./...` and `go test ./...` clean
- [x] Unit tests: app repo emits byte-identical `tests/ats/Pipfile`; non-app repo emits none; canonical pins + verbatim rendering asserted
- [x] E2E: `devctl gen circleci -r <repo> -l go -f app` writes the Pipfile; `-l go` (no app) writes none; generated file byte-identical to embedded source

Made with [Cursor](https://cursor.com)