### PR TITLE
fix(gen): scan built deps, not the whole module graph, with nancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- `gen makefile` (Go flavour): the `nancy` target scans `go list -json -deps ./...` again instead of
+  `go list -json -m all`, so it reports vulnerabilities only in packages actually compiled into the
+  module. `-m all` walks the whole module graph and flags modules that are never built: on
+  `team-stamper` it reported 7 vulnerable modules of which 5 are absent from the build, including
+  `golang.org/x/crypto` and the 13 CVEs attributed to it. #680 adopted `-deps ./...` for precisely
+  this reason in 2023; #1964 reverted to `-m all` in June only to work around nancy's 10 MB stdin
+  cap, which nancy had introduced days earlier in v2.0.0 and then made configurable, defaulting to
+  100 MB, in [v2.1.0](https://github.com/sonatype-nexus-community/nancy/releases/tag/v2.1.0) six
+  days later. The cap that motivated the workaround is therefore gone: `cluster-standup-teardown`,
+  the repository that hit it, emits 12 MB, and CI already runs nancy 2.1.0. The target's doc comment
+  now says v2.1.0 rather than v1.0.37.
+
 - devctl's own Renovate config: the `cimg/node` version baked into `gen circleci` was never actually
   tracked. The constant carries a `// renovate: datasource=docker depName=cimg/node` annotation, but the
   custom manager in `renovate-custom.json5` is anchored on `const \w*OrbVersion`, which never matched

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -2,7 +2,7 @@
 #
 #    devctl
 #
-#    https://github.com/giantswarm/devctl/blob/0ec3e49745962245bdd6d5c282d4272c40faec37/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+#    https://github.com/giantswarm/devctl/blob/7b83cf71e3ee7010ba57524ef43ad754c883f486/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
 #
 
 PACKAGE_DIR    := ./bin-dist
@@ -156,10 +156,17 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# `-deps ./...` lists only the packages actually compiled into this module, so nancy
+# reports vulnerabilities in code we really ship. `-m all` walks the entire module
+# graph instead and flags modules that are never built: on team-stamper it reported 7
+# vulnerable modules of which 5 are not in the build at all, including golang.org/x/crypto
+# and its 13 CVEs. #680 moved to `-deps ./...` for exactly this reason; #1964 moved back
+# to `-m all` only to dodge nancy's 10 MB stdin cap, which nancy made configurable and
+# defaulted to 100 MB in v2.1.0 -- so the workaround costs accuracy for nothing.
 .PHONY: nancy
-nancy: ## Runs nancy (requires v1.0.37 or newer).
+nancy: ## Runs nancy (requires v2.1.0 or newer).
 	@echo "====> $@"
-	CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
+	CGO_ENABLED=0 go list -json -deps ./... | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
 # Race detector needs a C toolchain. The architect CI image has none and runs
 # with CGO_ENABLED=0, so degrade to cgo-free there; everywhere a compiler exists

--- a/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
+++ b/pkg/gen/input/makefile/internal/file/Makefile.gen.go.mk.template
@@ -159,10 +159,17 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# `-deps ./...` lists only the packages actually compiled into this module, so nancy
+# reports vulnerabilities in code we really ship. `-m all` walks the entire module
+# graph instead and flags modules that are never built: on team-stamper it reported 7
+# vulnerable modules of which 5 are not in the build at all, including golang.org/x/crypto
+# and its 13 CVEs. #680 moved to `-deps ./...` for exactly this reason; #1964 moved back
+# to `-m all` only to dodge nancy's 10 MB stdin cap, which nancy made configurable and
+# defaulted to 100 MB in v2.1.0 -- so the workaround costs accuracy for nothing.
 .PHONY: nancy
-nancy: ## Runs nancy (requires v1.0.37 or newer).
+nancy: ## Runs nancy (requires v2.1.0 or newer).
 	@echo "====> $@"
-	CGO_ENABLED=0 go list -json -m all | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
+	CGO_ENABLED=0 go list -json -deps ./... | nancy sleuth --skip-update-check --quiet --exclude-vulnerability-file ./.nancy-ignore --additional-exclude-vulnerability-files ./.nancy-ignore.generated
 
 # Race detector needs a C toolchain. The architect CI image has none and runs
 # with CGO_ENABLED=0, so degrade to cgo-free there; everywhere a compiler exists


### PR DESCRIPTION
## Problem

The generated Go `nancy` target pipes `go list -json -m all` into nancy. That walks the **entire module graph**, so it reports vulnerabilities in modules that are never compiled into the binary.

Measured on `team-stamper` — of the 7 vulnerable modules nancy reports, **5 are absent from `go list -deps ./...` entirely**:

| Module | In the build? |
|---|---|
| `golang.org/x/net` | built |
| `golang.org/x/text` | built |
| `golang.org/x/crypto` | **graph only** — and 13 of the reported CVEs are attributed to it |
| `github.com/yuin/goldmark` | **graph only** |
| `go.opentelemetry.io/otel` | **graph only** |
| `go.opentelemetry.io/otel/sdk` | **graph only** |
| `github.com/klauspost/compress` | **graph only** |

On devctl itself: 75 modules are built, the graph has 155 — so **80 modules stop being scanned**.

## Why it regressed

This isn't new ground. #680 ("Prevent false positives from nancy", 2023) adopted `-deps ./...` for exactly this reason. #1964 reverted to `-m all` in June — but reading it, that wasn't a security decision:

> Building `cluster-standup-teardown` started to give me the following error:
> `Error: stdin input exceeded 10 MB limit; ensure you are piping valid 'go list' output`
> According to Claude, Nancy does also work with `go list -json -m all`, which produces a much smaller output.

So the goal was smaller output, and accuracy was the unintended cost.

## Why the workaround is now unnecessary

The 10 MB cap was short-lived upstream:

| Date | Nancy change |
|---|---|
| 2026-05-15 | `e3a0439e` caps stdin at 10 MB (ships in **v2.0.0**) |
| 2026-06-11 | devctl #1964 works around it |
| 2026-06-17 | `78d63366` adds `--max-input-size`, default **100 MB** (ships in **v2.1.0**) |

Six days after the workaround, the constraint became configurable and 100× larger. Verified it doesn't bite:

- `cluster-standup-teardown` — the repository that hit the cap — emits **12 MB**. Over the old 10 MB, comfortably under 100 MB.
- devctl itself emits **2.0 MB**.
- **CI already runs nancy 2.1.0** — confirmed from the `utm_content=2.1.0` parameter nancy puts in its OSS Index URLs in CircleCI logs.

I deliberately did *not* add `--max-input-size` explicitly: the default already covers the largest known repo, and passing the flag would hard-require v2.1.0 for anyone running `make nancy` locally with an older nancy. The doc comment is updated from the stale `v1.0.37` to `v2.1.0` instead.

## Verification

- `go generate ./...` then `go build ./...` and `go test ./pkg/gen/...` — all pass.
- `Makefile.gen.go.mk` regenerated with the real generator (`devctl gen makefile --flavour cli --language go`), not hand-edited, so its provenance header is correct. I reverted the two unrelated provenance-only header bumps the generator also produced (`Makefile`, `.github/zz_generated.windows-code-signing.sh`) to keep the diff focused.
- `make -n nancy` renders the intended command.
- The explanatory comment sits above the target rather than inside the recipe, so make strips it instead of echoing it into every CI log.

## What this does and doesn't fix

It removes false positives. It does **not** patch real vulnerabilities.

Context: this came out of 10 blocked align PRs in Honey Badger. 7 of them turned green simply by updating their stale align branches from `main`, where Renovate had already patched the CVEs — so this template was never their problem. The 3 that remain (`team-stamper`, `cluster-apps-operator`, `konfigure-operator`) have genuinely vulnerable *built* dependencies as well, and still need their pending Renovate dependency PRs merged. This change means they'll be judged on those real findings instead of on `x/crypto` CVEs from code they don't ship.
