### PR TITLE
fix(precommit): exclude vendored helm subcharts from auto-fixing base hooks

### DIFF
--- a/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
+++ b/pkg/gen/input/precommit/internal/file/pre-commit-config.yaml.template
@@ -3,17 +3,24 @@ minimum_pre_commit_version: '2.17'
 default_install_hook_types: [pre-commit, commit-msg{{ if .NodeDevLintHook }}, pre-push{{ end }}]
 repos:
   # base hooks
+  #
+  # helm/<chart>/charts/ holds vendored upstream subcharts (vendir-synced).
+  # Those files are not repo-authored: the auto-fixing hooks would rewrite
+  # them on every vendir bump and the next vendir sync would revert the fix,
+  # so the whitespace/shebang hooks skip the vendored subtree.
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
+        exclude: "^helm/[^/]+/charts/.*"
       - id: detect-private-key
       - id: end-of-file-fixer
-        exclude: "(.*testdata/.*|^\\.yarn/.*)"
+        exclude: "(.*testdata/.*|^\\.yarn/.*|^helm/[^/]+/charts/.*)"
       - id: mixed-line-ending
+        exclude: "^helm/[^/]+/charts/.*"
       - id: trailing-whitespace
-        exclude: "(.*testdata/.*|^\\.yarn/.*)"
+        exclude: "(.*testdata/.*|^\\.yarn/.*|^helm/[^/]+/charts/.*)"
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0


### PR DESCRIPTION
`helm/<chart>/charts/` holds vendir-synced upstream subcharts. The auto-fixing/checking base hooks (`end-of-file-fixer`, `trailing-whitespace`, `mixed-line-ending`, `check-shebang-scripts-are-executable`) would rewrite or flag those files on every vendir bump, and the next vendir sync reverts the fix.

Until now agentgateway, agent-sandbox and kagent-app each carried a full hand-maintained override copy of the generated config in `giantswarm/github/repositories/override/` just for this exclude (giantswarm/github#5609, #5623). Baking the exclude into the template makes the generated config correct by default so those overrides can be deleted — part of the pre-commit single-source consolidation (giantswarm/github#5804, decision teemow/klaus-lab#48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)