### PR TITLE
fix(precommit): bump golangci-lint to 2.13.1 and setup-go to 1.27

### DIFF
--- a/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go environment
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26"
+          go-version: "1.27"
       - name: Install goimports
         run: |
           go install golang.org/x/tools/cmd/goimports@v0.48.0
@@ -55,7 +55,7 @@ jobs:
         uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: golangci-lint
-          version: "2.12.2"
+          version: "2.13.1"
           download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/${binary}-${version}-linux-amd64.tar.gz"
 [[- end ]]
       - name: Execute pre-commit hooks


### PR DESCRIPTION
## Problem

`golangci-lint` 2.12.2 is built with `go1.26` and refuses to load a config whose targeted Go version is newer:

```
Error: can't load config: the Go language version (go1.26) used to build golangci-lint
is lower than the targeted Go version (1.27.0)
```

Every repo consuming the generated `zz_generated.pre-commit.yaml` therefore fails the `pre-commit` job on Renovate's `chore(deps): update go toolchain directive to v1.27.0` PR. This is a **fleet-wide queue stall**: the bump is innocent, the linter is the blocker, and it hits every Go repo at once as Renovate rolls the wave out.

Observed today across 10 repos in a single marge sweep:

| PR | |
|---|---|
| giantswarm/klaus-operator#186 | giantswarm/backstage-catalog-importer#563 |
| giantswarm/mcp-oauth#545 | giantswarm/fulfillment#99 |
| giantswarm/muster#1011 | giantswarm/crd-docs-generator#438 |
| giantswarm/mcp-runbooks#73 | giantswarm/release-exporter#129 |
| giantswarm/mcp-kubernetes#571 | giantswarm/operational-load-exporter#173 |

## Fix

- `golangci-lint` 2.12.2 -> **2.13.1** (released 2026-08-20, `built with go1.27.0` -- verified against the release binary).
- `actions/setup-go` `go-version` 1.26 -> **1.27**, in the same commit: the job runs with `GOTOOLCHAIN: local`, so once Renovate bumps the `go` directive (not just `toolchain`) past the installed toolchain, `go-fmt` and `go-mod-tidy` fail the same way. The two pins are one decision.

## Verification

Ran `golangci-lint 2.13.1` with the exact hook args from `.pre-commit-config.yaml` (`-E=gosec -E=goconst -E=govet --max-same-issues=0 --max-issues-per-linter=0`) against four consumer repos, including the two largest:

| Repo | Result |
|---|---|
| giantswarm/muster | 0 issues |
| giantswarm/mcp-kubernetes | 0 issues |
| giantswarm/klaus-operator | 0 issues |
| giantswarm/mcp-runbooks | 0 issues |

No new-lint-rule regression of the kind the 2.12.x `goconst` bump caused (#1802).

## Acceptance criteria

- [ ] `pre-commit` passes on the `renovate/go-1.x` PRs listed above once Align files propagates the regenerated workflow.