### PR TITLE
feat(gen precommit): emit node prettier hook, omit generic eslint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `gen precommit`: the generated `.pre-commit-config.yaml` now emits a **node**
+  formatting hook (`rbubley/mirrors-prettier`) when `--language node`. Linting is
+  intentionally omitted — every Giant Swarm node repo lints through its own
+  toolchain (`@backstage/cli`, Next.js, headlamp-plugin) in `node-build`, and a
+  generic eslint hook fails against their legacy `.eslintrc` configs. This makes
+  `devctl gen precommit` the single source of truth for node pre-commit (replacing
+  the static `languages/node/.pre-commit-config.yaml` in `giantswarm/github`, which
+  clobbered the generated `conventional-pre-commit` + per-chart helm hooks and shipped
+  the broken eslint hook).
+
 - `gen circleci`: the generated Node job now honours a per-repo **`resource_class`**
   (reusing the `gen.ci.resourceClass` knob the cli `go-build` job uses), defaulting to
   `large`. The Node verify chain (tsc + lint + test + build over a whole monorepo) is

--- a/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
@@ -61,6 +61,19 @@ repos:
       - id: go-imports
         args: [ -local, {{.RepoName}} ]
 {{- end }}
+{{- if eq .Language "node" }}
+
+  # JS/TS formatting. Linting is intentionally omitted: every Giant Swarm node
+  # repo lints through its own toolchain (@backstage/cli, Next.js,
+  # headlamp-plugin) in node-build, and a generic eslint hook fails against
+  # their legacy .eslintrc configs.
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.5
+    hooks:
+      - id: prettier
+        types_or: [javascript, jsx, ts, tsx, json, yaml, css, scss, markdown]
+        exclude: "(^\\.yarn/.*|.*/dist/.*|.*/node_modules/.*)"
+{{- end }}
 {{- if .HasBash }}
 
   # Bash/shell hooks


### PR DESCRIPTION
## Summary

Makes `devctl gen precommit` the single source of truth for **node** pre-commit config, and removes the broken generic eslint hook.

- `--language node` now emits a `prettier` formatting hook (`rbubley/mirrors-prettier`).
- **No eslint hook.** A generic eslint v9 flat-config hook hard-fails (`ESLint couldn't find an eslint.config.(js|mjs|cjs) file`) against every Giant Swarm node repo, all of which use a bespoke toolchain (`@backstage/cli`, Next.js, headlamp-plugin) with legacy `.eslintrc` config. Linting for these repos already runs in `node-build` (`ci:verify`), so a pre-commit eslint hook is redundant where it works and broken where it doesn't.
- Because the generated config already carries `conventional-pre-commit` and per-chart helm hooks, this lets `giantswarm/github` delete the static `languages/node/.pre-commit-config.yaml` (added in giantswarm/github#5550) that **clobbered** the generated file — silently dropping `conventional-pre-commit` + helm hooks and injecting the broken eslint hook. That clobber is what blocks giantswarm/backstage#1837.

## Context

Root cause analysis in giantswarm/github#5568. The align-files action runs `devctl gen precommit` and then overwrites its output with the static `languages/node/` template; eliminating the static template removes the double-generation entirely.

## Test plan

- [x] `go test ./pkg/gen/input/precommit/...`
- [x] `devctl gen precommit --language node --repo-name <r> --flavors helmchart` renders base + conventional-pre-commit + prettier + helm hooks, no eslint.

Sibling: `giantswarm/github` (delete static `languages/node/.pre-commit-config.yaml`, bump align-files devctl pin).

Made with [Cursor](https://cursor.com)