### PR TITLE
feat(release create): derive containerd version from os-tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- `release create`: records the containerd version as a `containerd` component and links it in the release
+  notes. It is derived from the release's `os-tooling` version, since that is the version nodes run rather
+  than the one Flatcar embeds.
 - `gen renovate --language node`: extends the new
   [`lang-node.json5`](https://github.com/giantswarm/renovate-presets/blob/main/lang-node.json5) preset, which
   groups every Node.js version pin (a `.nvmrc`, a Dockerfile `FROM node:`, a `setup-node` step) into one PR.

--- a/pkg/release/bumpall.go
+++ b/pkg/release/bumpall.go
@@ -102,6 +102,10 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 					} else { // minor or major
 						version.Version, err = getLatestFlatcarRelease()
 					}
+				} else if comp.Name == containerdComponentName {
+					// Derived from os-tooling below, never bumped to the latest upstream
+					// release: nodes run whatever image-builder baked into the image.
+					version.Version = comp.Version
 				} else {
 					// For minor releases, add an implicit constraint to prevent major version jumps.
 					// Users can still force a major bump via --component flag.
@@ -150,6 +154,21 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 					Version:       req.Version,
 					UserRequested: true,
 				}
+			}
+		}
+
+		// Derive containerd from the os-tooling version this release ends up with, so the
+		// recap table shows it alongside everything else that changes. The version itself is
+		// applied when the release is written, not returned as a bump below.
+		osToolingVersion := lookupComponentVersion(input.Spec.Components, osToolingComponentName)
+		if bumped, found := components[osToolingComponentName]; found {
+			osToolingVersion = bumped.Version
+		}
+
+		containerdVersion := deriveContainerdVersion(osToolingVersion)
+		if containerdVersion != "" && containerdVersion != lookupComponentVersion(input.Spec.Components, containerdComponentName) {
+			components[containerdComponentName] = componentVersion{
+				Version: containerdVersion,
 			}
 		}
 	}
