### PR TITLE
fix: enable polex in kyverno for chainsaw tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `gen makefile --language kyverno-policy`: enable PolicyExceptions in all namespaces in the Kyverno installed for chainsaw tests.
 - `gen precommit --language node`: emits **no** JS/TS formatting or linting hook
   (no prettier, no eslint). Both are repo-owned for every Giant Swarm node repo —
   `@backstage/cli`, Next.js and headlamp-plugin each ship their own prettier/eslint

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.chainsaw.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.chainsaw.mk.template
@@ -20,7 +20,10 @@ kind-create: ## create kind cluster if needed
 
 .PHONY: install-kyverno
 install-kyverno:
-	kubectl create -f https://github.com/kyverno/kyverno/releases/download/$(KYVERNO_VERSION)/install.yaml
+	# Install Kyverno, enable PolicyExceptions, allowed in all namespaces so tests can use them
+	curl -sL https://github.com/kyverno/kyverno/releases/download/$(KYVERNO_VERSION)/install.yaml \
+		| sed -E 's/^([[:space:]]*)- --enablePolicyException=false$$/\1- --enablePolicyException=true\n\1- --exceptionNamespace=*/' \
+		| kubectl create -f -
 	# Sometimes the next check executes faster than the deployment show up for the Kube API Server, so we need to wait for a second
 	sleep 5
 	kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kyverno -l app.kubernetes.io/component=admission-controller -n kyverno --timeout 300s


### PR DESCRIPTION
From [Franco's wisdom here](https://github.com/giantswarm/kyverno-policies/pull/382/changes#r3002748712), enables policy exceptions and allows them in all namespaces during chainsaw tests.

### Checklist

- [x] Update changelog in CHANGELOG.md.
