### PR TITLE
feat(gen/circleci): add --skip-app-catalog for charts that must stay private

### DIFF
--- a/cmd/gen/circleci/flag.go
+++ b/cmd/gen/circleci/flag.go
@@ -23,6 +23,7 @@ const (
 	flagImagePlatforms   = "image-platforms"
 	flagImageDockerfile  = "image-dockerfile"
 	flagResourceClass    = "resource-class"
+	flagSkipAppCatalog   = "skip-app-catalog"
 	flagSkipATS          = "skip-ats"
 	flagFlavour          = "flavour"
 	flagLanguage         = "language"
@@ -47,6 +48,7 @@ type flag struct {
 	ImagePlatforms   string
 	ImageDockerfile  string
 	ResourceClass    string
+	SkipAppCatalog   bool
 	SkipATS          bool
 	Flavours         gen.FlavourSlice
 	Language         gen.Language
@@ -71,6 +73,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ImagePlatforms, flagImagePlatforms, "", "Override the buildx platform list on the image jobs (push-to-registries `platforms` param). Empty lets the orb default apply (linux/amd64,linux/arm64 when no go-build .platforms file). Set it for single-architecture images (e.g. vllm -> linux/arm64, whose amd64 build has no prebuilt wheels).")
 	cmd.Flags().StringVar(&f.ImageDockerfile, flagImageDockerfile, "", "Override the Dockerfile path on the image jobs (push-to-registries `dockerfile` param). Set it for repos whose Dockerfile is not at the repo root (e.g. backstage -> packages/backend/Dockerfile); a non-empty value also turns the image pipeline on, since the root-Dockerfile derivation misses a nested Dockerfile. The append-only custom.yml merge cannot set this on a generated job. Empty keeps the orb default.")
 	cmd.Flags().StringVar(&f.ResourceClass, flagResourceClass, "", `Override the CircleCI resource_class on the cli-flavour go-build job. Empty defaults to "large". Raise it (e.g. "xlarge") for repos that need more RAM/CPU headroom for the cold cross-compile. Only applies to the cli flavour.`)
+	cmd.Flags().BoolVar(&f.SkipAppCatalog, flagSkipAppCatalog, false, "Do not publish the chart to a GitHub app catalog (push-to-app-catalog push_to_appcatalog: false); the OCI registry push is kept. Every GitHub app catalog is a public repository, so a private chart published to one is world-readable. Set it for private charts that must stay private: the chart then ships only to gsociprivate.azurecr.io, which Flux consumes via an OCIRepository. Only applies to the app flavour.")
 	cmd.Flags().BoolVar(&f.SkipATS, flagSkipATS, false, `Opt the chart pipeline out of app-test-suite (ATS) chart tests. By default an "app" flavour repo runs architect/run-tests-with-ats between build-chart and the chart push, and generation emits the canonical tests/ats/Pipfile. When set, those test jobs and the Pipfile are not generated and the chart push gates directly on build-chart. Only applies to the app flavour.`)
 	cmd.Flags().VarP(gen.NewFlavourSliceFlagValue(&f.Flavours, gen.FlavourSlice{}), flagFlavour, "f", fmt.Sprintf(`List of project flavours. The "app" flavour selects the chart pipeline. Possible values: <%s>`, strings.Join(gen.AllFlavours(), "|")))
 	cmd.Flags().VarP(gen.NewLanguageFlagValue(&f.Language, gen.Language("")), flagLanguage, "l", fmt.Sprintf(`The programming language. "go" selects the go-build job. Possible values: <%s>`, strings.Join(gen.AllLanguages(), "|")))

--- a/cmd/gen/circleci/runner.go
+++ b/cmd/gen/circleci/runner.go
@@ -76,6 +76,7 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 			RepoName:         r.flag.RepoName,
 			Language:         r.flag.Language,
 			Flavours:         r.flag.Flavours,
+			SkipAppCatalog:   r.flag.SkipAppCatalog,
 			SkipATS:          r.flag.SkipATS,
 			HasDockerfile:    hasDockerfile,
 			AppCatalog:       r.flag.AppCatalog,

--- a/pkg/gen/input/circleci/circleci.go
+++ b/pkg/gen/input/circleci/circleci.go
@@ -207,6 +207,14 @@ type Config struct {
 	// Flavours are the devctl gen flavours. The "app" flavour selects the
 	// chart pipeline.
 	Flavours gen.FlavourSlice
+	// SkipAppCatalog drops the GitHub app catalog push from the chart pipeline
+	// (push-to-app-catalog push_to_appcatalog: false), keeping the OCI registry
+	// push. Every GitHub app catalog is a public repository, so a private chart
+	// published to one is world-readable regardless of the source repo's
+	// visibility. Set it for private charts that must stay private: the chart
+	// then ships only to gsociprivate.azurecr.io, which Flux consumes via an
+	// OCIRepository. Only applies to a chart/app repo (the "app" flavour).
+	SkipAppCatalog bool
 	// SkipATS opts the chart pipeline out of app-test-suite (ATS) chart tests.
 	// When set, the run-tests-with-ats jobs and the canonical tests/ats/Pipfile
 	// are not generated, and the chart push jobs gate directly on build-chart.
@@ -468,6 +476,7 @@ func New(config Config) (*CircleCI, error) {
 			Language:                 config.Language.String(),
 			HasDockerfile:            hasDockerfile,
 			HasApp:                   hasApp,
+			SkipAppCatalog:           config.SkipAppCatalog,
 			SkipATS:                  config.SkipATS,
 			ChartName:                chartName,
 			ForcePublic:              config.ForcePublic,

--- a/pkg/gen/input/circleci/circleci_test.go
+++ b/pkg/gen/input/circleci/circleci_test.go
@@ -923,6 +923,57 @@ func Test_BranchPublishOnAddsCoupledBranchPushes(t *testing.T) {
 	}
 }
 
+// Test_SkipAppCatalogOffKeepsCatalogPush verifies the default: the chart
+// publish jobs push to a GitHub app catalog, so push_to_appcatalog is left at
+// the orb's default and never emitted.
+func Test_SkipAppCatalogOffKeepsCatalogPush(t *testing.T) {
+	got := render(t, Config{
+		RepoName:       repoMCPKubernetes,
+		Language:       gen.LanguageGo,
+		Flavours:       gen.FlavourSlice{gen.FlavourApp},
+		BranchPublish:  true,
+		SkipAppCatalog: false,
+	})
+
+	// build-chart is push-less by construction and always carries the flag;
+	// the two publish jobs must not.
+	if want := 1; strings.Count(got, "push_to_appcatalog: false") != want {
+		t.Errorf("default config should carry push_to_appcatalog: false exactly %d time (build-chart only):\n%s", want, got)
+	}
+}
+
+// Test_SkipAppCatalogOnDropsCatalogPush verifies the opt-in: both the branch
+// and the tag chart publish jobs disable the GitHub app catalog push, leaving
+// the OCI registry push as the only destination. Every GitHub app catalog is a
+// public repository, so this is what keeps a private chart private.
+func Test_SkipAppCatalogOnDropsCatalogPush(t *testing.T) {
+	got := render(t, Config{
+		RepoName:       repoMCPKubernetes,
+		Language:       gen.LanguageGo,
+		Flavours:       gen.FlavourSlice{gen.FlavourApp},
+		BranchPublish:  true,
+		SkipAppCatalog: true,
+	})
+
+	// build-chart plus both publish jobs.
+	if want := 3; strings.Count(got, "push_to_appcatalog: false") != want {
+		t.Errorf("skip-app-catalog config should carry push_to_appcatalog: false exactly %d times:\n%s", want, got)
+	}
+	// The OCI push must survive -- it is the only remaining destination, and
+	// the private one. Only build-chart, which pushes nothing, disables it.
+	if want := 1; strings.Count(got, "push_to_oci_registry: false") != want {
+		t.Errorf("skip-app-catalog should leave the OCI push enabled on the publish jobs, disabling it exactly %d time (build-chart only):\n%s", want, got)
+	}
+	for _, want := range []string{
+		"name: push-chart\n",
+		"name: push-chart-release",
+	} {
+		if !contains(got, want) {
+			t.Errorf("skip-app-catalog config missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // Test_NoCLIOmitsReleaseBinaries verifies the default: a Go service/chart repo
 // without the cli flavour carries no architectures matrix, no
 // upload-release-assets job, and no platforms cap on the release image push.

--- a/pkg/gen/input/circleci/internal/file/config.go
+++ b/pkg/gen/input/circleci/internal/file/config.go
@@ -42,6 +42,7 @@ func NewWorkflowsInput(p params.Params) input.Input {
 			"Language":         p.Language,
 			"HasDockerfile":    p.HasDockerfile,
 			"HasApp":           p.HasApp,
+			"SkipAppCatalog":   p.SkipAppCatalog,
 			"SkipATS":          p.SkipATS,
 			"ChartName":        p.ChartName,
 			"ForcePublic":      p.ForcePublic,

--- a/pkg/gen/input/circleci/internal/file/workflows.yml.template
+++ b/pkg/gen/input/circleci/internal/file/workflows.yml.template
@@ -388,6 +388,11 @@ workflows:
         app_catalog: {{ .AppCatalog }}
         app_catalog_test: {{ .AppCatalogTest }}
         chart: {{ .ChartName }}
+{{- if .SkipAppCatalog }}
+        # Private chart: every GitHub app catalog is a public repository, so the
+        # chart ships only to gsociprivate. The catalog params above are inert.
+        push_to_appcatalog: false
+{{- end }}
         requires:
 {{- if .SkipATS }}
         - build-chart
@@ -417,6 +422,11 @@ workflows:
         app_catalog: {{ .AppCatalog }}
         app_catalog_test: {{ .AppCatalogTest }}
         chart: {{ .ChartName }}
+{{- if .SkipAppCatalog }}
+        # Private chart: every GitHub app catalog is a public repository, so the
+        # chart ships only to gsociprivate. The catalog params above are inert.
+        push_to_appcatalog: false
+{{- end }}
         requires:
 {{- if .SkipATS }}
         - build-chart

--- a/pkg/gen/input/circleci/internal/params/params.go
+++ b/pkg/gen/input/circleci/internal/params/params.go
@@ -47,6 +47,12 @@ type Params struct {
 	// push-to-app-catalog `app_catalog_test` param). Defaults to
 	// "giantswarm-test-catalog". Kept paired with AppCatalog.
 	AppCatalogTest string
+	// SkipAppCatalog is true when the chart must not be published to a GitHub
+	// app catalog (push-to-app-catalog push_to_appcatalog: false), keeping the
+	// OCI registry push. Every GitHub app catalog is a public repository, so a
+	// private chart published to one is world-readable; when set, the chart
+	// ships only to gsociprivate.azurecr.io.
+	SkipAppCatalog bool
 	// BranchPublish is true when the repo opts into publishing a dev image and
 	// chart on branch builds. By default branches build + test only; when set,
 	// the branch path additionally pushes an amd64 dev image and the dev chart


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/37438

### What this PR does / why we need it

**Every GitHub app catalog is a public repository**, and `push-to-app-catalog`'s `push_to_appcatalog` defaults to `true`. So a chart built from a *private* repo is published world-readable, and there is currently no way to opt out.

This is not hypothetical. `pagerduty-config` is a private repository, and its chart is downloadable anonymously today:

```
$ curl -sS -o /dev/null -w '%{http_code} %{size_download}\n' \
    https://giantswarm.github.io/control-plane-catalog/pagerduty-config-0.13.1.tgz
200 15425
$ tar tzf pagerduty-config-0.13.1.tgz | grep integrations
pagerduty-config/templates/integrations/adidas.yaml
...
```

Customer names, team schedules and users, in a public catalog, from a private repo.

`gen.ci` offers no escape: `appCatalog` and `appCatalogTest` both name a public repository, and `.circleci/custom.yml` cannot help either — the `yq *+` merge appends to the job list and cannot amend a generated job.

### The knob

`--skip-app-catalog` (`gen.ci.skipAppCatalog`) sets `push_to_appcatalog: false` on the branch and tag chart publish jobs and keeps the OCI registry push. Per architect-orb, that resolves to `gsociprivate.azurecr.io/charts/giantswarm` for a private repo, which is exactly what Flux consumes through an `OCIRepository`. So the chart stays private **and** stays deployable.

Default is off, so nothing changes for existing repos.

### Motivation

`alerting-config` is a new private chart holding Giant Swarm's Alertmanager routing — team Slack channels, the EU PagerDuty endpoint — being moved out of the public `observability-operator` repository. Publishing it to a public catalog would defeat the entire point of the move.

### Testing

`go test ./pkg/gen/input/circleci/` passes, `gofmt` clean. Two new tests: default keeps the catalog push (the flag appears once, on the push-less `build-chart`), and the opt-in drops it on both publish jobs while leaving `push_to_oci_registry` enabled.

A companion PR in `giantswarm/github` adds the `gen.ci.skipAppCatalog` field and its mapping, and needs this released first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)