@@ -319,6 +338,11 @@ func BumpAll(input v1alpha1.Release, manuallyRequestedComponents []string, manua
 	appsRet := make([]string, 0)
 
 	for name, comp := range components {
+		if name == containerdComponentName {
+			// Shown in the table above, but derived again from os-tooling when the release is
+			// written rather than carried through as a requested bump.
+			continue
+		}
 		componentsRet = append(componentsRet, fmt.Sprintf("%s@%s", name, comp.Version))
 	}
 	for name, app := range apps {

--- a/pkg/release/changelog/changelog.go
+++ b/pkg/release/changelog/changelog.go
@@ -435,6 +435,11 @@ var KnownComponents = map[string]ParseParams{
 		Start:     commonStartPattern,
 		End:       commonEndPattern,
 	},
+	"containerd": {
+		// containerd keeps its release notes on the GitHub release rather than in a
+		// CHANGELOG we could parse, so only the tag URL is used.
+		Tag: "https://github.com/containerd/containerd/releases/tag/v{{.Version}}",
+	},
 }
 
 // GetRepoName extracts the repository name for a given component from its tag URL.
@@ -480,6 +485,16 @@ func ParseChangelog(componentName, currentVersion, endVersion string, extraFilte
 	params, ok := KnownComponents[componentName]
 	if !ok {
 		return nil, microerror.Mask(fmt.Errorf("unknown component: %s", componentName))
+	}
+
+	if componentName == "containerd" {
+		// containerd is derived from the image-builder release our os-tooling version pins,
+		// and has no CHANGELOG in the format parsed below. Link to the release and stop.
+		return &Version{
+			Name:    currentVersion,
+			Link:    strings.Replace(params.Tag, "{{.Version}}", currentVersion, 1),
+			Content: "",
+		}, nil
 	}
 
 	if componentName == "flatcar" {

--- a/pkg/release/containerd.go
+++ b/pkg/release/containerd.go
@@ -1,0 +1,174 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/releases/sdk/api/v1alpha1"
+	"github.com/google/go-github/v90/github"
+	"github.com/sirupsen/logrus"
+
+	"github.com/giantswarm/devctl/v8/internal/env"
+)
+
+const (
+	containerdComponentName = "containerd"
+	osToolingComponentName  = "os-tooling"
+
+	osToolingOwner = "giantswarm"
+	osToolingRepo  = "capi-image-builder"
+
+	// imageBuilderContainerdConfigURL points at the upstream packer config that defines the
+	// containerd version installed into /opt/bin on every node.
+	imageBuilderContainerdConfigURL = "https://raw.githubusercontent.com/kubernetes-sigs/image-builder/%s/images/capi/packer/config/containerd.json"
+)
+
+// imageBuilderVersionRegexp matches the upstream image-builder pin in the capi-image-builder
+// Dockerfile, e.g. `ARG IMAGE_BUILDER_VERSION=v0.1.55`.
+var imageBuilderVersionRegexp = regexp.MustCompile(`(?m)^ARG\s+IMAGE_BUILDER_VERSION=(\S+)`)
+
+// containerdVersionCache keeps the two lookups below to one round trip per os-tooling version.
+var containerdVersionCache = map[string]string{}
+
+// findContainerdVersion resolves the containerd version baked into our node images for a given
+// os-tooling (capi-image-builder) version.
+//
+// Node images are built by giantswarm/capi-image-builder, which pins an upstream
+// kubernetes-sigs/image-builder version in its Dockerfile. That upstream release carries the
+// containerd version in its packer config, and that is the version nodes actually run — it
+// differs from the one Flatcar embeds, which is why it is worth recording in the release.
+func findContainerdVersion(osToolingVersion string) (string, error) {
+	if cached, ok := containerdVersionCache[osToolingVersion]; ok {
+		return cached, nil
+	}
+
+	imageBuilderVersion, err := findImageBuilderVersion(osToolingVersion)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	url := fmt.Sprintf(imageBuilderContainerdConfigURL, imageBuilderVersion)
+	response, err := client.Get(url)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		return "", microerror.Maskf(executionFailedError, "unexpected status %d fetching %s", response.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	var config struct {
+		ContainerdVersion string `json:"containerd_version"`
+	}
+	err = json.Unmarshal(body, &config)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	if config.ContainerdVersion == "" {
+		return "", microerror.Maskf(executionFailedError, "no containerd_version found in %s", url)
+	}
+
+	containerdVersionCache[osToolingVersion] = config.ContainerdVersion
+
+	return config.ContainerdVersion, nil
+}
+
+// findImageBuilderVersion reads the upstream image-builder version pinned by the given
+// capi-image-builder release. The repository is private, so this goes through the API rather
+// than raw.githubusercontent.com.
+func findImageBuilderVersion(osToolingVersion string) (string, error) {
+	client, err := github.NewClient(github.WithAuthToken(env.GitHubToken.Val()))
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	opts := &github.RepositoryContentGetOptions{Ref: fmt.Sprintf("v%s", osToolingVersion)}
+	reader, _, err := client.Repositories.DownloadContents(context.Background(), osToolingOwner, osToolingRepo, "Dockerfile", opts)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	dockerfile, err := io.ReadAll(reader)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	match := imageBuilderVersionRegexp.FindSubmatch(dockerfile)
+	if match == nil {
+		return "", microerror.Maskf(executionFailedError, "no IMAGE_BUILDER_VERSION found in %s/%s Dockerfile at v%s", osToolingOwner, osToolingRepo, osToolingVersion)
+	}
+
+	return string(match[1]), nil
+}
+
+// deriveContainerdVersion returns the containerd version implied by the given os-tooling
+// version. An empty os-tooling version yields an empty result: providers that do not build
+// their own node images (AKS) have no os-tooling component and therefore no containerd entry.
+//
+// A lookup failure is not fatal. The version is informational, and a release should not fail
+// to be created because a tag is missing or GitHub is briefly unavailable.
+func deriveContainerdVersion(osToolingVersion string) string {
+	if osToolingVersion == "" {
+		return ""
+	}
+
+	version, err := findContainerdVersion(osToolingVersion)
+	if err != nil {
+		logrus.Warnf("Could not determine containerd version for os-tooling v%s: %v", osToolingVersion, err)
+		return ""
+	}
+
+	return version
+}
+
+// applyContainerdComponent records the containerd version that comes with the release's
+// os-tooling version as a component of its own, so it shows up in the Release CR and the
+// release notes.
+//
+// The version is always derived here and never requested: it is a property of the node image,
+// so anything else would record a version no node runs.
+func applyContainerdComponent(updates *v1alpha1.Release, base v1alpha1.Release, verbose bool) {
+	osToolingVersion := lookupComponentVersion(updates.Spec.Components, osToolingComponentName)
+	if osToolingVersion == "" {
+		osToolingVersion = lookupComponentVersion(base.Spec.Components, osToolingComponentName)
+	}
+
+	containerdVersion := deriveContainerdVersion(osToolingVersion)
+	if containerdVersion == "" {
+		return
+	}
+
+	if verbose {
+		fmt.Printf("Derived containerd v%s from os-tooling v%s\n", containerdVersion, osToolingVersion)
+	}
+
+	updates.Spec.Components = append(updates.Spec.Components, v1alpha1.ReleaseSpecComponent{
+		Name:    containerdComponentName,
+		Version: containerdVersion,
+	})
+}
+
+func lookupComponentVersion(components []v1alpha1.ReleaseSpecComponent, name string) string {
+	for _, component := range components {
+		if component.Name == name {
+			return component.Version
+		}
+	}
+
+	return ""
+}

--- a/pkg/release/containerd_test.go
+++ b/pkg/release/containerd_test.go
@@ -1,0 +1,94 @@
+package release
+
+import (
+	"testing"
+
+	"github.com/giantswarm/releases/sdk/api/v1alpha1"
+)
+
+func TestImageBuilderVersionRegexp(t *testing.T) {
+	testCases := []struct {
+		name       string
+		dockerfile string
+		expected   string
+	}{
+		{
+			name: "case 0: pin as written in capi-image-builder",
+			dockerfile: `# repo: kubernetes-sigs/image-builder
+ARG IMAGE_BUILDER_VERSION=v0.1.55
+
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.26-alpine as builder
+`,
+			expected: "v0.1.55",
+		},
+		{
+			name:       "case 1: no v prefix",
+			dockerfile: "ARG IMAGE_BUILDER_VERSION=0.1.48\n",
+			expected:   "0.1.48",
+		},
+		{
+			name:       "case 2: the later reference does not match",
+			dockerfile: "FROM registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:${IMAGE_BUILDER_VERSION}\n",
+			expected:   "",
+		},
+		{
+			name:       "case 3: no pin at all",
+			dockerfile: "FROM alpine:3.20\n",
+			expected:   "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := imageBuilderVersionRegexp.FindStringSubmatch(tc.dockerfile)
+
+			actual := ""
+			if match != nil {
+				actual = match[1]
+			}
+
+			if actual != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestLookupComponentVersion(t *testing.T) {
+	components := []v1alpha1.ReleaseSpecComponent{
+		{Name: "cluster-aws", Version: "7.7.3"},
+		{Name: "os-tooling", Version: "1.33.1"},
+	}
+
+	if actual := lookupComponentVersion(components, "os-tooling"); actual != "1.33.1" {
+		t.Fatalf("expected 1.33.1, got %q", actual)
+	}
+	if actual := lookupComponentVersion(components, "containerd"); actual != "" {
+		t.Fatalf("expected empty version for a missing component, got %q", actual)
+	}
+}
+
+// A release without os-tooling has no node image we build, so there is nothing to derive and
+// applyContainerdComponent must not reach out to GitHub. That makes this safe to assert offline.
+func TestApplyContainerdComponentWithoutOSTooling(t *testing.T) {
+	// AKS uses provider-managed node images and has no os-tooling component.
+	updates := v1alpha1.Release{
+		Spec: v1alpha1.ReleaseSpec{
+			Components: []v1alpha1.ReleaseSpecComponent{{Name: "kubernetes", Version: "1.35.7"}},
+		},
+	}
+	base := v1alpha1.Release{
+		Spec: v1alpha1.ReleaseSpec{
+			Components: []v1alpha1.ReleaseSpecComponent{{Name: "cluster-aks", Version: "0.5.0"}},
+		},
+	}
+
+	applyContainerdComponent(&updates, base, false)
+
+	if version := lookupComponentVersion(updates.Spec.Components, containerdComponentName); version != "" {
+		t.Fatalf("expected no containerd component, got %q", version)
+	}
+	if len(updates.Spec.Components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(updates.Spec.Components))
+	}
+}

--- a/pkg/release/create.go
+++ b/pkg/release/create.go
@@ -287,6 +287,14 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		}
 	}
 
+	// containerd always follows the os-tooling version, so setting it by hand would only
+	// record a version no node runs.
+	for _, componentVersion := range components {
+		if strings.Split(componentVersion, "@")[0] == containerdComponentName {
+			return microerror.Maskf(invalidItemTypeError, "'%s' is derived from the release's %s version and cannot be set directly.\nBump %s instead: --component %s@<version>", containerdComponentName, osToolingComponentName, osToolingComponentName, osToolingComponentName)
+		}
+	}
+
 	if bumpall {
 		if verbose {
 			fmt.Println("Requested automated bumping of all components and apps.")
@@ -427,6 +435,11 @@ func CreateRelease(name, base, releases, provider string, components, apps []str
 		})
 
 	}
+
+	// containerd is not bumped on its own: it comes from whichever upstream image-builder the
+	// release's os-tooling version pins, so it is derived from that rather than requested.
+	applyContainerdComponent(&updatesRelease, effectiveBaseRelease, verbose)
+
 	newRelease := mergeReleases(effectiveBaseRelease, updatesRelease)
 
 	// Rewrite catalogs to their test variants for apps/components carrying development

--- a/pkg/release/error.go
+++ b/pkg/release/error.go
@@ -51,3 +51,8 @@ func IsGithubNotFound(err error) bool {
 var fileNotFoundError = &microerror.Error{
 	Kind: "fileNotFoundError",
 }
+
+// Indicates that an external lookup returned something we cannot work with.
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}

--- a/pkg/release/release_notes.go
+++ b/pkg/release/release_notes.go
@@ -22,12 +22,16 @@ const releaseNotesTemplate = `# :zap: Giant Swarm Release {{ .Name }} for {{ .Pr
 {{ if .Components }}
 ### Components
 {{ range .Components }}
-{{- if eq .PreviousVersion "" }}
+{{- if and (eq .PreviousVersion "") (eq .Name "containerd") }}
+- Added containerd [v{{ .Version }}]({{ .Link }})
+{{- else if eq .PreviousVersion "" }}
 - Added {{ .Name }} v{{ .Version }}
 {{- else if eq .Name "kubernetes" }}
 - Kubernetes from v{{ .PreviousVersion }} to [v{{ .Version }}]({{ .Link }})
 {{- else if eq .Name "flatcar" }}
 - Flatcar from v{{ .PreviousVersion }} to [v{{ .Version }}]({{ .Link }})
+{{- else if eq .Name "containerd" }}
+- containerd from v{{ .PreviousVersion }} to [v{{ .Version }}]({{ .Link }})
 {{- else }}
 - {{ .Name }} from v{{ .PreviousVersion }} to v{{ .Version }}
 {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/37070

Records the containerd version as a `containerd` component in the Release CR and links it
in the release notes.

The version is derived from the release's `os-tooling` version: capi-image-builder pins an
upstream kubernetes-sigs/image-builder release, whose packer config carries the containerd
version installed into `/opt/bin` on every node. That is the version nodes actually run, and
it differs from the one Flatcar embeds.

containerd is never requested, only derived: it is a property of the node image, so
`--component containerd@<version>` is rejected and points at os-tooling instead. Providers
without an `os-tooling` component (AKS) are unaffected.