### PR TITLE
fix(gen precommit): node emits no prettier/eslint, both are repo-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- `gen precommit`: the generated `.pre-commit-config.yaml` now emits a **node**
-  formatting hook (`rbubley/mirrors-prettier`) when `--language node`. Linting is
-  intentionally omitted — every Giant Swarm node repo lints through its own
-  toolchain (`@backstage/cli`, Next.js, headlamp-plugin) in `node-build`, and a
-  generic eslint hook fails against their legacy `.eslintrc` configs. This makes
-  `devctl gen precommit` the single source of truth for node pre-commit (replacing
-  the static `languages/node/.pre-commit-config.yaml` in `giantswarm/github`, which
-  clobbered the generated `conventional-pre-commit` + per-chart helm hooks and shipped
-  the broken eslint hook).
+- `gen precommit --language node`: emits **no** JS/TS formatting or linting hook
+  (no prettier, no eslint). Both are repo-owned for every Giant Swarm node repo —
+  `@backstage/cli`, Next.js and headlamp-plugin each ship their own prettier/eslint
+  config that resolves only against the repo's installed `node_modules`, so a
+  standalone pre-commit `mirrors-prettier`/`mirrors-eslint` hook hard-fails
+  (`Cannot find package '@backstage/cli'` / `couldn't find eslint.config.js`).
+  Formatting and linting for these repos run in `node-build` (`ci:verify`). Node
+  pre-commit is therefore base hooks + `conventional-pre-commit` + per-chart helm
+  hooks only. This makes `devctl gen precommit` the single source of truth for node
+  pre-commit, replacing the static `languages/node/.pre-commit-config.yaml` in
+  `giantswarm/github` that clobbered the generated `conventional-pre-commit` + helm
+  hooks and shipped a broken eslint hook.
+
+### Added
 
 - `gen circleci`: the generated Node job now honours a per-repo **`resource_class`**
   (reusing the `gen.ci.resourceClass` knob the cli `go-build` job uses), defaulting to

--- a/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
@@ -61,19 +61,6 @@ repos:
       - id: go-imports
         args: [ -local, {{.RepoName}} ]
 {{- end }}
-{{- if eq .Language "node" }}
-
-  # JS/TS formatting. Linting is intentionally omitted: every Giant Swarm node
-  # repo lints through its own toolchain (@backstage/cli, Next.js,
-  # headlamp-plugin) in node-build, and a generic eslint hook fails against
-  # their legacy .eslintrc configs.
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.5
-    hooks:
-      - id: prettier
-        types_or: [javascript, jsx, ts, tsx, json, yaml, css, scss, markdown]
-        exclude: "(^\\.yarn/.*|.*/dist/.*|.*/node_modules/.*)"
-{{- end }}
 {{- if .HasBash }}
 
   # Bash/shell hooks


### PR DESCRIPTION
## Summary

Follow-up to #2068. v8.31.0 added a node `prettier` pre-commit hook, but it fails **identically** to the eslint hook it replaced:

```
[error] Invalid configuration for file ".../index.ts":
[error] Cannot find package '@backstage/cli' imported from .../package.json
```

backstage's prettier config delegates to `@backstage/cli`, which a standalone `mirrors-prettier` pre-commit hook cannot resolve. Every Giant Swarm node repo (`@backstage/cli`, Next.js, headlamp-plugin) ships a bespoke prettier/eslint config that resolves only against the repo's installed `node_modules`, so **no generic pre-commit formatting/linting hook works** for them.

## Change

`gen precommit --language node` now emits **no** JS/TS formatting or linting hook. Node pre-commit = base hooks + `conventional-pre-commit` + per-chart helm hooks. Formatting and linting run in `node-build` (`ci:verify`). This matches backstage's proven-green `main` config.

## Test plan

- [x] `go test ./pkg/gen/input/precommit/...`
- [x] `devctl gen precommit --language node --flavors helmchart` renders base + conventional-pre-commit + helm hooks, no prettier, no eslint.
- [ ] Re-run align for backstage; #1837 `pre-commit` + `node-build` pass.

Refs giantswarm/github#5568, giantswarm/backstage#1837. Follow-up to #2068.

Made with [Cursor](https://cursor.com)