### PR TITLE
fix(gen): document the customer flavour in --help and expand the flavours docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- `docs/flavours.md`: each flavour now documents the files it actually generates, per `gen` command, instead of only describing the repository type. Adds a "which flavour do I need" table, a section on how `--flavour` and `--language` combine (including the `cli` requires `go` rule and common pairings), and the gotchas: `--language` is only validated by `gen makefile` and `gen circleci`, `gen renovate --language` is a different list, and `gen precommit --flavors` is an unrelated flag.
 - `gen makefile --language kyverno-policy`: enable PolicyExceptions in all namespaces in the Kyverno installed for chainsaw tests.
 - `gen precommit --language node`: emits **no** JS/TS formatting or linting hook
   (no prettier, no eslint). Both are repo-owned for every Giant Swarm node repo —

--- a/docs/flavours.md
+++ b/docs/flavours.md
@@ -2,34 +2,128 @@
 
 `devctl` understands different types of GitHub repositories, to make the right modifications for each type. App repos have different needs than Go libraries, for example.
 
-Flavours are not mutually exclusive. Some repos must be configured with multiple flavours. For example, an operator may carry the flavours `app` and `k8sapi`. Note: this configuration is usually persisted in our [repository configuration](https://github.com/giantswarm/github/tree/main/repositories).
+A flavour describes **what kind of project the repository is**. It is passed with `--flavour` (`-f`) and decides which files the `gen` commands write:
 
-The following flavours are understood:
+```nohighlight
+devctl gen workflows --flavour app,customer
+devctl gen makefile --flavour cli --language go
+```
 
-## `app`
+Flavours are not mutually exclusive. Some repos must be configured with multiple flavours -- pass them comma-separated, or repeat the flag. For example, an operator may carry the flavours `app` and `k8sapi`. Note: this configuration is usually persisted in our [repository configuration](https://github.com/giantswarm/github/tree/main/repositories).
 
-An app, by the definition of the Giant Swarm app platform. Each app repository contains at lest one Helm chart.
+The flavour is one of **two independent axes**. The other one is the programming language (`--language`), described in [Flavours and languages](#flavours-and-languages) below. Roughly: the flavour decides the release and packaging plumbing, the language decides the build and test plumbing.
 
-## `cli`
+## Which flavour do I need?
 
-A command line interface (CLI) component which is typically executed on-demand either by a user or within an automation system. CLIs are typically released with downloadable and executable binaries.
+| Flavour | Pick it when the repo... |
+|---------|--------------------------|
+| [`app`](#app) | contains a Helm chart that is published to an app catalog |
+| [`cluster-app`](#cluster-app) | is a cluster app (`cluster-aws`, `cluster-azure`, ...) |
+| [`cli`](#cli) | ships downloadable binaries on its GitHub Release |
+| [`k8sapi`](#k8sapi) | defines a Kubernetes API (CRDs) |
+| [`fleet`](#fleet) | holds GitOps definitions for management clusters |
+| [`customer`](#customer) | tracks issues on a shared customer board |
+| [`generic`](#generic) | is none of the above and just needs to be released |
 
-## `cluster-app`
+`generic` is the neutral choice, not a fallback for "I am not sure": it adds nothing beyond the base files. If a more specific flavour applies, use it -- and add `generic` only when nothing else does.
+
+## Flavour reference
+
+### `app`
+
+An app, by the definition of the Giant Swarm app platform. Each app repository contains at least one Helm chart.
+
+| Command | Result |
+|---------|--------|
+| `gen makefile` | `Makefile.gen.app.mk` -- the `lint-chart`, `update-chart`, `update-deps` and `helm-docs` targets |
+| `gen workflows` | `.github/workflows/zz_generated.check_values_schema.yaml` |
+| `gen workflows --install-update-chart` | additionally `zz_generated.update_chart.yaml`, plus `zz_generated.sync_from_upstream.yaml` with `--upstream-sync-automation` and `zz_generated.dispatch_update_chart_events.yaml` with `--dispatch-update-chart-events-repo` |
+| `gen circleci` | the chart pipeline: `build-chart` / `push-to-app-catalog` jobs and the ATS chart tests |
+
+With `--language kyverno-policy` this flavour also generates `zz_generated.test-kyverno-policies-with-chainsaw.yaml`.
+
+### `cluster-app`
 
 A specific type of app repository which provides a values schema that aims to fulfill the requirements of the [RFC #55](https://github.com/giantswarm/rfc/pull/55).
 
-## `customer`
+| Command | Result |
+|---------|--------|
+| `gen makefile` | `Makefile.gen.cluster_app.mk` |
+| `gen workflows` | `.github/workflows/zz_generated.documentation_validation.yaml`, `zz_generated.json_schema_validation.yaml`, `zz_generated.diff_helm_render_templates.yaml` |
 
-A repository used to track mostly issues and provide project boards, shared with a customer.
+`cluster-app` only adds the schema and documentation validation on top of a chart repo -- it does not generate the chart build and publish pipeline itself. Combine it with `app` (`-f app,cluster-app`) to get both.
 
-## `k8sapi`
+### `cli`
+
+A command line interface (CLI) component which is typically executed on-demand either by a user or within an automation system. CLIs are typically released with downloadable and executable binaries.
+
+| Command | Result |
+|---------|--------|
+| `gen makefile` | `Makefile.gen.go.mk` gains the packaging targets (`package-darwin-amd64`, `package-linux-arm64`, ... writing to `./bin-dist`), plus `.github/zz_generated.windows-code-signing.sh` |
+| `gen circleci` | the `go-build` job builds the full six-architecture matrix (linux, darwin, windows on amd64/arm64) and an `upload-release-assets` job attaches the binaries to the GitHub Release on tag builds |
+
+**Requires `--language go`** -- `gen makefile` rejects any other combination, and the CircleCI binary jobs are only emitted for Go.
+
+Two `gen circleci` flags apply to this flavour only: `--build-concurrency` and `--resource-class`. Lower the first and/or raise the second if the cold cross-compile gets OOM-killed.
+
+### `k8sapi`
 
 A repository that provides a Kubernetes API (usually one or several custom resource definitions).
 
-## `generic`
+| Command | Result |
+|---------|--------|
+| `gen makefile` | `Makefile.gen.k8sapi.mk` (controller-gen based deepcopy/CRD generation), `hack/boilerplate.go.txt` and `hack/.gitignore`; removes the obsolete `Makefile.custom.mk` and `hack/tools/bin/controller-gen` |
+
+### `fleet`
+
+A repository to be used with GitOps containing kubernetes clusters.
+
+| Command | Result |
+|---------|--------|
+| `gen workflows` | `.github/workflows/zz_generated.cluster_app_values_validation_schema.yaml` -- validates the `management-clusters/**/cluster-app-manifests.yaml` committed in the repo against the corresponding cluster app schema |
+
+### `customer`
+
+A repository used to track mostly issues and provide project boards, shared with a customer.
+
+| Command | Result |
+|---------|--------|
+| `gen workflows` | `.github/workflows/zz_generated.add_customer_board_automation.yaml` -- adds new issues to the general customer board |
+
+This flavour is purely about issue tracking. It says nothing about how the repo is built or released, so it is almost always combined with another flavour.
+
+### `generic`
 
 A repository that does not fit any of the more specific flavours above.
 
-## `fleet`
+No flavour-specific files. The repo still gets everything that is not flavour-gated: the base `Makefile`, the release workflows, and whatever the `--language` selects.
 
-A repository to be used with GitOps containing kubernetes clusters.
+## Flavours and languages
+
+`--language` (`-l`) takes exactly **one** value and selects the toolchain:
+
+| Language | Result |
+|----------|--------|
+| `go` | `gen makefile`: `Makefile.gen.go.mk`. `gen circleci`: the `go-build` job. `gen workflows`: `zz_generated.fix_vulnerabilities.yaml`. `gen llm`: `zz_generated.go-llm-rules.mdc`. `gen precommit`: repo name auto-detected from `go.mod` |
+| `node` | `gen circleci`: a `node-build` / `node-test` job on a `cimg/node` executor, tuned with `--package-manager` and the `--node-*` flags. `gen precommit`: a `ci:lint` pre-push hook |
+| `kyverno-policy` | `gen makefile`: `Makefile.gen.chainsaw.mk` and the chainsaw test scaffolding. `gen workflows` (with flavour `app`): `zz_generated.test-kyverno-policies-with-chainsaw.yaml` |
+| `python` | accepted as a valid value, but no generator currently emits Python-specific files |
+| `generic` | no language-specific files |
+
+The two axes combine freely, apart from one rule: **`cli` requires `go`**. Some common pairings:
+
+| Repo | Flags |
+|------|-------|
+| Go operator with a chart | `-f app,k8sapi -l go` |
+| Cluster app | `-f app,cluster-app -l generic` |
+| Go CLI tool | `-f cli -l go` |
+| Kyverno policy chart | `-f app -l kyverno-policy` |
+| Management cluster fleet repo | `-f fleet -l generic` |
+
+### Caveats
+
+- Only `gen makefile` and `gen circleci` validate `--language` against the list above. `gen workflows`, `gen llm` and `gen precommit` accept any string, so a typo such as `-l golang` silently produces output with the language-specific parts missing.
+- `gen makefile` requires both `--flavour` and `--language`; `gen workflows` requires `--flavour`.
+- `gen llm` accepts `--flavour`, but no generated rule currently depends on it. Only `--language go` changes its output.
+- `gen renovate --language` is **not** this list. It names an ecosystem for Renovate to watch (`go`, `docker`, ...).
+- `gen precommit` has its own, unrelated `--flavors` flag (US spelling) with the values `bash`, `md` and `helmchart`. These select extra pre-commit checkers and have nothing to do with repository flavours.


### PR DESCRIPTION
## Problem

`devctl gen makefile --help` and `devctl gen workflows --help` print the supported `--flavour` values **twice**, from two different sources that had drifted apart:

1. The flag usage line — generated from `gen.AllFlavours()`, so always complete (7 values).
2. The command long description — a hand-typed bullet list in `cmd/gen/{makefile,workflows}/command.go`, listing only 6.

When `FlavourCustomer` was added to `pkg/gen/flavour.go`, the flag line picked it up automatically and the prose lists did not. The result: `customer` is a perfectly valid flavour that does something real (it adds the *Add issue to general customer board* workflow, `cmd/gen/workflows/runner.go:109`), but reading the command description you'd conclude it isn't supported. Nothing tied the prose to the constants and no test compared them, so the drift was invisible.

Before:

```
There are different generation flavours:

  - app - project containing a helm chart
  - cli - project released with a downloadable binary
  - generic - everything else, i.e a project which simply needs to be released
  ...
                             ^ no customer

  -f, --flavour flavourSlice   ... Possible values: <app|cli|customer|generic|k8sapi|cluster-app|fleet>
                                                            ^ but it's here
```

## Change

- `pkg/gen/flavour.go`: add `flavourDescriptions` (one entry per flavour) and `FlavourDescriptionList()`, which renders the bullet list from `AllFlavours()`.
- `cmd/gen/{makefile,workflows}/command.go`: drop the hand-typed lists; build `longDescription` from `gen.FlavourDescriptionList()` (`const` → `var`, since it's now computed).
- `pkg/gen/flavour_test.go`: fail if any `AllFlavours()` entry lacks a description, if a described flavour isn't valid, or if a flavour is missing from the rendered list.

Both lists now come from one source and render in the same order, so adding a flavour can't silently leave the help behind.

The `customer` wording is derived from what the flavour actually does — happy to reword.

## Follow-up: `docs/flavours.md`

Fixing the help text surfaced the same gap one level up. `docs/flavours.md` named each repository type but never said what picking it *does*, and never mentioned that `--flavour` and `--language` are two axes you choose together. A one-line "an app, by the definition of the app platform" doesn't help someone decide between `app` and `app,cluster-app`.

The doc now carries, for each flavour, the files it actually generates per `gen` command:

| Flavour | e.g. |
|---------|------|
| `app` | `Makefile.gen.app.mk`, `zz_generated.check_values_schema.yaml`, the CircleCI `build-chart`/`push-to-app-catalog` jobs |
| `cluster-app` | `Makefile.gen.cluster_app.mk`, `zz_generated.documentation_validation.yaml`, `zz_generated.json_schema_validation.yaml`, `zz_generated.diff_helm_render_templates.yaml` |
| `cli` | the `package-*` targets in `Makefile.gen.go.mk`, `.github/zz_generated.windows-code-signing.sh`, the six-arch `go-build` + `upload-release-assets` jobs |
| `k8sapi` | `Makefile.gen.k8sapi.mk`, `hack/boilerplate.go.txt` |
| `fleet` | `zz_generated.cluster_app_values_validation_schema.yaml` |
| `customer` | `zz_generated.add_customer_board_automation.yaml` |
| `generic` | nothing flavour-specific — stated explicitly, since it reads like a fallback and isn't one |

Plus a "which flavour do I need" table, a `--language` section (`go`, `node`, `python`, `generic`, `kyverno-policy` and what each emits), the `cli` requires `go` rule, and a table of common pairings (`-f app,k8sapi -l go` for an operator, `-f app,cluster-app` for a cluster app, …).

It also records three things that are easy to get wrong:

- Only `gen makefile` and `gen circleci` validate `--language` against the enum. `gen workflows`, `gen llm` and `gen precommit` take a plain string, so `-l golang` silently drops the language-specific output rather than erroring.
- `gen renovate --language` is a *different* list — Renovate ecosystems (`go`, `docker`), not this enum.
- `gen precommit --flavors` (US spelling, `bash`/`md`/`helmchart`) is an unrelated flag that selects extra checkers.

Every path and constraint in the doc was read out of the generators rather than inferred.

One thing found while writing it, **not** changed here: `create_release.go:28` passes `IsFlavourCLI` into the template, but `create_release.yaml.template` never reads it. Dead template data — the `cli` flavour has no effect on the release workflow. The doc reflects the real behaviour; happy to drop the unused param in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
