### PR TITLE
feat(gen/circleci): persist Node compute caches + resource_class knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `gen circleci`: the generated Node job now honours a per-repo **`resource_class`**
+  (reusing the `gen.ci.resourceClass` knob the cli `go-build` job uses), defaulting to
+  `large`. The Node verify chain (tsc + lint + test + build over a whole monorepo) is
+  memory-hungry — backstage's `ci:verify` pins `NODE_OPTIONS` `max-old-space-size` to 6 GiB —
+  so a bigger monorepo can size up to `xlarge` without forking the generated job.
 - `gen circleci`: the generated Node job now also caches the **build output**
   (`node_modules` + Yarn's `.yarn/install-state.gz`) for the Yarn package managers,
   keyed on the node image version and the lockfile checksum
@@ -23,6 +28,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `gen circleci`: the generated Node build-output cache is now saved **after** the
+  verify/build steps (it previously saved right after install). The same `node_modules`
+  cache therefore also persists the tsc/eslint/jest incremental caches those steps write
+  under `node_modules/.cache` — the compute-side analogue of persisting `$GOCACHE`, not just
+  the install-time native-addon rebuild. Still write-once per lockfile; the lockfile-agnostic
+  restore prefix keeps every run warm-started from the last good cache, so a red build never
+  leaves a repo cold.
 - `gen circleci`: the generated Node dependency-cache key now carries a `v1` version salt
   (`node-deps-<pm>-v1-{{ checksum "<lockfile>" }}`, restore prefix `node-deps-<pm>-v1-`). CircleCI
   cache keys are immutable, so a repo that first adopts the Node job while still on Yarn's default

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -62,6 +62,14 @@ const NodeImageVersion = "24.18.0"
 // command.
 const DefaultNodeTestTarget = "test"
 
+// DefaultNodeResourceClass is the CircleCI resource_class the Node job runs on
+// when a repo does not override it. The Node verify chain (tsc + lint + test +
+// build over a whole monorepo) is memory-hungry -- backstage's ci:verify pins
+// NODE_OPTIONS max-old-space-size to 6 GiB -- so "large" (4 vCPU / 8 GiB) is the
+// floor. A bigger monorepo raises it via gen.ci.resourceClass, the same knob the
+// cli go-build job uses.
+const DefaultNodeResourceClass = "large"
+
 // Package-manager values detected from the lockfile. Yarn Berry and Yarn
 // Classic are distinguished because their install commands and cache
 // directories differ (Berry: `--immutable` + .yarn/cache; Classic:
@@ -99,10 +107,13 @@ type nodeToolchain struct {
 	// output lives in node_modules, not the tarball cache. Restoring it lets the
 	// install reconcile incrementally instead of recompiling from source every
 	// run -- the Node analogue of go-build persisting $GOCACHE. Keyed on the
-	// node image version too (native ABI is node-version-specific). Empty for
-	// package managers where it does not apply: npm (`npm ci` wipes node_modules
-	// first) and pnpm (its content-addressable store already caches build
-	// side-effects, and that store is the dependency cache).
+	// node image version too (native ABI is node-version-specific). The template
+	// saves it after the verify/build steps, so the same cache also persists the
+	// tsc/eslint/jest incremental caches those tools write under
+	// node_modules/.cache (the compute-side win). Empty for package managers
+	// where it does not apply: npm (`npm ci` wipes node_modules first) and pnpm
+	// (its content-addressable store already caches build side-effects, and that
+	// store is the dependency cache).
 	buildCachePaths []string
 }
 
@@ -312,6 +323,7 @@ func New(config Config) (*CircleCI, error) {
 		nodeBuildCacheKey        string
 		nodeBuildCacheRestoreKey string
 		nodeCorepack             bool
+		nodeResourceClass        string
 		nodeTestTarget           string
 		nodeBuildTarget          string
 		nodeBuildOutput          string
@@ -323,6 +335,13 @@ func New(config Config) (*CircleCI, error) {
 		nodeCachePath = tc.cachePath
 		nodeBuildCachePaths = tc.buildCachePaths
 		nodeCorepack = tc.corepack
+		// The cli go-build resourceClass knob (gen.ci.resourceClass) is shared:
+		// a Node repo reuses it to size the verify/build box, defaulting to
+		// "large" when unset.
+		nodeResourceClass = config.ResourceClass
+		if nodeResourceClass == "" {
+			nodeResourceClass = DefaultNodeResourceClass
+		}
 		// Embed the literal CircleCI `{{ checksum }}` expression as a plain Go
 		// string so it survives Go-template rendering untouched and is
 		// evaluated by CircleCI at pipeline time. Key on the package manager so
@@ -346,7 +365,10 @@ func New(config Config) (*CircleCI, error) {
 		// the node version, so a node bump must not restore stale binaries. The
 		// restore prefix omits the lockfile checksum, so a changed lockfile
 		// still warm-starts from the previous node_modules and the install only
-		// reconciles (and rebuilds) the diff.
+		// reconciles (and rebuilds) the diff. The template saves this cache
+		// *after* the verify/build steps, so it captures the tsc/eslint/jest
+		// incremental caches those tools write under node_modules/.cache too --
+		// the compute-side analogue of go-build persisting $GOCACHE.
 		if len(nodeBuildCachePaths) > 0 {
 			nodeBuildCacheRestoreKey = "node-build-" + pm + "-v1-" + NodeImageVersion + "-"
 			nodeBuildCacheKey = nodeBuildCacheRestoreKey + `{{ checksum "` + tc.lockfile + `" }}`
@@ -423,6 +445,7 @@ func New(config Config) (*CircleCI, error) {
 			NodeBuildCacheKey:        nodeBuildCacheKey,
 			NodeBuildCacheRestoreKey: nodeBuildCacheRestoreKey,
 			NodeCorepack:             nodeCorepack,
+			NodeResourceClass:        nodeResourceClass,
 			NodeTestTarget:           nodeTestTarget,
 			NodeBuildTarget:          nodeBuildTarget,
 			NodeBuildOutput:          nodeBuildOutput,

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -35,6 +35,8 @@ const (
 	backstageDockerfile  = "packages/backend/Dockerfile"
 	backstageBuildOutput = "packages/*/dist/*"
 	nodeBuildTarget      = "build:backend"
+
+	resourceClassXLarge = "xlarge"
 )
 
 // mergeExpression is the yq deep-merge the generated setup config runs to
@@ -403,14 +405,14 @@ func Test_CLIParallelBuildOverride(t *testing.T) {
 		Flavours:         gen.FlavourSlice{gen.FlavourApp, gen.FlavourCLI},
 		HasDockerfile:    true,
 		BuildConcurrency: "2",
-		ResourceClass:    "xlarge",
+		ResourceClass:    resourceClassXLarge,
 	})
 	// A numeric override must be rendered as a quoted string: the orb's
 	// build_concurrency param is string-typed and rejects a bare int.
 	if !contains(cli, `build_concurrency: "2"`) {
 		t.Errorf("override not applied; want build_concurrency: \"2\" in:\n%s", cli)
 	}
-	if !contains(cli, "resource_class: xlarge") {
+	if !contains(cli, "resource_class: "+resourceClassXLarge) {
 		t.Errorf("override not applied; want resource_class: xlarge in:\n%s", cli)
 	}
 	if contains(cli, "build_concurrency: "+DefaultBuildConcurrency) {
@@ -439,7 +441,7 @@ func Test_CLIParallelBuildOverride(t *testing.T) {
 		Flavours:         gen.FlavourSlice{gen.FlavourApp},
 		HasDockerfile:    true,
 		BuildConcurrency: "2",
-		ResourceClass:    "xlarge",
+		ResourceClass:    resourceClassXLarge,
 	})
 	if contains(svc, "build_concurrency") {
 		t.Errorf("non-cli service should not render build_concurrency even when set:\n%s", svc)
@@ -1278,6 +1280,60 @@ func Test_NodeBuildOutputCache(t *testing.T) {
 		if contains(got, "node-build-"+pm) || contains(got, "- node_modules") {
 			t.Errorf("%s should not emit a build-output cache:\n%s", pm, got)
 		}
+	}
+}
+
+// Test_NodeResourceClass verifies the Node job renders the default resource
+// class when unset and honours the gen.ci.resourceClass override (the same knob
+// the cli go-build job uses), so a memory-hungry monorepo verify/build can be
+// sized up per repo without forking the generated job.
+func Test_NodeResourceClass(t *testing.T) {
+	def := render(t, Config{
+		RepoName:       repoK8sTypes,
+		Language:       gen.LanguageNode,
+		PackageManager: PackageManagerNPM,
+	})
+	if !contains(def, "resource_class: "+DefaultNodeResourceClass) {
+		t.Errorf("Node job should default resource_class to %q:\n%s", DefaultNodeResourceClass, def)
+	}
+
+	override := render(t, Config{
+		RepoName:       repoK8sTypes,
+		Language:       gen.LanguageNode,
+		PackageManager: PackageManagerNPM,
+		ResourceClass:  resourceClassXLarge,
+	})
+	if !contains(override, "resource_class: "+resourceClassXLarge) {
+		t.Errorf("Node job resource_class override not applied:\n%s", override)
+	}
+	if contains(override, "resource_class: "+DefaultNodeResourceClass) {
+		t.Errorf("default resource_class leaked through despite override:\n%s", override)
+	}
+}
+
+// Test_NodeBuildCacheSavedAfterBuild verifies the build-output cache is saved
+// after the verify/build steps (not right after install), so it captures the
+// tsc/eslint/jest incremental caches under node_modules/.cache in addition to
+// the native addons compiled during install -- the compute-side win.
+func Test_NodeBuildCacheSavedAfterBuild(t *testing.T) {
+	got := render(t, Config{
+		RepoName:        repoBackstage,
+		Language:        gen.LanguageNode,
+		Flavours:        gen.FlavourSlice{gen.FlavourApp},
+		PackageManager:  PackageManagerYarn,
+		NodeBuildTarget: nodeBuildTarget,
+		NodeBuildOutput: backstageBuildOutput,
+		ImageDockerfile: backstageDockerfile,
+	})
+
+	buildSave := strings.Index(got, "key: node-build-yarn-v1-")
+	verify := strings.Index(got, "name: Verify")
+	build := strings.Index(got, "name: Build")
+	if buildSave < 0 || verify < 0 || build < 0 {
+		t.Fatalf("missing expected steps (buildSave=%d verify=%d build=%d):\n%s", buildSave, verify, build, got)
+	}
+	if buildSave < verify || buildSave < build {
+		t.Errorf("build-output save_cache must come after Verify and Build to capture compute caches; got save=%d verify=%d build=%d:\n%s", buildSave, verify, build, got)
 	}
 }
 

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -69,6 +69,7 @@ func NewWorkflowsInput(p params.Params) input.Input {
 			"NodeBuildCacheKey":        p.NodeBuildCacheKey,
 			"NodeBuildCacheRestoreKey": p.NodeBuildCacheRestoreKey,
 			"NodeCorepack":             p.NodeCorepack,
+			"NodeResourceClass":        p.NodeResourceClass,
 			"NodeTestTarget":           p.NodeTestTarget,
 			"NodeBuildTarget":          p.NodeBuildTarget,
 			"NodeBuildOutput":          p.NodeBuildOutput,

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -17,7 +17,7 @@ jobs:
   {{ .NodeJobName }}:
     docker:
     - image: cimg/node:{{ .NodeImageVersion }}
-    resource_class: large
+    resource_class: {{ .NodeResourceClass }}
     steps:
     - checkout
 {{- if .NodeCorepack }}
@@ -47,14 +47,6 @@ jobs:
         key: {{ .NodeCacheKey }}
         paths:
         - {{ .NodeCachePath }}
-{{- if .NodeBuildCachePaths }}
-    - save_cache:
-        key: {{ .NodeBuildCacheKey }}
-        paths:
-{{- range .NodeBuildCachePaths }}
-        - {{ . }}
-{{- end }}
-{{- end }}
 {{- if .NodeTestTarget }}
     - run:
         # The repo composes typecheck/lint/format/test into this one script
@@ -66,6 +58,20 @@ jobs:
     - run:
         name: Build
         command: {{ .NodeRunPrefix }} {{ .NodeBuildTarget }}
+{{- end }}
+{{- if .NodeBuildCachePaths }}
+    # Save the build-output cache *after* verify/build so it captures both the
+    # node_modules native addons compiled during install AND the tsc/eslint/jest
+    # incremental caches those steps write under node_modules/.cache -- the
+    # compute-side analogue of persisting $GOCACHE. Write-once per lockfile (the
+    # restore prefix keeps every run warm-started from the last good cache, so a
+    # red build never leaves a repo cold).
+    - save_cache:
+        key: {{ .NodeBuildCacheKey }}
+        paths:
+{{- range .NodeBuildCachePaths }}
+        - {{ . }}
+{{- end }}
 {{- end }}
 {{- if .NodeBuildOutput }}
     - persist_to_workspace:

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -151,6 +151,10 @@ type Params struct {
 	// NodeCorepack is true when the package manager needs `corepack enable`
 	// (pnpm, which cimg/node does not bundle).
 	NodeCorepack bool
+	// NodeResourceClass is the CircleCI resource_class the Node job runs on.
+	// Defaults to "large"; raised per repo via gen.ci.resourceClass (the same
+	// knob the cli go-build job uses) for a memory-hungry monorepo verify/build.
+	NodeResourceClass string
 	// NodeTestTarget is the package.json script the Node job runs for the
 	// verify phase (the make-target interface). Defaults to "test".
 	NodeTestTarget string

--- a/pkg/gen/input/circleci/testdata/node-yarn-berry.workflows.yml
+++ b/pkg/gen/input/circleci/testdata/node-yarn-berry.workflows.yml
@@ -39,11 +39,6 @@ jobs:
         key: node-deps-yarn-v1-{{ checksum "yarn.lock" }}
         paths:
         - .yarn/cache
-    - save_cache:
-        key: node-build-yarn-v1-24.18.0-{{ checksum "yarn.lock" }}
-        paths:
-        - node_modules
-        - .yarn/install-state.gz
     - run:
         # The repo composes typecheck/lint/format/test into this one script
         # (the make-target interface), so CI and local runs share a command.
@@ -52,6 +47,17 @@ jobs:
     - run:
         name: Build
         command: yarn run build:backend
+    # Save the build-output cache *after* verify/build so it captures both the
+    # node_modules native addons compiled during install AND the tsc/eslint/jest
+    # incremental caches those steps write under node_modules/.cache -- the
+    # compute-side analogue of persisting $GOCACHE. Write-once per lockfile (the
+    # restore prefix keeps every run warm-started from the last good cache, so a
+    # red build never leaves a repo cold).
+    - save_cache:
+        key: node-build-yarn-v1-24.18.0-{{ checksum "yarn.lock" }}
+        paths:
+        - node_modules
+        - .yarn/install-state.gz
     - persist_to_workspace:
         # Hand the build output to the image jobs, which attach_workspace and
         # overlay it into the Docker build context (gen.ci.image.preBuildJob).


### PR DESCRIPTION
## Summary

Two compute-side optimizations to the generated Node job, following the go-build cache-perf precedent (giantswarm/giantswarm#36941 / architect-orb#838) and building on the installed-tree cache (#2064) and dependency-cache salt (#2057):

- **Persist the tsc/eslint/jest compute caches.** The build-output cache (`node_modules` + Yarn `install-state`) is now saved **after** the verify/build steps instead of right after install. The same `node_modules` cache therefore also captures the incremental caches those tools write under `node_modules/.cache`, not just the native addons compiled during install — the compute-side analogue of persisting `$GOCACHE`. Still write-once per lockfile; the lockfile-agnostic restore prefix keeps every run warm-started from the last good cache (save runs on success, so a red build never poisons or strands the cache).
- **Per-repo `resource_class` on the Node job.** Reuses the existing `gen.ci.resourceClass` knob (the cli go-build job already uses it), defaulting to `large`. The Node verify chain (tsc + lint + test + build over a monorepo) is memory-hungry — backstage's `ci:verify` pins `NODE_OPTIONS` `max-old-space-size` to 6 GiB — so a bigger monorepo can size up to `xlarge` without forking the generated job.

Coverage gating to main/tags is intentionally **not** a generator change: the job runs a single `package.json` script (the make-target interface), and CircleCI already exposes `CIRCLE_BRANCH`/`CIRCLE_TAG` to it, so a repo gates `--coverage` in its own script. This mirrors the go-build ADR's Tier-2 decision (branch-only-work gating rejected as not worth a generator flag once caching is in place).

Closes #2066. Part of the Node/TypeScript CI workstream (giantswarm/giantswarm#36729). Refs giantswarm/backstage#1829.

## Test plan

- [x] `make test` green; new `Test_NodeResourceClass` (default + override) and `Test_NodeBuildCacheSavedAfterBuild` (save positioned after verify/build); yarn-berry golden updated
- [ ] CircleCI green
- [ ] After release + align-pin bump: re-measure `node-build` wall-clock on backstage (the warm compute number left projected in #1829)

Made with [Cursor](https://cursor.com)